### PR TITLE
Support selecting the release when building Ignite images

### DIFF
--- a/images/Makefile
+++ b/images/Makefile
@@ -5,6 +5,7 @@ DOCKER_USER?=weaveworks
 VERSION?=$(shell git describe HEAD --tags)
 RELEASE?=latest
 TAG:=${RELEASE}$(if $(strip $(VERSION)),-${VERSION})
+OP:=build
 
 all: build
 build:
@@ -23,22 +24,15 @@ ifeq ($(IS_LATEST),true)
 	docker push ${DOCKER_USER}/ignite-${WHAT}:latest
 endif
 
-build-all:
-	# Temporarily comment out the kernel build for the RC
-	#	make -C kernel
-	$(MAKE) build WHAT=amazon-kernel
-	$(MAKE) build WHAT=amazonlinux
-	$(MAKE) build WHAT=alpine
-	$(MAKE) build WHAT=ubuntu
-	$(MAKE) build WHAT=centos
-	$(MAKE) build WHAT=kubeadm
-
 push-all: build-all
-	# Temporarily comment out the kernel build for the RC
-	#	make -C kernel push
-	$(MAKE) push WHAT=amazon-kernel
-	$(MAKE) push WHAT=amazonlinux
-	$(MAKE) push WHAT=alpine
-	$(MAKE) push WHAT=ubuntu
-	$(MAKE) push WHAT=centos
-	$(MAKE) push WHAT=kubeadm
+	$(MAKE) OP=push build-all
+
+build-all:
+	$(MAKE) ${OP} WHAT=amazon-kernel
+	$(MAKE) ${OP} WHAT=amazonlinux		RELEASE=2		IS_LATEST=true
+	$(MAKE) ${OP} WHAT=alpine
+	$(MAKE) ${OP} WHAT=ubuntu			RELEASE=16.04	IS_LATEST=true
+	$(MAKE) ${OP} WHAT=ubuntu			RELEASE=18.04	IS_LATEST=true
+	$(MAKE) ${OP} WHAT=ubuntu			RELEASE=19.04	IS_LATEST=true
+	$(MAKE) ${OP} WHAT=centos			RELEASE=7		IS_LATEST=true
+	$(MAKE) ${OP} WHAT=kubeadm

--- a/images/Makefile
+++ b/images/Makefile
@@ -29,10 +29,10 @@ push-all: build-all
 
 build-all:
 	$(MAKE) ${OP} WHAT=amazon-kernel
-	$(MAKE) ${OP} WHAT=amazonlinux		RELEASE=2		IS_LATEST=true
+	$(MAKE) ${OP} WHAT=amazonlinux   RELEASE=2     IS_LATEST=true
 	$(MAKE) ${OP} WHAT=alpine
-	$(MAKE) ${OP} WHAT=ubuntu			RELEASE=16.04
-	$(MAKE) ${OP} WHAT=ubuntu			RELEASE=18.04	IS_LATEST=true
-	$(MAKE) ${OP} WHAT=ubuntu			RELEASE=19.04
-	$(MAKE) ${OP} WHAT=centos			RELEASE=7		IS_LATEST=true
+	$(MAKE) ${OP} WHAT=ubuntu        RELEASE=16.04
+	$(MAKE) ${OP} WHAT=ubuntu        RELEASE=18.04 IS_LATEST=true
+	$(MAKE) ${OP} WHAT=ubuntu        RELEASE=19.04
+	$(MAKE) ${OP} WHAT=centos        RELEASE=7     IS_LATEST=true
 	$(MAKE) ${OP} WHAT=kubeadm

--- a/images/Makefile
+++ b/images/Makefile
@@ -1,5 +1,6 @@
 # WHAT specifies the OS image to build
 WHAT?=
+IS_LATEST?=
 DOCKER_USER?=weaveworks
 VERSION?=$(shell git describe HEAD --tags)
 RELEASE?=latest
@@ -15,8 +16,12 @@ endif
 
 push:
 	docker push ${DOCKER_USER}/ignite-${WHAT}:${TAG}
+	docker tag ${DOCKER_USER}/ignite-${WHAT}:${TAG} ${DOCKER_USER}/ignite-${WHAT}:${RELEASE}
+	docker push ${DOCKER_USER}/ignite-${WHAT}:${RELEASE}
+ifeq ($(IS_LATEST),true)
 	docker tag ${DOCKER_USER}/ignite-${WHAT}:${TAG} ${DOCKER_USER}/ignite-${WHAT}:latest
 	docker push ${DOCKER_USER}/ignite-${WHAT}:latest
+endif
 
 build-all:
 	# Temporarily comment out the kernel build for the RC

--- a/images/Makefile
+++ b/images/Makefile
@@ -31,8 +31,8 @@ build-all:
 	$(MAKE) ${OP} WHAT=amazon-kernel
 	$(MAKE) ${OP} WHAT=amazonlinux		RELEASE=2		IS_LATEST=true
 	$(MAKE) ${OP} WHAT=alpine
-	$(MAKE) ${OP} WHAT=ubuntu			RELEASE=16.04	IS_LATEST=true
+	$(MAKE) ${OP} WHAT=ubuntu			RELEASE=16.04
 	$(MAKE) ${OP} WHAT=ubuntu			RELEASE=18.04	IS_LATEST=true
-	$(MAKE) ${OP} WHAT=ubuntu			RELEASE=19.04	IS_LATEST=true
+	$(MAKE) ${OP} WHAT=ubuntu			RELEASE=19.04
 	$(MAKE) ${OP} WHAT=centos			RELEASE=7		IS_LATEST=true
 	$(MAKE) ${OP} WHAT=kubeadm

--- a/images/Makefile
+++ b/images/Makefile
@@ -2,6 +2,8 @@
 WHAT?=
 DOCKER_USER?=weaveworks
 VERSION?=$(shell git describe HEAD --tags)
+RELEASE?=latest
+TAG:=${RELEASE}$(if $(strip $(VERSION)),-${VERSION})
 
 all: build
 build:
@@ -9,11 +11,11 @@ ifeq ($(WHAT),)
 	$(error WHAT is a required argument)
 endif
 	@ls ${WHAT} >/dev/null
-	docker build -t ${DOCKER_USER}/ignite-${WHAT}:${VERSION} ${WHAT}
+	docker build --build-arg RELEASE -t ${DOCKER_USER}/ignite-${WHAT}:${TAG} ${WHAT}
 
 push:
-	docker push ${DOCKER_USER}/ignite-${WHAT}:${VERSION}
-	docker tag ${DOCKER_USER}/ignite-${WHAT}:${VERSION} ${DOCKER_USER}/ignite-${WHAT}:latest
+	docker push ${DOCKER_USER}/ignite-${WHAT}:${TAG}
+	docker tag ${DOCKER_USER}/ignite-${WHAT}:${TAG} ${DOCKER_USER}/ignite-${WHAT}:latest
 	docker push ${DOCKER_USER}/ignite-${WHAT}:latest
 
 build-all:

--- a/images/amazonlinux/Dockerfile
+++ b/images/amazonlinux/Dockerfile
@@ -1,4 +1,6 @@
-FROM amazonlinux:2
+ARG RELEASE
+
+FROM amazonlinux:${RELEASE}
 
 # Install common utilities
 RUN yum -y install \

--- a/images/centos/Dockerfile
+++ b/images/centos/Dockerfile
@@ -1,4 +1,6 @@
-FROM centos:7
+ARG RELEASE
+
+FROM centos:${RELEASE}
 
 # Install common utilities
 RUN yum -y install \

--- a/images/kubeadm/Dockerfile
+++ b/images/kubeadm/Dockerfile
@@ -1,6 +1,4 @@
-ARG RELEASE
-
-FROM weaveworks/ignite-ubuntu:${RELEASE}
+FROM weaveworks/ignite-ubuntu:18.04
 # Install dependencies. Use containerd for running the containers (for better performance)
 RUN apt-get update && apt-get install -y --no-install-recommends \
         apt-transport-https \

--- a/images/kubeadm/Dockerfile
+++ b/images/kubeadm/Dockerfile
@@ -1,4 +1,6 @@
-FROM weaveworks/ignite-ubuntu:latest
+ARG RELEASE
+
+FROM weaveworks/ignite-ubuntu:${RELEASE}
 # Install dependencies. Use containerd for running the containers (for better performance)
 RUN apt-get update && apt-get install -y --no-install-recommends \
         apt-transport-https \

--- a/images/ubuntu/Dockerfile
+++ b/images/ubuntu/Dockerfile
@@ -1,4 +1,6 @@
-FROM ubuntu:18.04
+ARG RELEASE
+
+FROM ubuntu:${RELEASE}
 
 # udev is needed for booting a "real" VM, setting up the ttyS0 console properly
 # kmod is needed for modprobing modules


### PR DESCRIPTION
Currently release selection is supported for `amazonlinux`, `centos`,
`ubuntu` and the `kubeadm` build based on `ubuntu`. To select a release,
use the `RELEASE` env variable, e.g. `WHAT=ubuntu RELEASE=cosmic make`.
The default release is `latest`. Fixes https://github.com/weaveworks/ignite/issues/116.