### PR TITLE
Fix image root permissions

### DIFF
--- a/pkg/dmlegacy/vm.go
+++ b/pkg/dmlegacy/vm.go
@@ -141,6 +141,11 @@ func copyToOverlay(vm *api.VM) error {
 		return err
 	}
 
+	// Set overlay root permissions
+	if err := os.Chmod(mp.Path, constants.DATA_DIR_PERM); err != nil {
+		return err
+	}
+
 	// TODO: This code seems to be flaky and not always copy over the files?
 	time.Sleep(500 * time.Millisecond)
 	return nil


### PR DESCRIPTION
The copyKernelToOverlay function will overwrite the overlay directory permissions, causing VMs to be booted with too strict permissions on the root directory (0700 instead of 0755).

Example kernel tarball, note the permissions that get 'extracted' to the overlay root:
```
> tar tvf /var/lib/firecracker/kernel/6bcef83ba671d8c1/kernel.tar | head -n10
drwx------ root/root         0 2019-07-26 13:00 ./
drwxr-xr-x root/root         0 2019-07-16 21:05 ./boot/
-rw-r--r-- root/root     81286 2019-07-16 21:05 ./boot/config-4.19.47
-rwxr-xr-x root/root  23775472 2019-07-16 21:05 ./boot/vmlinux-4.19.47
lrwxrwxrwx root/root         0 2019-07-16 21:05 ./boot/vmlinux -> /boot/vmlinux-4.19.47
```

Fixes #240