### PR TITLE
Improve vulnerability scanning of Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,6 @@ RUN apk add --no-cache \
     iproute2 \
     device-mapper
 
-# Remove unused files
-RUN rm -r /lib/apk /etc/apk
-
 # Download the Firecracker binary from Github
 ARG FIRECRACKER_VERSION
 RUN wget -q -O /usr/local/bin/firecracker https://github.com/firecracker-microvm/firecracker/releases/download/${FIRECRACKER_VERSION}/firecracker-${FIRECRACKER_VERSION}


### PR DESCRIPTION
Currently, the Alpine package list will be removed. This "optimization" saves less then 100 kBytes,
but without the package database file `/lib/apk/db/installed` it gets really harder to scan
this Docker Image for software vulnerabilities.

Therefore I'd like to strongly propose to remove this "optimization" step and keep the Alpine
package database file.

Signed-off-by: Dieter Reuter <dieter.reuter@me.com>