### PR TITLE
Fix monitoring link in docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,4 +9,4 @@ Table of Contents:
 - [CLI Reference](cli/ignite.md)
 - [API Reference](../api)
 - [Scope and Requirements](dependencies.md)
-- [Monitoring With Prometheus](dependencies.md)
+- [Monitoring With Prometheus](prometheus.md)


### PR DESCRIPTION
Fix monitoring link in docs.
Currently the **Montoring with Prometheus** links to `dependencies.md`.
Probably just a copy&paste error.