### PR TITLE
Verify `ignite-spawn` has started before returning from `start`

### DIFF
--- a/cmd/ignite-spawn/ignite-spawn.go
+++ b/cmd/ignite-spawn/ignite-spawn.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"fmt"
-	"github.com/weaveworks/ignite/pkg/constants"
 	"os"
 	"path"
+
+	"github.com/weaveworks/ignite/pkg/constants"
 
 	log "github.com/sirupsen/logrus"
 	api "github.com/weaveworks/ignite/pkg/apis/ignite/v1alpha1"

--- a/cmd/ignite-spawn/ignite-spawn.go
+++ b/cmd/ignite-spawn/ignite-spawn.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"github.com/weaveworks/ignite/pkg/constants"
 	"os"
 	"path"
 
@@ -49,9 +50,7 @@ func StartVM(co *options) error {
 	}
 
 	// Serve metrics over an unix socket in the VM's own directory
-	// TODO: when restarting a VM using `start`, we get a panic:
-	// panic: listen unix /var/lib/firecracker/vm/6a2b6ebafcb0e75c/prometheus.sock: bind: address already in use
-	metricsSocket := path.Join(co.vm.ObjectPath(), "prometheus.sock")
+	metricsSocket := path.Join(co.vm.ObjectPath(), constants.PROMETHEUS_SOCKET)
 	go prometheus.ServeMetrics(metricsSocket)
 
 	// VM state handling

--- a/pkg/constants/vm.go
+++ b/pkg/constants/vm.go
@@ -15,4 +15,7 @@ const (
 
 	// TODO: remove this when the old dm code is removed
 	OVERLAY_FILE = "overlay.dm"
+
+	// Prometheus socket filename
+	PROMETHEUS_SOCKET = "prometheus.sock"
 )


### PR DESCRIPTION
This temporary handler waits for the Prometheus socket to be created by `ignite-spawn`. Needs to be replaced with a more elegant solution when we have proper CLI <-> container interaction in place.
Fixes https://github.com/weaveworks/ignite/issues/124.