### PR TITLE
Add `-o pipefail` to bash when checking kernel version

### DIFF
--- a/pkg/operations/import.go
+++ b/pkg/operations/import.go
@@ -202,8 +202,9 @@ func importKernel(c *client.Client, ociRef meta.OCIImageRef) (*kernmd.Kernel, er
 
 	// Populate the kernel version field if possible
 	if len(runKernel.Status.Version) == 0 {
-		cmd := fmt.Sprintf(`strings %s | grep 'Linux version' | awk '{print $3}'`, vmlinuxFile)
-		out, err := util.ExecuteCommand("/bin/bash", "-c", cmd)
+		cmd := fmt.Sprintf("strings %s | grep 'Linux version' | awk '{print $3}'", vmlinuxFile)
+		// Use the pipefail option to return an error if any of the pipeline commands is not available
+		out, err := util.ExecuteCommand("/bin/bash", "-o", "pipefail", "-c", cmd)
 		if err != nil {
 			runKernel.Status.Version = "<unknown>"
 		} else {


### PR DESCRIPTION
This enables bash to return an error if any of the commands in the
pipeline fail (such as when the `strings` binary is missing).
Fixes https://github.com/weaveworks/ignite/issues/181.