### PR TITLE
Don't fail when there are unsupported net interfaces in the container

### DIFF
--- a/pkg/container/firecracker.go
+++ b/pkg/container/firecracker.go
@@ -36,9 +36,9 @@ func ExecuteFirecracker(md *vmmd.VM, dhcpIfaces []DHCPInterface) error {
 		cmdLine = constants.VM_DEFAULT_KERNEL_ARGS
 	}
 
-	firecrackerSocketPath := path.Join(md.ObjectPath(), FIRECRACKER_API_SOCKET)
-	logSocketPath := path.Join(md.ObjectPath(), LOG_FIFO)
-	metricsSocketPath := path.Join(md.ObjectPath(), METRICS_FIFO)
+	firecrackerSocketPath := path.Join(md.ObjectPath(), constants.FIRECRACKER_API_SOCKET)
+	logSocketPath := path.Join(md.ObjectPath(), constants.LOG_FIFO)
+	metricsSocketPath := path.Join(md.ObjectPath(), constants.METRICS_FIFO)
 	cfg := firecracker.Config{
 		SocketPath:      firecrackerSocketPath,
 		KernelImagePath: path.Join(constants.KERNEL_DIR, md.GetKernelUID().String(), constants.KERNEL_FILE),

--- a/pkg/container/network.go
+++ b/pkg/container/network.go
@@ -47,6 +47,7 @@ func SetupContainerNetworking() ([]DHCPInterface, error) {
 		}
 		if retry {
 			// we got an error, but let's ignore it and try again
+			log.Infof("Got an error while trying to set up networking, but retrying: %v", err)
 			return false, nil
 		}
 		// the error was fatal, return it
@@ -70,31 +71,43 @@ func networkSetup(dhcpIfaces *[]DHCPInterface) (bool, error) {
 	interfacesCount := 0
 	for _, iface := range ifaces {
 		// Skip the interface if it's ignored
-		if !ignoreInterfaces[iface.Name] {
-			// This is an interface we care about
-			interfacesCount++
-
-			ipNet, retry, err := takeAddress(&iface)
-			if err != nil {
-				return retry, fmt.Errorf("parsing interface failed: %v", err)
-			}
-
-			dhcpIface, err := bridge(&iface)
-			if err != nil {
-				return false, fmt.Errorf("bridging interface %s failed: %v0", iface.Name, err)
-			}
-
-			// Gateway for now is just x.x.x.1 TODO: Better detection
-			dhcpIface.GatewayIP = &net.IP{ipNet.IP[0], ipNet.IP[1], ipNet.IP[2], 1}
-			dhcpIface.VMIPNet = ipNet
-
-			*dhcpIfaces = append(*dhcpIfaces, *dhcpIface)
+		if ignoreInterfaces[iface.Name] {
+			continue
 		}
+
+		// Try to transfer the address from the container to the DHCP server
+		ipNet, _, err := takeAddress(&iface)
+		if err != nil {
+			// Log the problem, but don't quit the function here as there might be other good interfaces
+			log.Errorf("Parsing interface %s failed: %v", iface.Name, err)
+			// Try with the next interface
+			continue
+		}
+
+		// Bridge the Firecracker TAP interface with the container veth interface
+		dhcpIface, err := bridge(&iface)
+		if err != nil {
+			// Log the problem, but don't quit the function here as there might be other good interfaces
+			// Don't set shouldRetry here as there is no point really with retrying with this interface
+			// that seems broken/unsupported in some way.
+			log.Errorf("Bridging interface %s failed: %v", iface.Name, err)
+			// Try with the next interface
+			continue
+		}
+
+		// Gateway for now is just x.x.x.1 TODO: Better detection
+		dhcpIface.GatewayIP = &net.IP{ipNet.IP[0], ipNet.IP[1], ipNet.IP[2], 1}
+		dhcpIface.VMIPNet = ipNet
+
+		*dhcpIfaces = append(*dhcpIfaces, *dhcpIface)
+
+		// This is an interface we care about
+		interfacesCount++
 	}
 
-	// If there weren't any interfaces we cared about, retry the loop
+	// If there weren't any interfaces that were valid or active yet, retry the loop
 	if interfacesCount == 0 {
-		return true, fmt.Errorf("no active interfaces available yet")
+		return true, fmt.Errorf("no active or valid interfaces available yet")
 	}
 
 	return false, nil


### PR DESCRIPTION
Fixes #133 
(I believe)

The problem was that when ignite tried to parse the networking for the following container...

```
$ docker run -it busybox ip addr
...
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
2: sit0@NONE: <NOARP> mtu 1480 qdisc noop qlen 1000
    link/sit 0.0.0.0 brd 0.0.0.0
8: eth0@if9: <BROADCAST,MULTICAST,UP,LOWER_UP,M-DOWN> mtu 1500 qdisc noqueue
    link/ether 02:42:ac:11:00:02 brd ff:ff:ff:ff:ff:ff
    inet 172.17.0.2/16 brd 172.17.255.255 scope global eth0
       valid_lft forever preferred_lft forever
    inet 192.168.252.10 peer 192.168.252.9/32 scope global tun0
       valid_lft forever preferred_lft forever
    inet6 fe80::5eae:1d4:2b4b:ee4/64 scope link stable-privacy
       valid_lft forever preferred_lft forever
```

...it tried to find the address of the first interface `sit0@NONE`, but that failed (obviously). The problem was that the `networkSetup` function did not try the other interfaces, just retry and do the same thing after one more second.

This PR fixes so that ignite tries all network interfaces.

/cc @twelho @danielcb 