### PR TITLE
Expose firecracker sockets

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -29,7 +29,7 @@ const (
 	IGNITE_TIMEOUT = 10
 
 	// In-container path for the firecracker socket
-	SOCKET_PATH = "/tmp/firecracker.sock"
+	FIRECRACKER_SOCKET_PATH = "firecracker"
 
 	// In-container path for the firecracker log FIFO
 	LOG_FIFO = "/tmp/firecracker_log.fifo"

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -28,14 +28,13 @@ const (
 	// Additional timeout in seconds for docker to wait for ignite to save and quit
 	IGNITE_TIMEOUT = 10
 
-	// In-container path for the firecracker socket
-	FIRECRACKER_SOCKET_PATH = "firecracker"
+	// In-container file name for the firecracker socket
 	FIRECRACKER_API_SOCKET = "firecracker.sock"
 
-	// In-container path for the firecracker log FIFO
+	// In-container file name for the firecracker log FIFO
 	LOG_FIFO = "firecracker_log.fifo"
 
-	// In-container path for the firecracker metrics FIFO
+	// In-container file name for the firecracker metrics FIFO
 	METRICS_FIFO = "firecracker_metrics.fifo"
 
 	// Log level for the firecracker VM

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -30,12 +30,13 @@ const (
 
 	// In-container path for the firecracker socket
 	FIRECRACKER_SOCKET_PATH = "firecracker"
+	FIRECRACKER_API_SOCKET = "firecracker.sock"
 
 	// In-container path for the firecracker log FIFO
-	LOG_FIFO = "/tmp/firecracker_log.fifo"
+	LOG_FIFO = "firecracker_log.fifo"
 
 	// In-container path for the firecracker metrics FIFO
-	METRICS_FIFO = "/tmp/firecracker_metrics.fifo"
+	METRICS_FIFO = "firecracker_metrics.fifo"
 
 	// Log level for the firecracker VM
 	VM_LOG_LEVEL = "Error"

--- a/pkg/container/firecracker.go
+++ b/pkg/container/firecracker.go
@@ -36,8 +36,9 @@ func ExecuteFirecracker(md *vmmd.VM, dhcpIfaces []DHCPInterface) error {
 		cmdLine = constants.VM_DEFAULT_KERNEL_ARGS
 	}
 
+	firecrackerSocketPath := path.Join(md.ObjectPath(), constants.FIRECRACKER_SOCKET_PATH, "firecracker.sock")
 	cfg := firecracker.Config{
-		SocketPath:      constants.SOCKET_PATH,
+		SocketPath:      firecrackerSocketPath,
 		KernelImagePath: path.Join(constants.KERNEL_DIR, md.GetKernelUID().String(), constants.KERNEL_FILE),
 		KernelArgs:      cmdLine,
 		Drives: []models.Drive{{
@@ -75,7 +76,7 @@ func ExecuteFirecracker(md *vmmd.VM, dhcpIfaces []DHCPInterface) error {
 
 	cmd := firecracker.VMCommandBuilder{}.
 		WithBin("firecracker").
-		WithSocketPath(constants.SOCKET_PATH).
+		WithSocketPath(firecrackerSocketPath).
 		WithStdin(os.Stdin).
 		WithStdout(os.Stdout).
 		WithStderr(os.Stderr).

--- a/pkg/container/firecracker.go
+++ b/pkg/container/firecracker.go
@@ -36,9 +36,9 @@ func ExecuteFirecracker(md *vmmd.VM, dhcpIfaces []DHCPInterface) error {
 		cmdLine = constants.VM_DEFAULT_KERNEL_ARGS
 	}
 
-	firecrackerSocketPath := path.Join(md.ObjectPath(), constants.FIRECRACKER_SOCKET_PATH, FIRECRACKER_API_SOCKET)
-	logSocketPath := path.Join(md.ObjectPath(), constants.FIRECRACKER_SOCKET_PATH, LOG_FIFO)
-	metricsSocketPath := path.Join(md.ObjectPath(), constants.FIRECRACKER_SOCKET_PATH, METRICS_FIFO)
+	firecrackerSocketPath := path.Join(md.ObjectPath(), FIRECRACKER_API_SOCKET)
+	logSocketPath := path.Join(md.ObjectPath(), LOG_FIFO)
+	metricsSocketPath := path.Join(md.ObjectPath(), METRICS_FIFO)
 	cfg := firecracker.Config{
 		SocketPath:      firecrackerSocketPath,
 		KernelImagePath: path.Join(constants.KERNEL_DIR, md.GetKernelUID().String(), constants.KERNEL_FILE),

--- a/pkg/container/firecracker.go
+++ b/pkg/container/firecracker.go
@@ -36,7 +36,9 @@ func ExecuteFirecracker(md *vmmd.VM, dhcpIfaces []DHCPInterface) error {
 		cmdLine = constants.VM_DEFAULT_KERNEL_ARGS
 	}
 
-	firecrackerSocketPath := path.Join(md.ObjectPath(), constants.FIRECRACKER_SOCKET_PATH, "firecracker.sock")
+	firecrackerSocketPath := path.Join(md.ObjectPath(), constants.FIRECRACKER_SOCKET_PATH, FIRECRACKER_API_SOCKET)
+	logSocketPath := path.Join(md.ObjectPath(), constants.FIRECRACKER_SOCKET_PATH, LOG_FIFO)
+	metricsSocketPath := path.Join(md.ObjectPath(), constants.FIRECRACKER_SOCKET_PATH, METRICS_FIFO)
 	cfg := firecracker.Config{
 		SocketPath:      firecrackerSocketPath,
 		KernelImagePath: path.Join(constants.KERNEL_DIR, md.GetKernelUID().String(), constants.KERNEL_FILE),
@@ -63,13 +65,13 @@ func ExecuteFirecracker(md *vmmd.VM, dhcpIfaces []DHCPInterface) error {
 
 		// TODO: We could use /dev/null, but firecracker-go-sdk issues Mkfifo which collides with the existing device
 		LogLevel:    constants.VM_LOG_LEVEL,
-		LogFifo:     constants.LOG_FIFO,
-		MetricsFifo: constants.METRICS_FIFO,
+		LogFifo:     logSocketPath,
+		MetricsFifo: metricsSocketPath,
 	}
 
 	// Remove these FIFOs for now
-	defer os.Remove(constants.LOG_FIFO)
-	defer os.Remove(constants.METRICS_FIFO)
+	defer os.Remove(logSocketPath)
+	defer os.Remove(metricsSocketPath)
 
 	ctx, vmmCancel := context.WithCancel(context.Background())
 	defer vmmCancel()

--- a/pkg/metadata/metadata.go
+++ b/pkg/metadata/metadata.go
@@ -97,6 +97,10 @@ func processUID(obj meta.Object, c *client.Client) error {
 	if err := os.MkdirAll(dir, constants.DATA_DIR_PERM); err != nil {
 		return fmt.Errorf("failed to create directory for ID %q: %v", uid, err)
 	}
+	
+	if err := os.MkdirAll(paths.Join(dir, FIRECRACKER_SOCKET_PATH), constants.DATA_DIR_PERM); err != nil {
+		return fmt.Errorf("failed to create socket directory for ID %q: %v", uid, err)
+	}
 
 	return nil
 }

--- a/pkg/metadata/metadata.go
+++ b/pkg/metadata/metadata.go
@@ -97,10 +97,6 @@ func processUID(obj meta.Object, c *client.Client) error {
 	if err := os.MkdirAll(dir, constants.DATA_DIR_PERM); err != nil {
 		return fmt.Errorf("failed to create directory for ID %q: %v", uid, err)
 	}
-	
-	if err := os.MkdirAll(paths.Join(dir, FIRECRACKER_SOCKET_PATH), constants.DATA_DIR_PERM); err != nil {
-		return fmt.Errorf("failed to create socket directory for ID %q: %v", uid, err)
-	}
 
 	return nil
 }


### PR DESCRIPTION
This exposes the Firecracker socket files (API, Metrics and Logs) to the host by mapping them into the (already mounted) `/var/lib/firecracker/vm/$id/firecracker` directory.

This is useful for our use case because we want to use the Firecracker metadata service to expose AWS Credentials. These credentials need to be refreshed so cannot be set statically.