### PR TITLE
Added the -F flag in mkfs.ext4 command. 

### DIFF
--- a/pkg/dm/dm.go
+++ b/pkg/dm/dm.go
@@ -26,6 +26,7 @@ func mkfs(device blockDevice) error {
 	mkfsArgs := []string{
 		"-I",
 		"256",
+		"-F",
 		"-E",
 		"lazy_itable_init=0,lazy_journal_init=0",
 		device.Path(),

--- a/pkg/metadata/imgmd/image.go
+++ b/pkg/metadata/imgmd/image.go
@@ -31,7 +31,7 @@ func (md *Image) AllocateAndFormat() error {
 
 	// Use mkfs.ext4 to create the new image with an inode size of 256
 	// (gexto doesn't support anything but 128, but as long as we're not using that it's fine)
-	if _, err := util.ExecuteCommand("mkfs.ext4", "-I", "256", "-E", "lazy_itable_init=0,lazy_journal_init=0", p); err != nil {
+	if _, err := util.ExecuteCommand("mkfs.ext4", "-I", "256", "-F", "-E", "lazy_itable_init=0,lazy_journal_init=0", p); err != nil {
 		return errors.Wrapf(err, "failed to format image %s", md.GetUID())
 	}
 


### PR DESCRIPTION
To force mke2fs to create a filesystem, even if the specified device is not a partition on a block special device, or if other parameters do not make sense