### PR TITLE
Add `AttachContainer` to the runtime interface

### DIFF
--- a/cmd/ignite/run/attach.go
+++ b/cmd/ignite/run/attach.go
@@ -2,6 +2,7 @@ package run
 
 import (
 	"fmt"
+
 	"github.com/weaveworks/ignite/pkg/metadata/vmmd"
 	"github.com/weaveworks/ignite/pkg/providers"
 	"github.com/weaveworks/ignite/pkg/util"

--- a/cmd/ignite/run/attach.go
+++ b/cmd/ignite/run/attach.go
@@ -2,9 +2,8 @@ package run
 
 import (
 	"fmt"
-
-	"github.com/weaveworks/ignite/pkg/constants"
 	"github.com/weaveworks/ignite/pkg/metadata/vmmd"
+	"github.com/weaveworks/ignite/pkg/providers"
 	"github.com/weaveworks/ignite/pkg/util"
 )
 
@@ -30,18 +29,9 @@ func Attach(ao *attachOptions) error {
 	// Print the ID before attaching
 	fmt.Println(ao.vm.GetUID())
 
-	dockerArgs := []string{
-		"attach",
-		constants.IGNITE_PREFIX + ao.vm.GetUID().String(),
-	}
-
 	// Attach to the VM in Docker
-	// TODO: Implement the pseudo-TTY and remove this call, see
-	// https://github.com/weaveworks/ignite/pull/211#issuecomment-512809841
-	if ec, err := util.ExecForeground("docker", dockerArgs...); err != nil {
-		if ec != 1 { // Docker's detach sequence (^P^Q) has an exit code of -1
-			return fmt.Errorf("failed to attach to container for VM %s: %v", ao.vm.GetUID(), err)
-		}
+	if err := providers.Runtime.AttachContainer(util.NewPrefixer().Prefix(ao.vm.GetUID())); err != nil {
+		return fmt.Errorf("failed to attach to container for VM %s: %v", ao.vm.GetUID(), err)
 	}
 
 	return nil

--- a/pkg/runtime/docker/client.go
+++ b/pkg/runtime/docker/client.go
@@ -3,6 +3,7 @@ package docker
 import (
 	"context"
 	"fmt"
+	"github.com/weaveworks/ignite/pkg/util"
 	"io"
 	"time"
 
@@ -70,6 +71,21 @@ func (dc *dockerClient) ExportImage(image string) (io.ReadCloser, string, error)
 
 	rc, err := dc.client.ContainerExport(context.Background(), config.ID)
 	return rc, config.ID, err
+}
+
+func (dc *dockerClient) AttachContainer(container string) (err error) {
+	// TODO: Rework to perform the attach via the Docker client,
+	// this will require manual TTY and signal emulation/handling.
+	// Implement the pseudo-TTY and remove this call, see
+	// https://github.com/weaveworks/ignite/pull/211#issuecomment-512809841
+	var ec int
+	if ec, err = util.ExecForeground("docker", "attach", container); err != nil {
+		if ec == 1 { // Docker's detach sequence (^P^Q) has an exit code of -1
+			err = nil // Don't treat it as an error
+		}
+	}
+
+	return
 }
 
 func (dc *dockerClient) RunContainer(image string, config *runtime.ContainerConfig, name string) (string, error) {

--- a/pkg/runtime/docker/client.go
+++ b/pkg/runtime/docker/client.go
@@ -3,7 +3,6 @@ package docker
 import (
 	"context"
 	"fmt"
-	"github.com/weaveworks/ignite/pkg/util"
 	"io"
 	"time"
 
@@ -12,6 +11,7 @@ import (
 	"github.com/docker/docker/client"
 	"github.com/docker/go-connections/nat"
 	"github.com/weaveworks/ignite/pkg/runtime"
+	"github.com/weaveworks/ignite/pkg/util"
 )
 
 const (

--- a/pkg/runtime/types.go
+++ b/pkg/runtime/types.go
@@ -36,7 +36,7 @@ type Interface interface {
 	PullImage(image string) (io.ReadCloser, error)
 	ExportImage(image string) (io.ReadCloser, string, error)
 
-	// TODO: AttachContainer
+	AttachContainer(container string) error
 	RunContainer(image string, config *ContainerConfig, name string) (string, error)
 	StopContainer(container string, timeout *time.Duration) error
 	KillContainer(container, signal string) error


### PR DESCRIPTION
This removes the final direct call to `docker` outside of the runtime, for now this just moves the `attach` call into the `dockerClient`, a native implementation is TODO.