### PR TITLE
List all VMs if `ignite ps` is called via any of its aliases

### DIFF
--- a/cmd/ignite/cmd/vmcmd/ps.go
+++ b/cmd/ignite/cmd/vmcmd/ps.go
@@ -23,6 +23,12 @@ func NewCmdPs(out io.Writer) *cobra.Command {
 			also list VMs that are not currently running.
 		`),
 		Run: func(cmd *cobra.Command, args []string) {
+			// If `ps` is called via any of its aliases
+			// (`ls`, `list`), list all VMs
+			if cmd.CalledAs() != cmd.Name() {
+				pf.All = true
+			}
+
 			errutils.Check(func() error {
 				po, err := pf.NewPsOptions()
 				if err != nil {


### PR DESCRIPTION
Fixes https://github.com/weaveworks/ignite/issues/157. This enables `ignite vm(s) ls/list` to always list all VMs, not just running ones. `ignite ps` and `ignite vm(s) ps` are unaffected.

cc @luxas 