### PR TITLE
v0.4.0 cleanup 2, fix TypeMeta and the new Cache

### DIFF
--- a/pkg/apis/ignite/v1alpha1/defaults.go
+++ b/pkg/apis/ignite/v1alpha1/defaults.go
@@ -4,6 +4,7 @@ import (
 	meta "github.com/weaveworks/ignite/pkg/apis/meta/v1alpha1"
 	"github.com/weaveworks/ignite/pkg/constants"
 	"k8s.io/apimachinery/pkg/runtime"
+	"reflect"
 )
 
 func addDefaultingFuncs(scheme *runtime.Scheme) error {
@@ -72,4 +73,22 @@ func calcMetadataDevSize(obj *PoolSpec) meta.Size {
 	maxSize := meta.NewSizeFromBytes(16 * constants.GB)
 
 	return meta.NewSizeFromBytes(48 * obj.DataSize.Bytes() / obj.AllocationSize.Bytes()).Min(maxSize).Max(minSize)
+}
+
+// TODO: Temporary hacks to populate TypeMeta until we get the generator working
+func SetDefaults_VM(obj *VM) {
+	setTypeMeta(obj)
+}
+
+func SetDefaults_Image(obj *Image) {
+	setTypeMeta(obj)
+}
+
+func SetDefaults_Kernel(obj *Kernel) {
+	setTypeMeta(obj)
+}
+
+func setTypeMeta(obj meta.Object) {
+	obj.GetTypeMeta().APIVersion = SchemeGroupVersion.String()
+	obj.GetTypeMeta().Kind = reflect.Indirect(reflect.ValueOf(obj)).Type().Name()
 }

--- a/pkg/apis/ignite/v1alpha1/zz_generated.defaults.go
+++ b/pkg/apis/ignite/v1alpha1/zz_generated.defaults.go
@@ -20,10 +20,12 @@ func RegisterDefaults(scheme *runtime.Scheme) error {
 }
 
 func SetObjectDefaults_Image(in *Image) {
+	SetDefaults_Image(in)
 	SetDefaults_OCIImageClaim(&in.Spec.OCIClaim)
 }
 
 func SetObjectDefaults_Kernel(in *Kernel) {
+	SetDefaults_Kernel(in)
 	SetDefaults_OCIImageClaim(&in.Spec.OCIClaim)
 }
 
@@ -32,6 +34,7 @@ func SetObjectDefaults_Pool(in *Pool) {
 }
 
 func SetObjectDefaults_VM(in *VM) {
+	SetDefaults_VM(in)
 	SetDefaults_VMSpec(&in.Spec)
 	if in.Spec.Image.OCIClaim != nil {
 		SetDefaults_OCIImageClaim(in.Spec.Image.OCIClaim)

--- a/pkg/operations/import.go
+++ b/pkg/operations/import.go
@@ -58,6 +58,7 @@ func importImage(srcString string) (*imgmd.Image, error) {
 			OCISource: *src,
 		},
 	}
+
 	// Set defaults, and populate TypeMeta
 	// TODO: Make this more standardized; maybe a constructor method somewhere?
 	scheme.Scheme.Default(image)

--- a/pkg/storage/cache.go
+++ b/pkg/storage/cache.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	meta "github.com/weaveworks/ignite/pkg/apis/meta/v1alpha1"
+	"log"
 )
 
 // Cache is an intermediate caching layer, which conforms to Storage
@@ -14,11 +15,12 @@ type Cache interface {
 }
 
 func NewCache(backingStorage Storage) Cache {
-	return &cache{
-		storage:   backingStorage,
-		cache:     newObjectCache(),
-		metaCache: newObjectCache(),
+	c := &cache{
+		storage:     backingStorage,
+		objectCache: newObjectCache(backingStorage.GetByID),
 	}
+
+	return c
 }
 
 type cache struct {
@@ -28,27 +30,37 @@ type cache struct {
 
 	// cache caches the Objects by Kind and UID
 	// This guarantees uniqueness when looking up a specific Object
-	cache *objectCache
-
-	// metaCache caches the Objects as meta.APITypes by Kind and UID
-	metaCache *objectCache
+	objectCache *objectCache
 }
 
 var _ Cache = &cache{}
 
-type objectCache struct {
-	objects map[meta.Kind]map[meta.UID]meta.Object
+type cacheObject struct {
+	object  meta.Object
+	apiType bool
 }
 
-func newObjectCache() *objectCache {
+type loadFunc func(meta.Kind, meta.UID) (meta.Object, error)
+
+type objectCache struct {
+	objects  map[meta.Kind]map[meta.UID]cacheObject
+	loadFunc loadFunc
+}
+
+func newObjectCache(l loadFunc) *objectCache {
 	return &objectCache{
-		make(map[meta.Kind]map[meta.UID]meta.Object),
+		objects:  make(map[meta.Kind]map[meta.UID]cacheObject),
+		loadFunc: l,
 	}
 }
 
 func (c *cache) Get(obj meta.Object) error {
+	var err error
+
 	// Try to load from cache first
-	if obj = c.cache.load(obj); obj != nil {
+	if obj, err = c.objectCache.load(obj); err != nil {
+		return err
+	} else if obj != nil {
 		return nil
 	}
 
@@ -58,7 +70,7 @@ func (c *cache) Get(obj meta.Object) error {
 
 func (c *cache) Set(obj meta.Object) error {
 	// Store the changed Object in the cache
-	c.cache.store(obj)
+	c.objectCache.store(obj)
 
 	// TODO: For now the cache always flushes, we might add a Cache.Flush() later
 	return c.storage.Set(obj)
@@ -66,7 +78,9 @@ func (c *cache) Set(obj meta.Object) error {
 
 func (c *cache) GetByID(kind meta.Kind, uid meta.UID) (meta.Object, error) {
 	// If the requested Object resides in the cache, return it
-	if obj := c.cache.loadByID(kind, uid); obj != nil {
+	if obj, err := c.objectCache.loadByID(kind, uid); err != nil {
+		return nil, err
+	} else if obj != nil {
 		return obj, nil
 	}
 
@@ -74,7 +88,7 @@ func (c *cache) GetByID(kind meta.Kind, uid meta.UID) (meta.Object, error) {
 
 	// If no errors occurred while loading, store the Object in the cache
 	if err != nil {
-		c.cache.store(obj)
+		c.objectCache.store(obj)
 	}
 
 	return obj, err
@@ -82,11 +96,15 @@ func (c *cache) GetByID(kind meta.Kind, uid meta.UID) (meta.Object, error) {
 
 func (c *cache) Delete(kind meta.Kind, uid meta.UID) error {
 	// Delete the given Object from the cache and storage
-	c.cache.delete(kind, uid)
+	c.objectCache.delete(kind, uid)
 	return c.storage.Delete(kind, uid)
 }
 
-func (c *cache) List(kind meta.Kind) ([]meta.Object, error) {
+type listFunc func(meta.Kind) ([]meta.Object, error)
+type cacheStoreFunc func([]meta.Object)
+
+// list is a common handler for List and ListMeta
+func (c *cache) list(kind meta.Kind, slf, clf listFunc, csf cacheStoreFunc) ([]meta.Object, error) {
 	var objs []meta.Object
 	var storageCount uint64
 	var err error
@@ -95,44 +113,26 @@ func (c *cache) List(kind meta.Kind) ([]meta.Object, error) {
 		return nil, err
 	}
 
-	if c.cache.count(kind) != storageCount {
+	if c.objectCache.count(kind) != storageCount {
 		// If the cache doesn't track all of the Objects, request them from the storage
-		if objs, err = c.storage.List(kind); err != nil {
+		if objs, err = slf(kind); err != nil {
 			// If no errors occurred, store the Objects in the cache
-			c.cache.storeAll(objs)
+			csf(objs)
 		}
 	} else {
 		// If the cache tracks everything, return the cache's contents
-		objs = c.cache.list(kind)
+		objs, err = clf(kind)
 	}
 
 	return objs, err
 }
 
-// TODO: The metaCache falls out of sync on any updates, the cache should support saving
-// headers and objects coupled together loading the object to replace the header when needed
+func (c *cache) List(kind meta.Kind) ([]meta.Object, error) {
+	return c.list(kind, c.storage.List, c.objectCache.list, c.objectCache.storeAll)
+}
+
 func (c *cache) ListMeta(kind meta.Kind) ([]meta.Object, error) {
-	// TODO: Support extracting meta.APIType Objects from fully loaded objects to back the meta cache
-	var objs []meta.Object
-	var storageCount uint64
-	var err error
-
-	if storageCount, err = c.storage.Count(kind); err != nil {
-		return nil, err
-	}
-
-	if c.metaCache.count(kind) != storageCount {
-		// If the cache doesn't track all of the Objects, request them from the storage
-		if objs, err = c.storage.ListMeta(kind); err != nil {
-			// If no errors occurred, store the Objects in the cache
-			c.metaCache.storeAll(objs)
-		}
-	} else {
-		// If the cache tracks everything, return the cache's contents
-		objs = c.metaCache.list(kind)
-	}
-
-	return objs, err
+	return c.list(kind, c.storage.ListMeta, c.objectCache.listMeta, c.objectCache.storeAllMeta)
 }
 
 func (c *cache) Count(kind meta.Kind) (uint64, error) {
@@ -142,7 +142,12 @@ func (c *cache) Count(kind meta.Kind) (uint64, error) {
 
 func (c *cache) Flush() error {
 	// Load the entire cache
-	for _, obj := range c.cache.loadAll() {
+	allObjects, err := c.objectCache.loadAll()
+	if err != nil {
+		return err
+	}
+
+	for _, obj := range allObjects {
 		// Request the storage to save each Object
 		if err := c.storage.Set(obj); err != nil {
 			return err
@@ -152,21 +157,38 @@ func (c *cache) Flush() error {
 	return nil
 }
 
-func (c *objectCache) load(obj meta.Object) meta.Object {
+// loadFull checks if the Object is an APIType, and loads the full Object in that case
+func (c *objectCache) loadFull(obj cacheObject) (meta.Object, error) {
+	if !obj.apiType {
+		log.Printf("cache: full %s object cached\n", obj.object.GetKind())
+		return obj.object, nil
+	}
+
+	log.Printf("cache: loading full %s object\n", obj.object.GetKind())
+	result, err := c.loadFunc(obj.object.GetKind(), obj.object.GetUID())
+	if err != nil {
+		return nil, err
+	}
+
+	c.store(result)
+	return result, nil
+}
+
+func (c *objectCache) load(obj meta.Object) (meta.Object, error) {
 	return c.loadByID(obj.GetKind(), obj.GetUID())
 }
 
-func (c *objectCache) loadByID(kind meta.Kind, uid meta.UID) meta.Object {
+func (c *objectCache) loadByID(kind meta.Kind, uid meta.UID) (meta.Object, error) {
 	if uids, ok := c.objects[kind]; ok {
 		if obj, ok := uids[uid]; ok {
-			return obj
+			return c.loadFull(obj)
 		}
 	}
 
-	return nil
+	return nil, nil
 }
 
-func (c *objectCache) loadAll() []meta.Object {
+func (c *objectCache) loadAll() ([]meta.Object, error) {
 	var size uint64
 
 	for kind := range c.objects {
@@ -175,28 +197,52 @@ func (c *objectCache) loadAll() []meta.Object {
 
 	all := make([]meta.Object, 0, size)
 
-	for _, uids := range c.objects {
-		for _, obj := range uids {
-			all = append(all, obj)
+	for kind := range c.objects {
+		if objects, err := c.list(kind); err == nil {
+			all = append(all, objects...)
+		} else {
+			return nil, err
 		}
 	}
 
-	return all
+	return all, nil
+}
+
+func (c *objectCache) storeCO(obj cacheObject) {
+	kind := obj.object.GetKind()
+
+	if _, ok := c.objects[kind]; !ok {
+		c.objects[kind] = make(map[meta.UID]cacheObject)
+	}
+
+	c.objects[kind][obj.object.GetUID()] = obj
 }
 
 func (c *objectCache) store(obj meta.Object) {
-	kind := obj.GetKind()
-
-	if _, ok := c.objects[kind]; !ok {
-		c.objects[kind] = make(map[meta.UID]meta.Object)
-	}
-
-	c.objects[kind][obj.GetUID()] = obj
+	log.Printf("cache: storing %s object\n", obj.GetKind())
+	c.storeCO(cacheObject{object: obj})
 }
 
 func (c *objectCache) storeAll(objs []meta.Object) {
 	for _, obj := range objs {
 		c.store(obj)
+	}
+}
+
+func (c *objectCache) storeMeta(obj meta.Object) {
+	log.Printf("cache: storing %s meta object\n", obj.GetKind())
+	c.storeCO(cacheObject{object: obj, apiType: true})
+}
+
+func (c *objectCache) storeAllMeta(objs []meta.Object) {
+	for _, obj := range objs {
+		if uids, ok := c.objects[obj.GetKind()]; ok {
+			if _, ok := uids[obj.GetUID()]; ok {
+				continue
+			}
+		}
+
+		c.storeMeta(obj)
 	}
 }
 
@@ -207,16 +253,39 @@ func (c *objectCache) delete(kind meta.Kind, uid meta.UID) {
 }
 
 func (c *objectCache) count(kind meta.Kind) uint64 {
-	return uint64(len(c.objects[kind]))
+	count := uint64(len(c.objects[kind]))
+	log.Printf("cache: counted %d %s objects\n", count, kind)
+	return count
 }
 
-func (c *objectCache) list(kind meta.Kind) []meta.Object {
+func (c *objectCache) list(kind meta.Kind) ([]meta.Object, error) {
 	uids := c.objects[kind]
 	list := make([]meta.Object, 0, len(uids))
 
 	for _, obj := range uids {
-		list = append(list, obj)
+		if result, err := c.loadFull(obj); err == nil {
+			list = append(list, result)
+		} else {
+			return nil, err
+		}
 	}
 
-	return list
+	return list, nil
+}
+
+func (c *objectCache) listMeta(kind meta.Kind) ([]meta.Object, error) {
+	uids := c.objects[kind]
+	list := make([]meta.Object, 0, len(uids))
+
+	for _, obj := range uids {
+		apiType := obj.object
+
+		if !obj.apiType {
+			apiType = meta.APITypeFrom(obj.object)
+		}
+
+		list = append(list, apiType)
+	}
+
+	return list, nil
 }

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -39,7 +39,7 @@ type Storage interface {
 }
 
 // DefaultStorage is the default storage implementation
-var DefaultStorage = NewGenericStorage(NewDefaultRawStorage(constants.DATA_DIR), scheme.Serializer)
+var DefaultStorage = NewCache(NewGenericStorage(NewDefaultRawStorage(constants.DATA_DIR), scheme.Serializer))
 
 // NewGenericStorage constructs a new Storage
 func NewGenericStorage(rawStorage RawStorage, serializer serializer.Serializer) Storage {


### PR DESCRIPTION
This PR contains the reworked cache (which should be robust) and backs the `DefaultStorage` with it.
Also contains a temporary fix for the unpopulated `TypeMeta`.