### PR TITLE
Allow unmarshaling unquoted Ignite UIDs from JSON

### DIFF
--- a/api/meta.md
+++ b/api/meta.md
@@ -74,6 +74,7 @@
   * [func (t *TypeMeta) GetTypeMeta() *TypeMeta](#TypeMeta.GetTypeMeta)
 * [type UID](#UID)
   * [func (u UID) String() string](#UID.String)
+  * [func (u *UID) UnmarshalJSON(b []byte) error](#UID.UnmarshalJSON)
 
 
 #### <a name="pkg-files">Package files</a>
@@ -664,7 +665,7 @@ This is a helper for APIType generation
 
 
 
-## <a name="UID">type</a> [UID](/pkg/apis/meta/v1alpha1/uid.go?s=74:89#L6)
+## <a name="UID">type</a> [UID](/pkg/apis/meta/v1alpha1/uid.go?s=152:167#L11)
 ``` go
 type UID string
 ```
@@ -679,11 +680,22 @@ UID represents an unique ID for a type
 
 
 
-### <a name="UID.String">func</a> (UID) [String](/pkg/apis/meta/v1alpha1/uid.go?s=172:200#L11)
+### <a name="UID.String">func</a> (UID) [String](/pkg/apis/meta/v1alpha1/uid.go?s=250:278#L16)
 ``` go
 func (u UID) String() string
 ```
 String returns the UID in string representation
+
+
+
+
+### <a name="UID.UnmarshalJSON">func</a> (\*UID) [UnmarshalJSON](/pkg/apis/meta/v1alpha1/uid.go?s=444:487#L23)
+``` go
+func (u *UID) UnmarshalJSON(b []byte) error
+```
+This unmarshaler enables the UID to be passed in as an
+unquoted string in JSON. Upon marshaling, quotes will
+be automatically added.
 
 
 

--- a/pkg/apis/meta/v1alpha1/uid.go
+++ b/pkg/apis/meta/v1alpha1/uid.go
@@ -1,6 +1,11 @@
 package v1alpha1
 
-import "fmt"
+import (
+	"fmt"
+	"github.com/weaveworks/ignite/pkg/constants"
+	"strconv"
+	"unicode/utf8"
+)
 
 // UID represents an unique ID for a type
 type UID string
@@ -10,4 +15,25 @@ var _ fmt.Stringer = UID("")
 // String returns the UID in string representation
 func (u UID) String() string {
 	return string(u)
+}
+
+// This unmarshaler enables the UID to be passed in as an
+// unquoted string in JSON. Upon marshaling, quotes will
+// be automatically added.
+func (u *UID) UnmarshalJSON(b []byte) error {
+	if !utf8.Valid(b) {
+		return fmt.Errorf("invalid UID string: %s", b)
+	}
+
+	uid, err := strconv.Unquote(string(b))
+	if err != nil {
+		return err
+	}
+
+	if len(uid) < constants.IGNITE_UID_LENGTH {
+		return fmt.Errorf("UID string too short: %q", uid)
+	}
+
+	*u = UID(uid)
+	return nil
 }

--- a/pkg/apis/meta/v1alpha1/uid.go
+++ b/pkg/apis/meta/v1alpha1/uid.go
@@ -2,9 +2,10 @@ package v1alpha1
 
 import (
 	"fmt"
-	"github.com/weaveworks/ignite/pkg/constants"
 	"strconv"
 	"unicode/utf8"
+
+	"github.com/weaveworks/ignite/pkg/constants"
 )
 
 // UID represents an unique ID for a type

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -39,4 +39,7 @@ const (
 
 	// Log level for the firecracker VM
 	VM_LOG_LEVEL = "Error"
+
+	// How many characters Ignite UIDs should have
+	IGNITE_UID_LENGTH = 16
 )

--- a/pkg/metadata/metadata.go
+++ b/pkg/metadata/metadata.go
@@ -74,7 +74,7 @@ func processUID(obj meta.Object, c *client.Client) error {
 		// No UID set, generate one
 		var uidBytes []byte
 		for {
-			uidBytes = make([]byte, 8)
+			uidBytes = make([]byte, constants.IGNITE_UID_LENGTH/2)
 			if _, err := rand.Read(uidBytes); err != nil {
 				return fmt.Errorf("failed to generate ID: %v", err)
 			}


### PR DESCRIPTION
This implements a custom unmarshaler, which supports decoding unquoted UID strings, so the user can enter `"uid": 897302d44b0de795` in addition to `"uid": "897302d44b0de795"`. Fixes https://github.com/weaveworks/ignite/issues/170.

cc @luxas 