### PR TITLE
Client and Storage rework: Recognize multiple API groups

### DIFF
--- a/api/ignite.md
+++ b/api/ignite.md
@@ -18,11 +18,8 @@
 ## <a name="pkg-index">Index</a>
 * [Constants](#pkg-constants)
 * [Variables](#pkg-variables)
-* [func SetDefaults_Image(obj *Image)](#SetDefaults_Image)
-* [func SetDefaults_Kernel(obj *Kernel)](#SetDefaults_Kernel)
 * [func SetDefaults_OCIImageClaim(obj *OCIImageClaim)](#SetDefaults_OCIImageClaim)
 * [func SetDefaults_PoolSpec(obj *PoolSpec)](#SetDefaults_PoolSpec)
-* [func SetDefaults_VM(obj *VM)](#SetDefaults_VM)
 * [func SetDefaults_VMKernelSpec(obj *VMKernelSpec)](#SetDefaults_VMKernelSpec)
 * [func SetDefaults_VMNetworkSpec(obj *VMNetworkSpec)](#SetDefaults_VMNetworkSpec)
 * [func SetDefaults_VMSpec(obj *VMSpec)](#SetDefaults_VMSpec)
@@ -97,57 +94,37 @@ SchemeGroupVersion is group version used to register these objects
 
 
 
-## <a name="SetDefaults_Image">func</a> [SetDefaults_Image](/pkg/apis/ignite/v1alpha1/defaults.go?s=2218:2252#L91)
-``` go
-func SetDefaults_Image(obj *Image)
-```
-
-
-## <a name="SetDefaults_Kernel">func</a> [SetDefaults_Kernel](/pkg/apis/ignite/v1alpha1/defaults.go?s=2276:2312#L95)
-``` go
-func SetDefaults_Kernel(obj *Kernel)
-```
-
-
-## <a name="SetDefaults_OCIImageClaim">func</a> [SetDefaults_OCIImageClaim](/pkg/apis/ignite/v1alpha1/defaults.go?s=275:325#L15)
+## <a name="SetDefaults_OCIImageClaim">func</a> [SetDefaults_OCIImageClaim](/pkg/apis/ignite/v1alpha1/defaults.go?s=263:313#L13)
 ``` go
 func SetDefaults_OCIImageClaim(obj *OCIImageClaim)
 ```
 
 
-## <a name="SetDefaults_PoolSpec">func</a> [SetDefaults_PoolSpec](/pkg/apis/ignite/v1alpha1/defaults.go?s=365:405#L19)
+## <a name="SetDefaults_PoolSpec">func</a> [SetDefaults_PoolSpec](/pkg/apis/ignite/v1alpha1/defaults.go?s=353:393#L17)
 ``` go
 func SetDefaults_PoolSpec(obj *PoolSpec)
 ```
 
 
-## <a name="SetDefaults_VM">func</a> [SetDefaults_VM](/pkg/apis/ignite/v1alpha1/defaults.go?s=2166:2194#L87)
-``` go
-func SetDefaults_VM(obj *VM)
-```
-TODO: Temporary hacks to populate TypeMeta until we get the generator working
-
-
-
-## <a name="SetDefaults_VMKernelSpec">func</a> [SetDefaults_VMKernelSpec](/pkg/apis/ignite/v1alpha1/defaults.go?s=1247:1295#L55)
+## <a name="SetDefaults_VMKernelSpec">func</a> [SetDefaults_VMKernelSpec](/pkg/apis/ignite/v1alpha1/defaults.go?s=1235:1283#L53)
 ``` go
 func SetDefaults_VMKernelSpec(obj *VMKernelSpec)
 ```
 
 
-## <a name="SetDefaults_VMNetworkSpec">func</a> [SetDefaults_VMNetworkSpec](/pkg/apis/ignite/v1alpha1/defaults.go?s=1532:1582#L66)
+## <a name="SetDefaults_VMNetworkSpec">func</a> [SetDefaults_VMNetworkSpec](/pkg/apis/ignite/v1alpha1/defaults.go?s=1520:1570#L64)
 ``` go
 func SetDefaults_VMNetworkSpec(obj *VMNetworkSpec)
 ```
 
 
-## <a name="SetDefaults_VMSpec">func</a> [SetDefaults_VMSpec](/pkg/apis/ignite/v1alpha1/defaults.go?s=931:967#L41)
+## <a name="SetDefaults_VMSpec">func</a> [SetDefaults_VMSpec](/pkg/apis/ignite/v1alpha1/defaults.go?s=919:955#L39)
 ``` go
 func SetDefaults_VMSpec(obj *VMSpec)
 ```
 
 
-## <a name="SetDefaults_VMStatus">func</a> [SetDefaults_VMStatus](/pkg/apis/ignite/v1alpha1/defaults.go?s=1653:1693#L72)
+## <a name="SetDefaults_VMStatus">func</a> [SetDefaults_VMStatus](/pkg/apis/ignite/v1alpha1/defaults.go?s=1641:1681#L70)
 ``` go
 func SetDefaults_VMStatus(obj *VMStatus)
 ```

--- a/api/meta.md
+++ b/api/meta.md
@@ -73,6 +73,8 @@
 * [type TypeMeta](#TypeMeta)
   * [func (t *TypeMeta) GetKind() Kind](#TypeMeta.GetKind)
   * [func (t *TypeMeta) GetTypeMeta() *TypeMeta](#TypeMeta.GetTypeMeta)
+  * [func (t *TypeMeta) GroupVersionKind() schema.GroupVersionKind](#TypeMeta.GroupVersionKind)
+  * [func (t *TypeMeta) SetGroupVersionKind(gvk schema.GroupVersionKind)](#TypeMeta.SetGroupVersionKind)
 * [type UID](#UID)
   * [func (u UID) String() string](#UID.String)
   * [func (u *UID) UnmarshalJSON(b []byte) error](#UID.UnmarshalJSON)
@@ -90,7 +92,7 @@ var EmptySize = NewSizeFromBytes(0)
 
 
 
-## <a name="APIType">type</a> [APIType](/pkg/apis/meta/v1alpha1/meta.go?s=411:495#L19)
+## <a name="APIType">type</a> [APIType](/pkg/apis/meta/v1alpha1/meta.go?s=453:537#L20)
 ``` go
 type APIType struct {
     *TypeMeta   `json:",inline"`
@@ -109,14 +111,14 @@ where .Name, .UID, .Kind and .APIVersion become easily available
 
 
 
-### <a name="APITypeFrom">func</a> [APITypeFrom](/pkg/apis/meta/v1alpha1/meta.go?s=705:742#L33)
+### <a name="APITypeFrom">func</a> [APITypeFrom](/pkg/apis/meta/v1alpha1/meta.go?s=747:784#L34)
 ``` go
 func APITypeFrom(obj Object) *APIType
 ```
 APITypeFrom is used to create a bound APIType from an Object
 
 
-### <a name="NewAPIType">func</a> [NewAPIType](/pkg/apis/meta/v1alpha1/meta.go?s=556:582#L25)
+### <a name="NewAPIType">func</a> [NewAPIType](/pkg/apis/meta/v1alpha1/meta.go?s=598:624#L26)
 ``` go
 func NewAPIType() *APIType
 ```
@@ -126,7 +128,7 @@ This constructor ensures the APIType fields are not nil
 
 
 
-## <a name="APITypeList">type</a> [APITypeList](/pkg/apis/meta/v1alpha1/meta.go?s=898:925#L43)
+## <a name="APITypeList">type</a> [APITypeList](/pkg/apis/meta/v1alpha1/meta.go?s=940:967#L44)
 ``` go
 type APITypeList []*APIType
 ```
@@ -212,7 +214,7 @@ func (i IPAddresses) String() string
 
 
 
-## <a name="Kind">type</a> [Kind](/pkg/apis/meta/v1alpha1/meta.go?s=1218:1234#L59)
+## <a name="Kind">type</a> [Kind](/pkg/apis/meta/v1alpha1/meta.go?s=1507:1523#L68)
 ``` go
 type Kind string
 ```
@@ -225,7 +227,7 @@ type Kind string
 
 
 
-### <a name="Kind.Lower">func</a> (Kind) [Lower](/pkg/apis/meta/v1alpha1/meta.go?s=1644:1672#L81)
+### <a name="Kind.Lower">func</a> (Kind) [Lower](/pkg/apis/meta/v1alpha1/meta.go?s=1933:1961#L90)
 ``` go
 func (k Kind) Lower() string
 ```
@@ -234,7 +236,7 @@ Returns a lowercase string representation of the Kind
 
 
 
-### <a name="Kind.String">func</a> (Kind) [String](/pkg/apis/meta/v1alpha1/meta.go?s=1337:1366#L64)
+### <a name="Kind.String">func</a> (Kind) [String](/pkg/apis/meta/v1alpha1/meta.go?s=1626:1655#L73)
 ``` go
 func (k Kind) String() string
 ```
@@ -243,7 +245,7 @@ Returns a string representation of the Kind suitable for sentences
 
 
 
-### <a name="Kind.Title">func</a> (Kind) [Title](/pkg/apis/meta/v1alpha1/meta.go?s=1535:1563#L76)
+### <a name="Kind.Title">func</a> (Kind) [Title](/pkg/apis/meta/v1alpha1/meta.go?s=1824:1852#L85)
 ``` go
 func (k Kind) Title() string
 ```
@@ -300,7 +302,7 @@ func (i *OCIImageRef) UnmarshalJSON(b []byte) error
 
 
 
-## <a name="Object">type</a> [Object](/pkg/apis/meta/v1alpha1/meta.go?s=3724:4069#L165)
+## <a name="Object">type</a> [Object](/pkg/apis/meta/v1alpha1/meta.go?s=4013:4448#L174)
 ``` go
 type Object interface {
     runtime.Object
@@ -309,6 +311,8 @@ type Object interface {
     GetObjectMeta() *ObjectMeta
 
     GetKind() Kind
+    GroupVersionKind() schema.GroupVersionKind
+    SetGroupVersionKind(schema.GroupVersionKind)
 
     GetName() string
     SetName(string)
@@ -338,7 +342,7 @@ extra GetName() and GetUID() methods from ObjectMeta
 
 
 
-## <a name="ObjectMeta">type</a> [ObjectMeta](/pkg/apis/meta/v1alpha1/meta.go?s=1879:2171#L88)
+## <a name="ObjectMeta">type</a> [ObjectMeta](/pkg/apis/meta/v1alpha1/meta.go?s=2168:2460#L97)
 ``` go
 type ObjectMeta struct {
     Name        string            `json:"name"`
@@ -362,7 +366,7 @@ implement the Object interface
 
 
 
-### <a name="ObjectMeta.GetAnnotation">func</a> (\*ObjectMeta) [GetAnnotation](/pkg/apis/meta/v1alpha1/meta.go?s=3279:3332#L148)
+### <a name="ObjectMeta.GetAnnotation">func</a> (\*ObjectMeta) [GetAnnotation](/pkg/apis/meta/v1alpha1/meta.go?s=3568:3621#L157)
 ``` go
 func (o *ObjectMeta) GetAnnotation(key string) string
 ```
@@ -371,7 +375,7 @@ GetAnnotation returns the label value for the key
 
 
 
-### <a name="ObjectMeta.GetCreated">func</a> (\*ObjectMeta) [GetCreated](/pkg/apis/meta/v1alpha1/meta.go?s=2716:2754#L122)
+### <a name="ObjectMeta.GetCreated">func</a> (\*ObjectMeta) [GetCreated](/pkg/apis/meta/v1alpha1/meta.go?s=3005:3043#L131)
 ``` go
 func (o *ObjectMeta) GetCreated() Time
 ```
@@ -380,7 +384,7 @@ GetCreated returns when the Object was created
 
 
 
-### <a name="ObjectMeta.GetLabel">func</a> (\*ObjectMeta) [GetLabel](/pkg/apis/meta/v1alpha1/meta.go?s=2937:2985#L132)
+### <a name="ObjectMeta.GetLabel">func</a> (\*ObjectMeta) [GetLabel](/pkg/apis/meta/v1alpha1/meta.go?s=3226:3274#L141)
 ``` go
 func (o *ObjectMeta) GetLabel(key string) string
 ```
@@ -389,7 +393,7 @@ GetLabel returns the label value for the key
 
 
 
-### <a name="ObjectMeta.GetName">func</a> (\*ObjectMeta) [GetName](/pkg/apis/meta/v1alpha1/meta.go?s=2322:2359#L102)
+### <a name="ObjectMeta.GetName">func</a> (\*ObjectMeta) [GetName](/pkg/apis/meta/v1alpha1/meta.go?s=2611:2648#L111)
 ``` go
 func (o *ObjectMeta) GetName() string
 ```
@@ -398,7 +402,7 @@ GetName returns the name of the Object
 
 
 
-### <a name="ObjectMeta.GetObjectMeta">func</a> (\*ObjectMeta) [GetObjectMeta](/pkg/apis/meta/v1alpha1/meta.go?s=2216:2264#L97)
+### <a name="ObjectMeta.GetObjectMeta">func</a> (\*ObjectMeta) [GetObjectMeta](/pkg/apis/meta/v1alpha1/meta.go?s=2505:2553#L106)
 ``` go
 func (o *ObjectMeta) GetObjectMeta() *ObjectMeta
 ```
@@ -407,7 +411,7 @@ This is a helper for APIType generation
 
 
 
-### <a name="ObjectMeta.GetUID">func</a> (\*ObjectMeta) [GetUID](/pkg/apis/meta/v1alpha1/meta.go?s=2521:2554#L112)
+### <a name="ObjectMeta.GetUID">func</a> (\*ObjectMeta) [GetUID](/pkg/apis/meta/v1alpha1/meta.go?s=2810:2843#L121)
 ``` go
 func (o *ObjectMeta) GetUID() UID
 ```
@@ -416,7 +420,7 @@ GetUID returns the UID of the Object
 
 
 
-### <a name="ObjectMeta.SetAnnotation">func</a> (\*ObjectMeta) [SetAnnotation](/pkg/apis/meta/v1alpha1/meta.go?s=3453:3506#L156)
+### <a name="ObjectMeta.SetAnnotation">func</a> (\*ObjectMeta) [SetAnnotation](/pkg/apis/meta/v1alpha1/meta.go?s=3742:3795#L165)
 ``` go
 func (o *ObjectMeta) SetAnnotation(key, value string)
 ```
@@ -425,7 +429,7 @@ SetAnnotation sets a label value for a key
 
 
 
-### <a name="ObjectMeta.SetCreated">func</a> (\*ObjectMeta) [SetCreated](/pkg/apis/meta/v1alpha1/meta.go?s=2829:2868#L127)
+### <a name="ObjectMeta.SetCreated">func</a> (\*ObjectMeta) [SetCreated](/pkg/apis/meta/v1alpha1/meta.go?s=3118:3157#L136)
 ``` go
 func (o *ObjectMeta) SetCreated(t Time)
 ```
@@ -434,7 +438,7 @@ SetCreated sets the creation time of the Object
 
 
 
-### <a name="ObjectMeta.SetLabel">func</a> (\*ObjectMeta) [SetLabel](/pkg/apis/meta/v1alpha1/meta.go?s=3091:3139#L140)
+### <a name="ObjectMeta.SetLabel">func</a> (\*ObjectMeta) [SetLabel](/pkg/apis/meta/v1alpha1/meta.go?s=3380:3428#L149)
 ``` go
 func (o *ObjectMeta) SetLabel(key, value string)
 ```
@@ -443,7 +447,7 @@ SetLabel sets a label value for a key
 
 
 
-### <a name="ObjectMeta.SetName">func</a> (\*ObjectMeta) [SetName](/pkg/apis/meta/v1alpha1/meta.go?s=2419:2460#L107)
+### <a name="ObjectMeta.SetName">func</a> (\*ObjectMeta) [SetName](/pkg/apis/meta/v1alpha1/meta.go?s=2708:2749#L116)
 ``` go
 func (o *ObjectMeta) SetName(name string)
 ```
@@ -452,7 +456,7 @@ SetName sets the name of the Object
 
 
 
-### <a name="ObjectMeta.SetUID">func</a> (\*ObjectMeta) [SetUID](/pkg/apis/meta/v1alpha1/meta.go?s=2611:2647#L117)
+### <a name="ObjectMeta.SetUID">func</a> (\*ObjectMeta) [SetUID](/pkg/apis/meta/v1alpha1/meta.go?s=2900:2936#L126)
 ``` go
 func (o *ObjectMeta) SetUID(uid UID)
 ```
@@ -639,7 +643,7 @@ The default string for Time is a human readable difference between the Time and 
 
 
 
-## <a name="TypeMeta">type</a> [TypeMeta](/pkg/apis/meta/v1alpha1/meta.go?s=1014:1055#L46)
+## <a name="TypeMeta">type</a> [TypeMeta](/pkg/apis/meta/v1alpha1/meta.go?s=1056:1097#L47)
 ``` go
 type TypeMeta struct {
     metav1.TypeMeta
@@ -657,19 +661,33 @@ TypeMeta is an alias for the k8s/apimachinery TypeMeta with some additional meth
 
 
 
-### <a name="TypeMeta.GetKind">func</a> (\*TypeMeta) [GetKind](/pkg/apis/meta/v1alpha1/meta.go?s=1158:1191#L55)
+### <a name="TypeMeta.GetKind">func</a> (\*TypeMeta) [GetKind](/pkg/apis/meta/v1alpha1/meta.go?s=1200:1233#L56)
 ``` go
 func (t *TypeMeta) GetKind() Kind
 ```
 
 
 
-### <a name="TypeMeta.GetTypeMeta">func</a> (\*TypeMeta) [GetTypeMeta](/pkg/apis/meta/v1alpha1/meta.go?s=1100:1142#L51)
+### <a name="TypeMeta.GetTypeMeta">func</a> (\*TypeMeta) [GetTypeMeta](/pkg/apis/meta/v1alpha1/meta.go?s=1142:1184#L52)
 ``` go
 func (t *TypeMeta) GetTypeMeta() *TypeMeta
 ```
 This is a helper for APIType generation
 
+
+
+
+### <a name="TypeMeta.GroupVersionKind">func</a> (\*TypeMeta) [GroupVersionKind](/pkg/apis/meta/v1alpha1/meta.go?s=1260:1321#L60)
+``` go
+func (t *TypeMeta) GroupVersionKind() schema.GroupVersionKind
+```
+
+
+
+### <a name="TypeMeta.SetGroupVersionKind">func</a> (\*TypeMeta) [SetGroupVersionKind](/pkg/apis/meta/v1alpha1/meta.go?s=1381:1448#L64)
+``` go
+func (t *TypeMeta) SetGroupVersionKind(gvk schema.GroupVersionKind)
+```
 
 
 

--- a/cmd/ignite/run/create.go
+++ b/cmd/ignite/run/create.go
@@ -17,13 +17,9 @@ import (
 )
 
 func NewCreateFlags() *CreateFlags {
-	cf := &CreateFlags{
-		VM: &api.VM{},
+	return &CreateFlags{
+		VM: client.VMs().New(),
 	}
-
-	scheme.Serializer.DefaultInternal(cf.VM)
-
-	return cf
 }
 
 type CreateFlags struct {

--- a/pkg/apis/ignite/v1alpha1/defaults.go
+++ b/pkg/apis/ignite/v1alpha1/defaults.go
@@ -1,8 +1,6 @@
 package v1alpha1
 
 import (
-	"reflect"
-
 	meta "github.com/weaveworks/ignite/pkg/apis/meta/v1alpha1"
 	"github.com/weaveworks/ignite/pkg/constants"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -81,22 +79,4 @@ func calcMetadataDevSize(obj *PoolSpec) meta.Size {
 	maxSize := meta.NewSizeFromBytes(16 * constants.GB)
 
 	return meta.NewSizeFromBytes(48 * obj.DataSize.Bytes() / obj.AllocationSize.Bytes()).Min(maxSize).Max(minSize)
-}
-
-// TODO: Temporary hacks to populate TypeMeta until we get the generator working
-func SetDefaults_VM(obj *VM) {
-	setTypeMeta(obj)
-}
-
-func SetDefaults_Image(obj *Image) {
-	setTypeMeta(obj)
-}
-
-func SetDefaults_Kernel(obj *Kernel) {
-	setTypeMeta(obj)
-}
-
-func setTypeMeta(obj meta.Object) {
-	obj.GetTypeMeta().APIVersion = SchemeGroupVersion.String()
-	obj.GetTypeMeta().Kind = reflect.Indirect(reflect.ValueOf(obj)).Type().Name()
 }

--- a/pkg/apis/ignite/v1alpha1/zz_generated.defaults.go
+++ b/pkg/apis/ignite/v1alpha1/zz_generated.defaults.go
@@ -20,12 +20,10 @@ func RegisterDefaults(scheme *runtime.Scheme) error {
 }
 
 func SetObjectDefaults_Image(in *Image) {
-	SetDefaults_Image(in)
 	SetDefaults_OCIImageClaim(&in.Spec.OCIClaim)
 }
 
 func SetObjectDefaults_Kernel(in *Kernel) {
-	SetDefaults_Kernel(in)
 	SetDefaults_OCIImageClaim(&in.Spec.OCIClaim)
 }
 
@@ -34,7 +32,6 @@ func SetObjectDefaults_Pool(in *Pool) {
 }
 
 func SetObjectDefaults_VM(in *VM) {
-	SetDefaults_VM(in)
 	SetDefaults_VMSpec(&in.Spec)
 	SetDefaults_OCIImageClaim(&in.Spec.Image.OCIClaim)
 	SetDefaults_VMKernelSpec(&in.Spec.Kernel)

--- a/pkg/apis/meta/v1alpha1/meta.go
+++ b/pkg/apis/meta/v1alpha1/meta.go
@@ -6,6 +6,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 const (
@@ -54,6 +55,14 @@ func (t *TypeMeta) GetTypeMeta() *TypeMeta {
 
 func (t *TypeMeta) GetKind() Kind {
 	return Kind(t.Kind)
+}
+
+func (t *TypeMeta) GroupVersionKind() schema.GroupVersionKind {
+	return t.TypeMeta.GetObjectKind().GroupVersionKind()
+}
+
+func (t *TypeMeta) SetGroupVersionKind(gvk schema.GroupVersionKind) {
+	t.TypeMeta.GetObjectKind().SetGroupVersionKind(gvk)
 }
 
 type Kind string
@@ -169,6 +178,8 @@ type Object interface {
 	GetObjectMeta() *ObjectMeta
 
 	GetKind() Kind
+	GroupVersionKind() schema.GroupVersionKind
+	SetGroupVersionKind(schema.GroupVersionKind)
 
 	GetName() string
 	SetName(string)

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -45,27 +45,44 @@ VM with a new IP address:
 package client
 
 import (
-	meta "github.com/weaveworks/ignite/pkg/apis/meta/v1alpha1"
+	api "github.com/weaveworks/ignite/pkg/apis/ignite"
 	"github.com/weaveworks/ignite/pkg/storage"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // NewClient creates a client for the specified storage
 func NewClient(s storage.Storage) *Client {
 	return &Client{
-		storage:        s,
-		dynamicClients: map[meta.Kind]DynamicClient{},
+		IgniteInternalClient: NewIgniteInternalClient(s),
 	}
 }
 
 // Client is a struct providing high-level access to objects in a storage
 // The resource-specific client interfaces are automatically generated based
 // off client_resource_template.go. The auto-generation can be done with hack/client.sh
+// At the moment IgniteInternalClient is the default client. If more than this client
+// is created in the future, the IgniteInternalClient will be accessible under
+// Client.IgniteInternal() instead.
 type Client struct {
+	*IgniteInternalClient
+}
+
+func NewIgniteInternalClient(s storage.Storage) *IgniteInternalClient {
+	return &IgniteInternalClient{
+		storage:        s,
+		dynamicClients: map[schema.GroupVersionKind]DynamicClient{},
+		gv:             api.SchemeGroupVersion,
+	}
+}
+
+type IgniteInternalClient struct {
 	storage        storage.Storage
+	gv             schema.GroupVersion
 	vmClient       VMClient
 	kernelClient   KernelClient
 	imageClient    ImageClient
-	dynamicClients map[meta.Kind]DynamicClient
+	dynamicClients map[schema.GroupVersionKind]DynamicClient
 }
 
 // DefaultClient is the default client that can be easily used

--- a/pkg/client/client_dynamic.go
+++ b/pkg/client/client_dynamic.go
@@ -1,13 +1,19 @@
 package client
 
 import (
+	"fmt"
+
 	meta "github.com/weaveworks/ignite/pkg/apis/meta/v1alpha1"
 	"github.com/weaveworks/ignite/pkg/storage"
 	"github.com/weaveworks/ignite/pkg/storage/filterer"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // DynamicClient is an interface for accessing API types generically
 type DynamicClient interface {
+	// New returns a new Object of its kind
+	New() meta.Object
 	// Get returns an Object matching the UID from the storage
 	Get(meta.UID) (meta.Object, error)
 	// Set saves an Object into the persistent storage
@@ -25,11 +31,12 @@ type DynamicClient interface {
 }
 
 // Dynamic returns the DynamicClient for the Client instance, for the specific kind
-func (c *Client) Dynamic(kind meta.Kind) (dc DynamicClient) {
+func (c *IgniteInternalClient) Dynamic(kind meta.Kind) (dc DynamicClient) {
 	var ok bool
-	if dc, ok = c.dynamicClients[kind]; !ok {
-		dc = newDynamicClient(c.storage, kind)
-		c.dynamicClients[kind] = dc
+	gvk := c.gv.WithKind(kind.Title())
+	if dc, ok = c.dynamicClients[gvk]; !ok {
+		dc = newDynamicClient(c.storage, gvk)
+		c.dynamicClients[gvk] = dc
 	}
 
 	return
@@ -44,45 +51,54 @@ func Dynamic(kind meta.Kind) DynamicClient {
 // It uses a shared storage instance passed from the Client together with its own Filterer
 type dynamicClient struct {
 	storage  storage.Storage
-	kind     meta.Kind
+	gvk      schema.GroupVersionKind
 	filterer *filterer.Filterer
 }
 
 // newDynamicClient builds the dynamicClient struct using the storage implementation and a new Filterer
-func newDynamicClient(s storage.Storage, kind meta.Kind) DynamicClient {
+func newDynamicClient(s storage.Storage, gvk schema.GroupVersionKind) DynamicClient {
 	return &dynamicClient{
 		storage:  s,
-		kind:     kind,
+		gvk:      gvk,
 		filterer: filterer.NewFilterer(s),
 	}
 }
 
+// New returns a new Object of its kind
+func (c *dynamicClient) New() meta.Object {
+	obj, err := c.storage.New(c.gvk)
+	if err != nil {
+		panic(fmt.Sprintf("Client.New must not return an error: %v", err))
+	}
+	return obj
+}
+
 // Get returns an Object based the given UID
 func (c *dynamicClient) Get(uid meta.UID) (meta.Object, error) {
-	return c.storage.GetByID(c.kind, uid)
+	return c.storage.Get(c.gvk, uid)
 }
 
 // Set saves an Object into the persistent storage
 func (c *dynamicClient) Set(resource meta.Object) error {
-	return c.storage.Set(resource)
+	return c.storage.Set(c.gvk, resource)
 }
 
 // Find returns an Object based on a given Filter
 func (c *dynamicClient) Find(filter filterer.BaseFilter) (meta.Object, error) {
-	return c.filterer.Find(c.kind, filter)
+	return c.filterer.Find(c.gvk, filter)
 }
 
 // FindAll returns multiple Objects based on a given Filter
 func (c *dynamicClient) FindAll(filter filterer.BaseFilter) ([]meta.Object, error) {
-	return c.filterer.FindAll(c.kind, filter)
+	return c.filterer.FindAll(c.gvk, filter)
 }
 
 // Delete deletes the Object from the storage
 func (c *dynamicClient) Delete(uid meta.UID) error {
-	return c.storage.Delete(c.kind, uid)
+	return c.storage.Delete(c.gvk, uid)
 }
 
 // List returns a list of all Objects available
 func (c *dynamicClient) List() ([]meta.Object, error) {
-	return c.storage.List(c.kind)
+	return c.storage.List(c.gvk)
 }

--- a/pkg/client/client_resource_template.go
+++ b/pkg/client/client_resource_template.go
@@ -9,15 +9,21 @@
 package client
 
 import (
+	"fmt"
+
 	log "github.com/sirupsen/logrus"
 	api "github.com/weaveworks/ignite/pkg/apis/ignite"
 	meta "github.com/weaveworks/ignite/pkg/apis/meta/v1alpha1"
 	"github.com/weaveworks/ignite/pkg/storage"
 	"github.com/weaveworks/ignite/pkg/storage/filterer"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // ResourceClient is an interface for accessing Resource-specific API objects
 type ResourceClient interface {
+	// New returns a new Resource
+	New() *api.Resource
 	// Get returns the Resource matching given UID from the storage
 	Get(meta.UID) (*api.Resource, error)
 	// Set saves the given Resource into persistent storage
@@ -34,10 +40,10 @@ type ResourceClient interface {
 	List() ([]*api.Resource, error)
 }
 
-// Resources returns the ResourceClient for the Client instance
-func (c *Client) Resources() ResourceClient {
+// Resources returns the ResourceClient for the IgniteInternalClient instance
+func (c *IgniteInternalClient) Resources() ResourceClient {
 	if c.resourceClient == nil {
-		c.resourceClient = newResourceClient(c.storage)
+		c.resourceClient = newResourceClient(c.storage, c.gv)
 	}
 
 	return c.resourceClient
@@ -53,19 +59,32 @@ func Resources() ResourceClient {
 type resourceClient struct {
 	storage  storage.Storage
 	filterer *filterer.Filterer
+	gvk      schema.GroupVersionKind
 }
 
 // newResourceClient builds the resourceClient struct using the storage implementation and a new Filterer
-func newResourceClient(s storage.Storage) ResourceClient {
+func newResourceClient(s storage.Storage, gv schema.GroupVersion) ResourceClient {
 	return &resourceClient{
 		storage:  s,
 		filterer: filterer.NewFilterer(s),
+		gvk:      gv.WithKind(api.KindResource.Title()),
 	}
+}
+
+// New returns a new Object of its kind
+func (c *resourceClient) New() *api.Resource {
+	log.Tracef("Client.New; GVK: %v", c.gvk)
+	obj, err := c.storage.New(c.gvk)
+	if err != nil {
+		panic(fmt.Sprintf("Client.New must not return an error: %v", err))
+	}
+	return obj.(*api.Resource)
 }
 
 // Find returns a single Resource based on the given Filter
 func (c *resourceClient) Find(filter filterer.BaseFilter) (*api.Resource, error) {
-	object, err := c.filterer.Find(api.KindResource, filter)
+	log.Tracef("Client.Find; GVK: %v", c.gvk)
+	object, err := c.filterer.Find(c.gvk, filter)
 	if err != nil {
 		return nil, err
 	}
@@ -75,7 +94,8 @@ func (c *resourceClient) Find(filter filterer.BaseFilter) (*api.Resource, error)
 
 // FindAll returns multiple Resources based on the given Filter
 func (c *resourceClient) FindAll(filter filterer.BaseFilter) ([]*api.Resource, error) {
-	matches, err := c.filterer.FindAll(api.KindResource, filter)
+	log.Tracef("Client.FindAll; GVK: %v", c.gvk)
+	matches, err := c.filterer.FindAll(c.gvk, filter)
 	if err != nil {
 		return nil, err
 	}
@@ -90,8 +110,8 @@ func (c *resourceClient) FindAll(filter filterer.BaseFilter) ([]*api.Resource, e
 
 // Get returns the Resource matching given UID from the storage
 func (c *resourceClient) Get(uid meta.UID) (*api.Resource, error) {
-	log.Debugf("Client.Get; UID: %q, Kind: %s", uid, api.KindResource)
-	object, err := c.storage.GetByID(api.KindResource, uid)
+	log.Tracef("Client.Get; UID: %q, GVK: %v", uid, c.gvk)
+	object, err := c.storage.Get(c.gvk, uid)
 	if err != nil {
 		return nil, err
 	}
@@ -101,19 +121,20 @@ func (c *resourceClient) Get(uid meta.UID) (*api.Resource, error) {
 
 // Set saves the given Resource into the persistent storage
 func (c *resourceClient) Set(resource *api.Resource) error {
-	log.Debugf("Client.Set; UID: %q, Kind: %s", resource.GetUID(), resource.GetKind())
-	return c.storage.Set(resource)
+	log.Tracef("Client.Set; UID: %q, GVK: %v", resource.GetUID(), c.gvk)
+	return c.storage.Set(c.gvk, resource)
 }
 
 // Delete deletes the Resource from the storage
 func (c *resourceClient) Delete(uid meta.UID) error {
-	log.Debugf("Client.Delete; UID: %q, Kind: %s", uid, api.KindResource)
-	return c.storage.Delete(api.KindResource, uid)
+	log.Tracef("Client.Delete; UID: %q, GVK: %v", uid, c.gvk)
+	return c.storage.Delete(c.gvk, uid)
 }
 
 // List returns a list of all Resources available
 func (c *resourceClient) List() ([]*api.Resource, error) {
-	list, err := c.storage.List(api.KindResource)
+	log.Tracef("Client.List; GVK: %v", c.gvk)
+	list, err := c.storage.List(c.gvk)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/zz_generated.client_image.go
+++ b/pkg/client/zz_generated.client_image.go
@@ -8,15 +8,21 @@
 package client
 
 import (
+	"fmt"
+
 	log "github.com/sirupsen/logrus"
 	api "github.com/weaveworks/ignite/pkg/apis/ignite"
 	meta "github.com/weaveworks/ignite/pkg/apis/meta/v1alpha1"
 	"github.com/weaveworks/ignite/pkg/storage"
 	"github.com/weaveworks/ignite/pkg/storage/filterer"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // ImageClient is an interface for accessing Image-specific API objects
 type ImageClient interface {
+	// New returns a new Image
+	New() *api.Image
 	// Get returns the Image matching given UID from the storage
 	Get(meta.UID) (*api.Image, error)
 	// Set saves the given Image into persistent storage
@@ -33,10 +39,10 @@ type ImageClient interface {
 	List() ([]*api.Image, error)
 }
 
-// Images returns the ImageClient for the Client instance
-func (c *Client) Images() ImageClient {
+// Images returns the ImageClient for the IgniteInternalClient instance
+func (c *IgniteInternalClient) Images() ImageClient {
 	if c.imageClient == nil {
-		c.imageClient = newImageClient(c.storage)
+		c.imageClient = newImageClient(c.storage, c.gv)
 	}
 
 	return c.imageClient
@@ -52,19 +58,32 @@ func Images() ImageClient {
 type imageClient struct {
 	storage  storage.Storage
 	filterer *filterer.Filterer
+	gvk      schema.GroupVersionKind
 }
 
 // newImageClient builds the imageClient struct using the storage implementation and a new Filterer
-func newImageClient(s storage.Storage) ImageClient {
+func newImageClient(s storage.Storage, gv schema.GroupVersion) ImageClient {
 	return &imageClient{
 		storage:  s,
 		filterer: filterer.NewFilterer(s),
+		gvk:      gv.WithKind(api.KindImage.Title()),
 	}
+}
+
+// New returns a new Object of its kind
+func (c *imageClient) New() *api.Image {
+	log.Tracef("Client.New; GVK: %v", c.gvk)
+	obj, err := c.storage.New(c.gvk)
+	if err != nil {
+		panic(fmt.Sprintf("Client.New must not return an error: %v", err))
+	}
+	return obj.(*api.Image)
 }
 
 // Find returns a single Image based on the given Filter
 func (c *imageClient) Find(filter filterer.BaseFilter) (*api.Image, error) {
-	object, err := c.filterer.Find(api.KindImage, filter)
+	log.Tracef("Client.Find; GVK: %v", c.gvk)
+	object, err := c.filterer.Find(c.gvk, filter)
 	if err != nil {
 		return nil, err
 	}
@@ -74,7 +93,8 @@ func (c *imageClient) Find(filter filterer.BaseFilter) (*api.Image, error) {
 
 // FindAll returns multiple Images based on the given Filter
 func (c *imageClient) FindAll(filter filterer.BaseFilter) ([]*api.Image, error) {
-	matches, err := c.filterer.FindAll(api.KindImage, filter)
+	log.Tracef("Client.FindAll; GVK: %v", c.gvk)
+	matches, err := c.filterer.FindAll(c.gvk, filter)
 	if err != nil {
 		return nil, err
 	}
@@ -89,8 +109,8 @@ func (c *imageClient) FindAll(filter filterer.BaseFilter) ([]*api.Image, error) 
 
 // Get returns the Image matching given UID from the storage
 func (c *imageClient) Get(uid meta.UID) (*api.Image, error) {
-	log.Debugf("Client.Get; UID: %q, Kind: %s", uid, api.KindImage)
-	object, err := c.storage.GetByID(api.KindImage, uid)
+	log.Tracef("Client.Get; UID: %q, GVK: %v", uid, c.gvk)
+	object, err := c.storage.Get(c.gvk, uid)
 	if err != nil {
 		return nil, err
 	}
@@ -100,19 +120,20 @@ func (c *imageClient) Get(uid meta.UID) (*api.Image, error) {
 
 // Set saves the given Image into the persistent storage
 func (c *imageClient) Set(image *api.Image) error {
-	log.Debugf("Client.Set; UID: %q, Kind: %s", image.GetUID(), image.GetKind())
-	return c.storage.Set(image)
+	log.Tracef("Client.Set; UID: %q, GVK: %v", image.GetUID(), c.gvk)
+	return c.storage.Set(c.gvk, image)
 }
 
 // Delete deletes the Image from the storage
 func (c *imageClient) Delete(uid meta.UID) error {
-	log.Debugf("Client.Delete; UID: %q, Kind: %s", uid, api.KindImage)
-	return c.storage.Delete(api.KindImage, uid)
+	log.Tracef("Client.Delete; UID: %q, GVK: %v", uid, c.gvk)
+	return c.storage.Delete(c.gvk, uid)
 }
 
 // List returns a list of all Images available
 func (c *imageClient) List() ([]*api.Image, error) {
-	list, err := c.storage.List(api.KindImage)
+	log.Tracef("Client.List; GVK: %v", c.gvk)
+	list, err := c.storage.List(c.gvk)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/zz_generated.client_kernel.go
+++ b/pkg/client/zz_generated.client_kernel.go
@@ -8,15 +8,21 @@
 package client
 
 import (
+	"fmt"
+
 	log "github.com/sirupsen/logrus"
 	api "github.com/weaveworks/ignite/pkg/apis/ignite"
 	meta "github.com/weaveworks/ignite/pkg/apis/meta/v1alpha1"
 	"github.com/weaveworks/ignite/pkg/storage"
 	"github.com/weaveworks/ignite/pkg/storage/filterer"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // KernelClient is an interface for accessing Kernel-specific API objects
 type KernelClient interface {
+	// New returns a new Kernel
+	New() *api.Kernel
 	// Get returns the Kernel matching given UID from the storage
 	Get(meta.UID) (*api.Kernel, error)
 	// Set saves the given Kernel into persistent storage
@@ -33,10 +39,10 @@ type KernelClient interface {
 	List() ([]*api.Kernel, error)
 }
 
-// Kernels returns the KernelClient for the Client instance
-func (c *Client) Kernels() KernelClient {
+// Kernels returns the KernelClient for the IgniteInternalClient instance
+func (c *IgniteInternalClient) Kernels() KernelClient {
 	if c.kernelClient == nil {
-		c.kernelClient = newKernelClient(c.storage)
+		c.kernelClient = newKernelClient(c.storage, c.gv)
 	}
 
 	return c.kernelClient
@@ -52,19 +58,32 @@ func Kernels() KernelClient {
 type kernelClient struct {
 	storage  storage.Storage
 	filterer *filterer.Filterer
+	gvk      schema.GroupVersionKind
 }
 
 // newKernelClient builds the kernelClient struct using the storage implementation and a new Filterer
-func newKernelClient(s storage.Storage) KernelClient {
+func newKernelClient(s storage.Storage, gv schema.GroupVersion) KernelClient {
 	return &kernelClient{
 		storage:  s,
 		filterer: filterer.NewFilterer(s),
+		gvk:      gv.WithKind(api.KindKernel.Title()),
 	}
+}
+
+// New returns a new Object of its kind
+func (c *kernelClient) New() *api.Kernel {
+	log.Tracef("Client.New; GVK: %v", c.gvk)
+	obj, err := c.storage.New(c.gvk)
+	if err != nil {
+		panic(fmt.Sprintf("Client.New must not return an error: %v", err))
+	}
+	return obj.(*api.Kernel)
 }
 
 // Find returns a single Kernel based on the given Filter
 func (c *kernelClient) Find(filter filterer.BaseFilter) (*api.Kernel, error) {
-	object, err := c.filterer.Find(api.KindKernel, filter)
+	log.Tracef("Client.Find; GVK: %v", c.gvk)
+	object, err := c.filterer.Find(c.gvk, filter)
 	if err != nil {
 		return nil, err
 	}
@@ -74,7 +93,8 @@ func (c *kernelClient) Find(filter filterer.BaseFilter) (*api.Kernel, error) {
 
 // FindAll returns multiple Kernels based on the given Filter
 func (c *kernelClient) FindAll(filter filterer.BaseFilter) ([]*api.Kernel, error) {
-	matches, err := c.filterer.FindAll(api.KindKernel, filter)
+	log.Tracef("Client.FindAll; GVK: %v", c.gvk)
+	matches, err := c.filterer.FindAll(c.gvk, filter)
 	if err != nil {
 		return nil, err
 	}
@@ -89,8 +109,8 @@ func (c *kernelClient) FindAll(filter filterer.BaseFilter) ([]*api.Kernel, error
 
 // Get returns the Kernel matching given UID from the storage
 func (c *kernelClient) Get(uid meta.UID) (*api.Kernel, error) {
-	log.Debugf("Client.Get; UID: %q, Kind: %s", uid, api.KindKernel)
-	object, err := c.storage.GetByID(api.KindKernel, uid)
+	log.Tracef("Client.Get; UID: %q, GVK: %v", uid, c.gvk)
+	object, err := c.storage.Get(c.gvk, uid)
 	if err != nil {
 		return nil, err
 	}
@@ -100,19 +120,20 @@ func (c *kernelClient) Get(uid meta.UID) (*api.Kernel, error) {
 
 // Set saves the given Kernel into the persistent storage
 func (c *kernelClient) Set(kernel *api.Kernel) error {
-	log.Debugf("Client.Set; UID: %q, Kind: %s", kernel.GetUID(), kernel.GetKind())
-	return c.storage.Set(kernel)
+	log.Tracef("Client.Set; UID: %q, GVK: %v", kernel.GetUID(), c.gvk)
+	return c.storage.Set(c.gvk, kernel)
 }
 
 // Delete deletes the Kernel from the storage
 func (c *kernelClient) Delete(uid meta.UID) error {
-	log.Debugf("Client.Delete; UID: %q, Kind: %s", uid, api.KindKernel)
-	return c.storage.Delete(api.KindKernel, uid)
+	log.Tracef("Client.Delete; UID: %q, GVK: %v", uid, c.gvk)
+	return c.storage.Delete(c.gvk, uid)
 }
 
 // List returns a list of all Kernels available
 func (c *kernelClient) List() ([]*api.Kernel, error) {
-	list, err := c.storage.List(api.KindKernel)
+	log.Tracef("Client.List; GVK: %v", c.gvk)
+	list, err := c.storage.List(c.gvk)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/zz_generated.client_vm.go
+++ b/pkg/client/zz_generated.client_vm.go
@@ -8,15 +8,21 @@
 package client
 
 import (
+	"fmt"
+
 	log "github.com/sirupsen/logrus"
 	api "github.com/weaveworks/ignite/pkg/apis/ignite"
 	meta "github.com/weaveworks/ignite/pkg/apis/meta/v1alpha1"
 	"github.com/weaveworks/ignite/pkg/storage"
 	"github.com/weaveworks/ignite/pkg/storage/filterer"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // VMClient is an interface for accessing VM-specific API objects
 type VMClient interface {
+	// New returns a new VM
+	New() *api.VM
 	// Get returns the VM matching given UID from the storage
 	Get(meta.UID) (*api.VM, error)
 	// Set saves the given VM into persistent storage
@@ -33,10 +39,10 @@ type VMClient interface {
 	List() ([]*api.VM, error)
 }
 
-// VMs returns the VMClient for the Client instance
-func (c *Client) VMs() VMClient {
+// VMs returns the VMClient for the IgniteInternalClient instance
+func (c *IgniteInternalClient) VMs() VMClient {
 	if c.vmClient == nil {
-		c.vmClient = newVMClient(c.storage)
+		c.vmClient = newVMClient(c.storage, c.gv)
 	}
 
 	return c.vmClient
@@ -52,19 +58,32 @@ func VMs() VMClient {
 type vmClient struct {
 	storage  storage.Storage
 	filterer *filterer.Filterer
+	gvk      schema.GroupVersionKind
 }
 
 // newVMClient builds the vmClient struct using the storage implementation and a new Filterer
-func newVMClient(s storage.Storage) VMClient {
+func newVMClient(s storage.Storage, gv schema.GroupVersion) VMClient {
 	return &vmClient{
 		storage:  s,
 		filterer: filterer.NewFilterer(s),
+		gvk:      gv.WithKind(api.KindVM.Title()),
 	}
+}
+
+// New returns a new Object of its kind
+func (c *vmClient) New() *api.VM {
+	log.Tracef("Client.New; GVK: %v", c.gvk)
+	obj, err := c.storage.New(c.gvk)
+	if err != nil {
+		panic(fmt.Sprintf("Client.New must not return an error: %v", err))
+	}
+	return obj.(*api.VM)
 }
 
 // Find returns a single VM based on the given Filter
 func (c *vmClient) Find(filter filterer.BaseFilter) (*api.VM, error) {
-	object, err := c.filterer.Find(api.KindVM, filter)
+	log.Tracef("Client.Find; GVK: %v", c.gvk)
+	object, err := c.filterer.Find(c.gvk, filter)
 	if err != nil {
 		return nil, err
 	}
@@ -74,7 +93,8 @@ func (c *vmClient) Find(filter filterer.BaseFilter) (*api.VM, error) {
 
 // FindAll returns multiple VMs based on the given Filter
 func (c *vmClient) FindAll(filter filterer.BaseFilter) ([]*api.VM, error) {
-	matches, err := c.filterer.FindAll(api.KindVM, filter)
+	log.Tracef("Client.FindAll; GVK: %v", c.gvk)
+	matches, err := c.filterer.FindAll(c.gvk, filter)
 	if err != nil {
 		return nil, err
 	}
@@ -89,8 +109,8 @@ func (c *vmClient) FindAll(filter filterer.BaseFilter) ([]*api.VM, error) {
 
 // Get returns the VM matching given UID from the storage
 func (c *vmClient) Get(uid meta.UID) (*api.VM, error) {
-	log.Debugf("Client.Get; UID: %q, Kind: %s", uid, api.KindVM)
-	object, err := c.storage.GetByID(api.KindVM, uid)
+	log.Tracef("Client.Get; UID: %q, GVK: %v", uid, c.gvk)
+	object, err := c.storage.Get(c.gvk, uid)
 	if err != nil {
 		return nil, err
 	}
@@ -100,19 +120,20 @@ func (c *vmClient) Get(uid meta.UID) (*api.VM, error) {
 
 // Set saves the given VM into the persistent storage
 func (c *vmClient) Set(vm *api.VM) error {
-	log.Debugf("Client.Set; UID: %q, Kind: %s", vm.GetUID(), vm.GetKind())
-	return c.storage.Set(vm)
+	log.Tracef("Client.Set; UID: %q, GVK: %v", vm.GetUID(), c.gvk)
+	return c.storage.Set(c.gvk, vm)
 }
 
 // Delete deletes the VM from the storage
 func (c *vmClient) Delete(uid meta.UID) error {
-	log.Debugf("Client.Delete; UID: %q, Kind: %s", uid, api.KindVM)
-	return c.storage.Delete(api.KindVM, uid)
+	log.Tracef("Client.Delete; UID: %q, GVK: %v", uid, c.gvk)
+	return c.storage.Delete(c.gvk, uid)
 }
 
 // List returns a list of all VMs available
 func (c *vmClient) List() ([]*api.VM, error) {
-	list, err := c.storage.List(api.KindVM)
+	log.Tracef("Client.List; GVK: %v", c.gvk)
+	list, err := c.storage.List(c.gvk)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/metadata/imgmd/imgmd.go
+++ b/pkg/metadata/imgmd/imgmd.go
@@ -4,7 +4,6 @@ import (
 	"path"
 
 	api "github.com/weaveworks/ignite/pkg/apis/ignite"
-	"github.com/weaveworks/ignite/pkg/apis/ignite/scheme"
 	"github.com/weaveworks/ignite/pkg/client"
 	"github.com/weaveworks/ignite/pkg/constants"
 	"github.com/weaveworks/ignite/pkg/metadata"
@@ -22,9 +21,6 @@ var _ metadata.Metadata = &Image{}
 // NewImage, hence it should only be used for "safe"
 // data coming from storage.
 func WrapImage(obj *api.Image) *Image {
-	// Run the object through defaulting, just to be sure it has all the values
-	scheme.Serializer.DefaultInternal(obj)
-
 	return &Image{
 		Image: obj,
 		c:     client.DefaultClient,

--- a/pkg/metadata/kernmd/kernmd.go
+++ b/pkg/metadata/kernmd/kernmd.go
@@ -4,7 +4,6 @@ import (
 	"path"
 
 	api "github.com/weaveworks/ignite/pkg/apis/ignite"
-	"github.com/weaveworks/ignite/pkg/apis/ignite/scheme"
 	"github.com/weaveworks/ignite/pkg/client"
 	"github.com/weaveworks/ignite/pkg/constants"
 	"github.com/weaveworks/ignite/pkg/metadata"
@@ -22,9 +21,6 @@ var _ metadata.Metadata = &Kernel{}
 // NewKernel, hence it should only be used for "safe"
 // data coming from storage.
 func WrapKernel(obj *api.Kernel) *Kernel {
-	// Run the object through defaulting, just to be sure it has all the values
-	scheme.Serializer.DefaultInternal(obj)
-
 	return &Kernel{
 		Kernel: obj,
 		c:      client.DefaultClient,

--- a/pkg/metadata/metadata.go
+++ b/pkg/metadata/metadata.go
@@ -8,7 +8,6 @@ import (
 	"regexp"
 
 	api "github.com/weaveworks/ignite/pkg/apis/ignite"
-	"github.com/weaveworks/ignite/pkg/apis/ignite/scheme"
 	meta "github.com/weaveworks/ignite/pkg/apis/meta/v1alpha1"
 	"github.com/weaveworks/ignite/pkg/client"
 	"github.com/weaveworks/ignite/pkg/constants"
@@ -39,20 +38,13 @@ func InitObject(obj meta.Object, c *client.Client) error {
 		c = client.DefaultClient
 	}
 
-	// Default the object
-	scheme.Serializer.DefaultInternal(obj)
-
 	// Generate or validate the given UID, if any
 	if err := processUID(obj, c); err != nil {
 		return err
 	}
 
 	// Generate or validate the given name, if any
-	if err := processName(obj, c); err != nil {
-		return err
-	}
-
-	return nil
+	return processName(obj, c)
 }
 
 // processUID a new 8-byte ID and handles directory creation/deletion

--- a/pkg/metadata/vmmd/vmmd.go
+++ b/pkg/metadata/vmmd/vmmd.go
@@ -6,7 +6,6 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	api "github.com/weaveworks/ignite/pkg/apis/ignite"
-	"github.com/weaveworks/ignite/pkg/apis/ignite/scheme"
 	"github.com/weaveworks/ignite/pkg/apis/ignite/validation"
 	meta "github.com/weaveworks/ignite/pkg/apis/meta/v1alpha1"
 	"github.com/weaveworks/ignite/pkg/client"
@@ -31,9 +30,6 @@ var _ metadata.Metadata = &VM{}
 // NewVM, hence it should only be used for "safe"
 // data coming from storage.
 func WrapVM(obj *api.VM) *VM {
-	// Run the object through defaulting, just to be sure it has all the values
-	scheme.Serializer.DefaultInternal(obj)
-
 	vm := &VM{
 		VM: obj,
 		c:  client.DefaultClient,

--- a/pkg/operations/import.go
+++ b/pkg/operations/import.go
@@ -8,7 +8,6 @@ import (
 	"path"
 
 	log "github.com/sirupsen/logrus"
-	api "github.com/weaveworks/ignite/pkg/apis/ignite"
 	meta "github.com/weaveworks/ignite/pkg/apis/meta/v1alpha1"
 	"github.com/weaveworks/ignite/pkg/client"
 	"github.com/weaveworks/ignite/pkg/constants"
@@ -50,19 +49,13 @@ func importImage(c *client.Client, ociRef meta.OCIImageRef) (*imgmd.Image, error
 		return nil, err
 	}
 
-	image := &api.Image{
-		ObjectMeta: meta.ObjectMeta{
-			Name: ociRef.String(),
-		},
-		Spec: api.ImageSpec{
-			OCIClaim: api.OCIImageClaim{
-				Ref: ociRef,
-			},
-		},
-		Status: api.ImageStatus{
-			OCISource: *src,
-		},
-	}
+	image := client.Images().New()
+	// Set the image name
+	image.Name = ociRef.String()
+	// Set the image's ociRef
+	image.Spec.OCIClaim.Ref = ociRef
+	// Set the image's ociSource
+	image.Status.OCISource = *src
 
 	// Create a new image runtime object
 	runImage, err := imgmd.NewImage(image, c)
@@ -120,19 +113,13 @@ func importKernel(c *client.Client, ociRef meta.OCIImageRef) (*kernmd.Kernel, er
 		return nil, err
 	}
 
-	kernel := &api.Kernel{
-		ObjectMeta: meta.ObjectMeta{
-			Name: ociRef.String(),
-		},
-		Spec: api.KernelSpec{
-			OCIClaim: api.OCIImageClaim{
-				Ref: ociRef,
-			},
-		},
-		Status: api.KernelStatus{
-			OCISource: *src,
-		},
-	}
+	kernel := client.Kernels().New()
+	// Set the kernel name
+	kernel.Name = ociRef.String()
+	// Set the kernel's ociRef
+	kernel.Spec.OCIClaim.Ref = ociRef
+	// Set the kernel's ociSource
+	kernel.Status.OCISource = *src
 
 	// Create new kernel metadata
 	runKernel, err := kernmd.NewKernel(kernel, c)

--- a/pkg/storage/filterer/filterer.go
+++ b/pkg/storage/filterer/filterer.go
@@ -5,6 +5,8 @@ import (
 
 	meta "github.com/weaveworks/ignite/pkg/apis/meta/v1alpha1"
 	"github.com/weaveworks/ignite/pkg/storage"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 type Filterer struct {
@@ -20,12 +22,12 @@ func NewFilterer(storage storage.Storage) *Filterer {
 type filterFunc func(meta.Object) (Match, error)
 
 // Find a single meta.Object of the given kind using the given filter
-func (f *Filterer) Find(kind meta.Kind, filter BaseFilter) (meta.Object, error) {
+func (f *Filterer) Find(gvk schema.GroupVersionKind, filter BaseFilter) (meta.Object, error) {
 	var results []Match
 	var exactMatch Match
 
 	// Fetch the sources, correct filtering method and if we're dealing with meta.APIType objects
-	sources, filterFunc, metaObjects, err := f.parseFilter(kind, filter)
+	sources, filterFunc, metaObjects, err := f.parseFilter(gvk, filter)
 	if err != nil {
 		return nil, err
 	}
@@ -65,18 +67,18 @@ func (f *Filterer) Find(kind meta.Kind, filter BaseFilter) (meta.Object, error) 
 
 	// If we're filtering meta.APIType objects, load the full Object to be returned
 	if metaObjects {
-		return f.storage.GetByID(result.GetKind(), result.GetUID())
+		return f.storage.Get(result.GroupVersionKind(), result.GetUID())
 	}
 
 	return result, nil
 }
 
 // Find all meta.Objects of the given kind using the given filter
-func (f *Filterer) FindAll(kind meta.Kind, filter BaseFilter) ([]meta.Object, error) {
+func (f *Filterer) FindAll(gvk schema.GroupVersionKind, filter BaseFilter) ([]meta.Object, error) {
 	var results []meta.Object
 
 	// Fetch the sources, correct filtering method and if we're dealing with meta.APIType objects
-	sources, filterFunc, metaObjects, err := f.parseFilter(kind, filter)
+	sources, filterFunc, metaObjects, err := f.parseFilter(gvk, filter)
 	if err != nil {
 		return nil, err
 	}
@@ -94,7 +96,7 @@ func (f *Filterer) FindAll(kind meta.Kind, filter BaseFilter) ([]meta.Object, er
 	if metaObjects {
 		objects := make([]meta.Object, len(results))
 		for i, result := range results {
-			if objects[i], err = f.storage.GetByID(result.GetKind(), result.GetUID()); err != nil {
+			if objects[i], err = f.storage.Get(result.GroupVersionKind(), result.GetUID()); err != nil {
 				return nil, err
 			}
 		}
@@ -105,21 +107,21 @@ func (f *Filterer) FindAll(kind meta.Kind, filter BaseFilter) ([]meta.Object, er
 	return results, nil
 }
 
-func (f *Filterer) parseFilter(kind meta.Kind, filter BaseFilter) (sources []meta.Object, filterFunc filterFunc, metaObjects bool, err error) {
+func (f *Filterer) parseFilter(gvk schema.GroupVersionKind, filter BaseFilter) (sources []meta.Object, filterFunc filterFunc, metaObjects bool, err error) {
 	// Parse ObjectFilters before MetaFilters, so ObjectFilters can embed MetaFilters
 	if objectFilter, ok := filter.(ObjectFilter); ok {
 		filterFunc = objectFilter.Filter
-		sources, err = f.storage.List(kind)
+		sources, err = f.storage.List(gvk)
 	} else if metaFilter, ok := filter.(MetaFilter); ok {
 		filterFunc = metaFilter.FilterMeta
-		sources, err = f.storage.ListMeta(kind)
+		sources, err = f.storage.ListMeta(gvk)
 		metaObjects = true
 	} else {
 		err = fmt.Errorf("invalid filter type: %T", filter)
 	}
 
 	// Make sure the desired kind propagates down to the filter
-	filter.SetKind(kind)
+	filter.SetKind(meta.Kind(gvk.Kind))
 
 	return
 }

--- a/pkg/storage/serializer/serializer.go
+++ b/pkg/storage/serializer/serializer.go
@@ -99,6 +99,9 @@ func (s *serializer) Decode(content []byte, internal bool) (runtime.Object, erro
 	if err != nil {
 		return nil, err
 	}
+	// Default the object
+	s.scheme.Default(obj)
+
 	// If we did not request an internal conversion, return quickly
 	if !internal {
 		return obj, nil

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -17,25 +17,25 @@ import (
 // Storage is an interface for persisting and retrieving API objects to/from a backend
 // One Storage instance handles all different Kinds of Objects
 type Storage interface {
-	// Get populates the Object using the given pointer, based on the file content
-	Get(obj meta.Object) error
+	// New creates a new object for the specified kind
+	New(gvk schema.GroupVersionKind) (meta.Object, error)
+	// Get returns a new Object for the resource at the specified kind/uid path, based on the file content
+	Get(gvk schema.GroupVersionKind, uid meta.UID) (meta.Object, error)
 	// Set saves the Object to disk. If the object does not exist, the
 	// ObjectMeta.Created field is set automatically
-	Set(obj meta.Object) error
-	// GetByID returns a new Object for the resource at the specified kind/uid path, based on the file content
-	GetByID(kind meta.Kind, uid meta.UID) (meta.Object, error)
+	Set(gvk schema.GroupVersionKind, obj meta.Object) error
 	// Delete removes an object from the storage
-	Delete(kind meta.Kind, uid meta.UID) error
+	Delete(gvk schema.GroupVersionKind, uid meta.UID) error
 	// List lists objects for the specific kind
-	List(kind meta.Kind) ([]meta.Object, error)
+	List(gvk schema.GroupVersionKind) ([]meta.Object, error)
 	// ListMeta lists all objects' APIType representation. In other words,
 	// only metadata about each object is unmarshalled (uid/name/kind/apiVersion).
 	// This allows for faster runs (no need to unmarshal "the world"), and less
 	// resource usage, when only metadata is unmarshalled into memory
-	ListMeta(kind meta.Kind) ([]meta.Object, error)
+	ListMeta(gvk schema.GroupVersionKind) ([]meta.Object, error)
 	// Count returns the amount of available Objects of a specific kind
 	// This is used by Caches to check if all objects are cached to perform a List
-	Count(kind meta.Kind) (uint64, error)
+	Count(gvk schema.GroupVersionKind) (uint64, error)
 }
 
 // DefaultStorage is the default storage implementation
@@ -54,122 +54,127 @@ type GenericStorage struct {
 
 var _ Storage = &GenericStorage{}
 
-// Get populates the pointer to the Object given, based on the file content
-func (s *GenericStorage) Get(obj meta.Object) error {
-	storageKey, err := s.keyForObj(obj)
+// New creates a new object for the specified kind
+// TODO: Create better error handling if the GVK specified is not recognized
+func (s *GenericStorage) New(gvk schema.GroupVersionKind) (meta.Object, error) {
+	obj, err := s.serializer.Scheme().New(gvk)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	content, err := s.raw.Read(storageKey)
-	if err != nil {
-		return err
+	// Default either through the scheme, or the high-level serializer object
+	if gvk.Version == runtime.APIVersionInternal {
+		if err := s.serializer.DefaultInternal(obj); err != nil {
+			return nil, err
+		}
+	} else {
+		s.serializer.Scheme().Default(obj)
 	}
 
-	return s.serializer.DecodeInto(content, obj)
+	// Cast to meta.Object, and make sure it works
+	metaObj, ok := obj.(meta.Object)
+	if !ok {
+		return nil, fmt.Errorf("can't convert to ignite object")
+	}
+	// Set the desired gvk from the caller of this object
+	// In practice, this means, although we created an internal type,
+	// from defaulting external TypeMeta information was set. Set the
+	// desired gvk here so it's correctly handled in all code that gets
+	// the gvk from the object
+	metaObj.SetGroupVersionKind(gvk)
+	return metaObj, nil
 }
 
-// GetByID returns a new Object for the resource at the specified kind/uid path, based on the file content
-func (s *GenericStorage) GetByID(kind meta.Kind, uid meta.UID) (meta.Object, error) {
-	storageKey := KeyForUID(kind, uid)
+// Get returns a new Object for the resource at the specified kind/uid path, based on the file content
+func (s *GenericStorage) Get(gvk schema.GroupVersionKind, uid meta.UID) (meta.Object, error) {
+	storageKey := KeyForUID(gvk, uid)
 	content, err := s.raw.Read(storageKey)
 	if err != nil {
 		return nil, err
 	}
 
-	// Decode the bytes to the internal version of the object
-	internalobj, err := s.serializer.Decode(content, true)
-	if err != nil {
-		return nil, err
-	}
-
-	obj, ok := internalobj.(meta.Object)
-	if !ok {
-		return nil, fmt.Errorf("cannot convert to ignite Object")
-	}
-
-	return obj, nil
+	// Decode the bytes to the internal version of the object, if desired
+	isInternal := gvk.Version == runtime.APIVersionInternal
+	return s.decode(content, isInternal)
 }
 
 // Set saves the Object to disk
-func (s *GenericStorage) Set(obj meta.Object) error {
-	storageKey, err := s.keyForObj(obj)
-	if err != nil {
-		return err
-	}
-
+func (s *GenericStorage) Set(gvk schema.GroupVersionKind, obj meta.Object) error {
 	b, err := s.serializer.EncodeJSON(obj)
 	if err != nil {
 		return err
 	}
 
+	storageKey := KeyForUID(gvk, obj.GetUID())
 	return s.raw.Write(storageKey, b)
 }
 
 // Delete removes an object from the storage
-func (s *GenericStorage) Delete(kind meta.Kind, uid meta.UID) error {
-	storageKey := KeyForUID(kind, uid)
+func (s *GenericStorage) Delete(gvk schema.GroupVersionKind, uid meta.UID) error {
+	storageKey := KeyForUID(gvk, uid)
 	return s.raw.Delete(storageKey)
 }
 
 // List lists objects for the specific kind
-func (s *GenericStorage) List(kind meta.Kind) ([]meta.Object, error) {
-	result := []meta.Object{} // TODO: Fix these initializations
-	err := s.walkKind(kind, func(content []byte) error {
-		// Decode the bytes to the internal version of the object
-		internalobj, err := s.serializer.Decode(content, true)
+func (s *GenericStorage) List(gvk schema.GroupVersionKind) (result []meta.Object, walkerr error) {
+	walkerr = s.walkKind(gvk, func(content []byte) error {
+		isInternal := gvk.Version == runtime.APIVersionInternal
+		obj, err := s.decode(content, isInternal)
 		if err != nil {
 			return err
-		}
-
-		obj, ok := internalobj.(meta.Object)
-		if !ok {
-			return fmt.Errorf("can't convert to ignite object")
 		}
 
 		result = append(result, obj)
 		return nil
 	})
-
-	if err != nil {
-		return nil, err
-	}
-
-	return result, nil
+	return
 }
 
 // ListMeta lists all objects' APIType representation. In other words,
 // only metadata about each object is unmarshalled (uid/name/kind/apiVersion).
 // This allows for faster runs (no need to unmarshal "the world"), and less
 // resource usage, when only metadata is unmarshalled into memory
-func (s *GenericStorage) ListMeta(kind meta.Kind) ([]meta.Object, error) {
-	result := []meta.Object{}
-	err := s.walkKind(kind, func(content []byte) error {
+func (s *GenericStorage) ListMeta(gvk schema.GroupVersionKind) (result []meta.Object, walkerr error) {
+	walkerr = s.walkKind(gvk, func(content []byte) error {
 		obj := meta.NewAPIType()
 		// The yaml package supports both YAML and JSON
 		if err := yaml.Unmarshal(content, obj); err != nil {
 			return err
 		}
+		// Set the desired gvk from the caller of this object
+		// In practice, this means, although we got an external type,
+		// we might want internal objects later in the client. Hence,
+		// set the right expectation here
+		obj.SetGroupVersionKind(gvk)
 
 		result = append(result, obj)
 		return nil
 	})
-
-	if err != nil {
-		return nil, err
-	}
-
-	return result, nil
+	return
 }
 
 // Count counts the objects for the specific kind
-func (s *GenericStorage) Count(kind meta.Kind) (uint64, error) {
-	entries, err := s.raw.List(KeyForKind(kind))
+func (s *GenericStorage) Count(gvk schema.GroupVersionKind) (uint64, error) {
+	entries, err := s.raw.List(KeyForKind(gvk))
 	return uint64(len(entries)), err
 }
 
-func (s *GenericStorage) walkKind(kind meta.Kind, fn func(content []byte) error) error {
-	kindKey := KeyForKind(kind)
+func (s *GenericStorage) decode(content []byte, internal bool) (meta.Object, error) {
+	// Decode the bytes to the internal version of the object
+	obj, err := s.serializer.Decode(content, internal)
+	if err != nil {
+		return nil, err
+	}
+	// Cast to meta.Object, and make sure it works
+	metaObj, ok := obj.(meta.Object)
+	if !ok {
+		return nil, fmt.Errorf("can't convert to ignite object")
+	}
+	return metaObj, nil
+}
+
+func (s *GenericStorage) walkKind(gvk schema.GroupVersionKind, fn func(content []byte) error) error {
+	kindKey := KeyForKind(gvk)
 	entries, err := s.raw.List(kindKey)
 	if err != nil {
 		return err
@@ -194,36 +199,10 @@ func (s *GenericStorage) walkKind(kind meta.Kind, fn func(content []byte) error)
 	return nil
 }
 
-func (s *GenericStorage) keyForObj(obj meta.Object) (string, error) {
-	gvk, err := s.gvkFromObj(obj)
-	if err != nil {
-		return "", err
-	}
-
-	return KeyForUID(meta.Kind(gvk.Kind), obj.GetUID()), nil
+func KeyForUID(gvk schema.GroupVersionKind, uid meta.UID) string {
+	return "/" + path.Join(meta.Kind(gvk.Kind).Lower(), uid.String())
 }
 
-func (s *GenericStorage) gvkFromObj(obj runtime.Object) (*schema.GroupVersionKind, error) {
-	gvks, unversioned, err := s.serializer.Scheme().ObjectKinds(obj.(runtime.Object))
-	if err != nil {
-		return nil, err
-	}
-
-	if unversioned {
-		return nil, fmt.Errorf("unversioned")
-	}
-
-	if len(gvks) != 1 {
-		return nil, fmt.Errorf("unexpected gvks %v", gvks)
-	}
-
-	return &gvks[0], nil
-}
-
-func KeyForUID(kind meta.Kind, uid meta.UID) string {
-	return "/" + path.Join(kind.Lower(), uid.String())
-}
-
-func KeyForKind(kind meta.Kind) string {
-	return "/" + kind.Lower()
+func KeyForKind(gvk schema.GroupVersionKind) string {
+	return "/" + meta.Kind(gvk.Kind).Lower()
 }

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 
 	api "github.com/weaveworks/ignite/pkg/apis/ignite"
-	meta "github.com/weaveworks/ignite/pkg/apis/meta/v1alpha1"
 	"github.com/weaveworks/ignite/pkg/apis/ignite/scheme"
+	meta "github.com/weaveworks/ignite/pkg/apis/meta/v1alpha1"
 )
 
 var s = NewGenericStorage(NewDefaultRawStorage("/tmp/bar"), scheme.Serializer)
@@ -46,6 +46,7 @@ func TestStorageSet(t *testing.T) {
 	err := s.Set(vmGVK, vm)
 	t.Fatal(err)
 }
+
 /*
 func TestStorageDelete(t *testing.T) {
 	err := s.Delete("VM", "1234")

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -3,14 +3,19 @@ package storage
 import (
 	"testing"
 
-	"github.com/weaveworks/ignite/pkg/apis/ignite/scheme"
-
 	api "github.com/weaveworks/ignite/pkg/apis/ignite"
-	meta "github.com/weaveworks/ignite/pkg/apis/meta/v1alpha1"
+	"github.com/weaveworks/ignite/pkg/apis/ignite/scheme"
 )
 
 var s = NewGenericStorage(NewDefaultRawStorage("/tmp/foo"), scheme.Serializer)
 
+func TestStorageNew(t *testing.T) {
+	gvk := api.SchemeGroupVersion.WithKind("VM")
+	obj, err := s.New(gvk)
+	t.Fatal(*(obj.(*api.VM)), err)
+}
+
+/*
 func TestStorageGet(t *testing.T) {
 	obj := &api.VM{
 		ObjectMeta: meta.ObjectMeta{
@@ -74,3 +79,4 @@ func TestStorageListMeta(t *testing.T) {
 
 	t.Fatal("fo")
 }
+*/

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -4,46 +4,49 @@ import (
 	"testing"
 
 	api "github.com/weaveworks/ignite/pkg/apis/ignite"
+	meta "github.com/weaveworks/ignite/pkg/apis/meta/v1alpha1"
 	"github.com/weaveworks/ignite/pkg/apis/ignite/scheme"
 )
 
-var s = NewGenericStorage(NewDefaultRawStorage("/tmp/foo"), scheme.Serializer)
+var s = NewGenericStorage(NewDefaultRawStorage("/tmp/bar"), scheme.Serializer)
+var vmGVK = api.SchemeGroupVersion.WithKind("VM")
 
 func TestStorageNew(t *testing.T) {
-	gvk := api.SchemeGroupVersion.WithKind("VM")
-	obj, err := s.New(gvk)
+	obj, err := s.New(vmGVK)
 	t.Fatal(*(obj.(*api.VM)), err)
 }
 
-/*
 func TestStorageGet(t *testing.T) {
-	obj := &api.VM{
-		ObjectMeta: meta.ObjectMeta{
-			UID: meta.UID("1234"),
-		},
-	}
-
-	err := s.Get(obj)
-	t.Fatal(*obj, err)
+	obj, err := s.Get(vmGVK, meta.UID("0123456789101112"))
+	t.Error(err)
+	t.Error(*(obj.(*api.VM)))
 }
 
 func TestStorageSet(t *testing.T) {
-	err := s.Set(&api.VM{
+	vm := &api.VM{
 		ObjectMeta: meta.ObjectMeta{
 			Name: "foo",
-			UID:  meta.UID("1234"),
+			UID:  meta.UID("0123456789101112"),
 		},
 		Spec: api.VMSpec{
 			CPUs:   2,
 			Memory: meta.NewSizeFromBytes(4 * 1024 * 1024),
+			Image: api.VMImageSpec{
+				OCIClaim: api.OCIImageClaim{
+					Ref: meta.OCIImageRef("centos:7"),
+				},
+			},
+			Kernel: api.VMKernelSpec{
+				OCIClaim: api.OCIImageClaim{
+					Ref: meta.OCIImageRef("ubuntu:18.04"),
+				},
+			},
 		},
-	})
-
-	if err != nil {
-		t.Fatal(err)
 	}
+	err := s.Set(vmGVK, vm)
+	t.Fatal(err)
 }
-
+/*
 func TestStorageDelete(t *testing.T) {
 	err := s.Delete("VM", "1234")
 	t.Fatal("foo", err)


### PR DESCRIPTION
Before this, the client and storage framework was locked in to only one particular combination of `apiVersion`, or in other words, `GroupVersion`. We only checked `meta.Kind` everywhere; but that always implicitly assumed that the GroupVersion was ignite/v1alpha1

Fixes: #199 

This PR:
 - Makes the `Storage` (`Cache`), and `Filterer` interfaces operate on `schema.GroupVersionKind`, not `meta.Kind`
 - Automatically sets the desired GVK when decoding or creating an object, so the hacky defaulting functions we had are now obsolete
 - Extracts ignite-related stuff from the `Client` struct to a gv-specific `IgniteInternalClient`, and passes through the GVK automatically to the storage as a consequence.
 - Adds a `Client.New` -> `Storage.New` method being the canonical way to create a new API object. In other words, do not do `&api.VM{}` or similar anymore.
 - Adapts the rest of the application to this new code flow

