### PR TITLE
gofmt after generating code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,9 +44,9 @@ endif
 tidy: $(API_DOCS)
 	go mod tidy
 	go mod vendor
+	hack/generate-client.sh
 	gofmt -s -w pkg cmd
 	goimports -w pkg cmd
-	hack/generate-client.sh
 	go run hack/cobra.go
 
 graph:


### PR DESCRIPTION
generating code before `gofmt` causes `make tidy` to create spurious diffs with leading blank lines in generated code. moving `gofmt` to run after generating code avoids this.
