### PR TITLE
ignited improvements

### DIFF
--- a/cmd/ignited/cmd/daemon.go
+++ b/cmd/ignited/cmd/daemon.go
@@ -28,7 +28,7 @@ func NewCmdDaemon(out io.Writer) *cobra.Command {
 			ms := manifeststorage.ManifestStorage
 
 			go func() {
-				log.Infof("starting reconciliation loop")
+				log.Infof("Starting reconciliation loop...")
 				reconcile.ReconcileManifests(ms)
 			}()
 

--- a/cmd/ignited/cmd/gitops.go
+++ b/cmd/ignited/cmd/gitops.go
@@ -35,7 +35,7 @@ func NewCmdGitOps(out io.Writer) *cobra.Command {
 		`),
 		Args: cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			util.GenericCheckErr(gitops.RunLoop(args[0], f.branch, f.paths))
+			util.GenericCheckErr(gitops.RunGitOps(args[0], f.branch, f.paths))
 		},
 	}
 

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -37,6 +37,9 @@ const (
 	// In-container file name for the firecracker metrics FIFO
 	METRICS_FIFO = "firecracker_metrics.fifo"
 
+	// Socket with a web server (with metrics for now) for the daemon
+	DAEMON_SOCKET = "daemon.sock"
+
 	// How many characters Ignite UIDs should have
 	IGNITE_UID_LENGTH = 16
 )

--- a/pkg/gitops/gitdir/gitdir.go
+++ b/pkg/gitops/gitdir/gitdir.go
@@ -221,3 +221,14 @@ func (d *GitDirectory) Ready() bool {
 	log.Tracef("git directory ready: %t", r)
 	return r
 }
+
+func (d *GitDirectory) WaitForClone() {
+	for {
+		// Check if the Git repo is ready and cloned, otherwise wait
+		if d.Ready() {
+			break
+		}
+
+		time.Sleep(d.syncInterval / 2)
+	}
+}

--- a/pkg/gitops/gitops.go
+++ b/pkg/gitops/gitops.go
@@ -1,210 +1,33 @@
 package gitops
 
 import (
-	"fmt"
 	"time"
 
 	log "github.com/sirupsen/logrus"
-	api "github.com/weaveworks/ignite/pkg/apis/ignite"
-	"github.com/weaveworks/ignite/pkg/apis/ignite/validation"
-	"github.com/weaveworks/ignite/pkg/client"
-	"github.com/weaveworks/ignite/pkg/dmlegacy"
 	"github.com/weaveworks/ignite/pkg/gitops/gitdir"
-	"github.com/weaveworks/ignite/pkg/operations"
-	"github.com/weaveworks/ignite/pkg/storage/cache"
+	"github.com/weaveworks/ignite/pkg/operations/reconcile"
 	"github.com/weaveworks/ignite/pkg/storage/manifest"
-	"github.com/weaveworks/ignite/pkg/util"
-	"github.com/weaveworks/ignite/pkg/util/watcher"
 )
 
-var (
-	c            *client.Client
-	gitDir       *gitdir.GitDirectory
-	syncInterval = 10 * time.Second
-)
+const syncInterval = 10 * time.Second
 
-func RunLoop(url, branch string, paths []string) error {
+func RunGitOps(url, branch string, paths []string) error {
 	log.Infof("Starting GitOps loop for repo at %q\n", url)
 	log.Infof("Whenever changes are pushed to the %s branch, Ignite will apply the desired state locally\n", branch)
 
 	// Construct the GitDirectory implementation which backs the storage
-	gitDir = gitdir.NewGitDirectory(url, branch, paths, syncInterval)
+	gitDir := gitdir.NewGitDirectory(url, branch, paths, syncInterval)
 
 	// Wait for the repo to be cloned
-	for {
-		// Check if the Git repo is ready and cloned, otherwise wait
-		if gitDir.Ready() {
-			break
-		}
-
-		time.Sleep(syncInterval / 2)
-	}
+	gitDir.WaitForClone()
 
 	// Construct a manifest storage for the path backed by git
 	s, err := manifest.NewManifestStorage(gitDir.Dir())
 	if err != nil {
 		return err
 	}
-	// Wrap the Manifest Storage with a cache for better performance, and create a client
-	c = client.NewClient(cache.NewCache(s))
 
-	// These updates are coming from the SyncStorage
-	for upd := range s.GetUpdateStream() {
-
-		// Only care about VMs
-		if upd.APIType.GetKind() != api.KindVM {
-			log.Tracef("GitOps: Ignoring kind %s", upd.APIType.GetKind())
-			continue
-		}
-
-		var vm *api.VM
-		if upd.Event == watcher.EventDelete {
-			// As we know this VM was deleted, it wouldn't show up in a Get() call
-			// Construct a temporary VM object for passing to the delete function
-			vm = &api.VM{
-				TypeMeta:   *upd.APIType.GetTypeMeta(),
-				ObjectMeta: *upd.APIType.GetObjectMeta(),
-				Status: api.VMStatus{
-					State: api.VMStateStopped,
-				},
-			}
-		} else {
-			// Get the real API object
-			vm, err = c.VMs().Get(upd.APIType.GetUID())
-			if err != nil {
-				log.Errorf("Getting VM %q returned an error: %v", upd.APIType.GetUID(), err)
-				continue
-			}
-
-			// If the object was existent in the storage; validate it
-			// Validate the VM object
-			if err := validation.ValidateVM(vm).ToAggregate(); err != nil {
-				log.Warn("Skipping %s of %s with UID %s, VM not valid %v.", upd.Event, upd.APIType.GetKind(), upd.APIType.GetUID(), err)
-				continue
-			}
-		}
-
-		// TODO: Paralellization
-		switch upd.Event {
-		case watcher.EventCreate:
-			runHandle(func() error {
-				return handleCreate(vm)
-			})
-		case watcher.EventModify:
-			runHandle(func() error {
-				return handleChange(vm)
-			})
-		case watcher.EventDelete:
-			runHandle(func() error {
-				// TODO: Temporary VM Object for removal
-				return handleDelete(vm)
-			})
-		default:
-			log.Infof("Unrecognized Git update type %s\n", upd.Event)
-			continue
-		}
-	}
+	// TODO: Make the reconcile function signal-aware
+	reconcile.ReconcileManifests(s)
 	return nil
-}
-
-// TODO: Maybe paralellize these commands?
-func runHandle(fn func() error) {
-	if err := fn(); err != nil {
-		log.Errorf("An error occurred when processing a VM update: %v\n", err)
-	}
-}
-
-func handleCreate(vm *api.VM) error {
-	var err error
-
-	switch vm.Status.State {
-	case api.VMStateCreated:
-		err = create(vm)
-	case api.VMStateRunning:
-		err = start(vm)
-	case api.VMStateStopped:
-		log.Infof("VM %q was added to git with status Stopped, nothing to do\n", vm.GetUID())
-	default:
-		log.Infof("Unknown state of VM %q: %s", vm.GetUID().String(), vm.Status.State)
-	}
-
-	return err
-}
-
-func handleChange(vm *api.VM) error {
-	var err error
-
-	switch vm.Status.State {
-	case api.VMStateCreated:
-		err = fmt.Errorf("VM %q cannot changed into the Created state", vm.GetUID())
-	case api.VMStateRunning:
-		err = start(vm)
-	case api.VMStateStopped:
-		err = stop(vm)
-	default:
-		log.Infof("Unknown state of VM %q: %s", vm.GetUID().String(), vm.Status.State)
-	}
-
-	return err
-}
-
-func handleDelete(vm *api.VM) error {
-	return remove(vm)
-}
-
-// TODO: Unify this with the "real" Create() method currently in cmd/
-func create(vm *api.VM) error {
-	log.Infof("Creating VM %q with name %q...", vm.GetUID(), vm.GetName())
-	if err := ensureOCIImages(vm); err != nil {
-		return err
-	}
-
-	// Allocate and populate the overlay file
-	return dmlegacy.AllocateAndPopulateOverlay(vm)
-}
-
-// ensureOCIImages imports the base/kernel OCI images if needed
-func ensureOCIImages(vm *api.VM) error {
-	// Check if a image with this name already exists, or import it
-	image, err := operations.FindOrImportImage(c, vm.Spec.Image.OCIClaim.Ref)
-	if err != nil {
-		return err
-	}
-
-	// Populate relevant data from the Image on the VM object
-	vm.SetImage(image)
-
-	// Check if a kernel with this name already exists, or import it
-	kernel, err := operations.FindOrImportKernel(c, vm.Spec.Kernel.OCIClaim.Ref)
-	if err != nil {
-		return err
-	}
-
-	// Populate relevant data from the Kernel on the VM object
-	vm.SetKernel(kernel)
-
-	// Save the file to disk. This will also write the file to /var/lib/firecracker for compability
-	return c.VMs().Set(vm)
-}
-
-func start(vm *api.VM) error {
-	// create the overlay if it doesn't exist
-	if !util.FileExists(vm.OverlayFile()) {
-		if err := create(vm); err != nil {
-			return err
-		}
-	}
-
-	log.Infof("Starting VM %q with name %q...", vm.GetUID(), vm.GetName())
-	return operations.StartVM(vm, true)
-}
-
-func stop(vm *api.VM) error {
-	log.Infof("Stopping VM %q with name %q...", vm.GetUID(), vm.GetName())
-	return operations.StopVM(vm, true, false)
-}
-
-func remove(vm *api.VM) error {
-	log.Infof("Removing VM %q with name %q...", vm.GetUID(), vm.GetName())
-	return operations.RemoveVM(c, vm)
 }

--- a/pkg/operations/reconcile/metrics.go
+++ b/pkg/operations/reconcile/metrics.go
@@ -1,0 +1,20 @@
+package reconcile
+
+import (
+	"path"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/weaveworks/ignite/pkg/constants"
+	"github.com/weaveworks/ignite/pkg/prometheus"
+)
+
+func startMetricsThread() {
+	_, server := prometheus.New()
+	go func() {
+		// create a new registry and http.Server. don't register custom metrics to the registry quite yet
+		metricsSocket := path.Join(constants.DATA_DIR, constants.DAEMON_SOCKET)
+		if err := prometheus.ServeOnSocket(server, metricsSocket); err != nil {
+			log.Errorf("prometheus server was stopped with error: %v", err)
+		}
+	}()
+}

--- a/pkg/operations/reconcile/reconcile.go
+++ b/pkg/operations/reconcile/reconcile.go
@@ -1,0 +1,186 @@
+package reconcile
+
+import (
+	"fmt"
+
+	log "github.com/sirupsen/logrus"
+	api "github.com/weaveworks/ignite/pkg/apis/ignite"
+	"github.com/weaveworks/ignite/pkg/apis/ignite/validation"
+	"github.com/weaveworks/ignite/pkg/client"
+	"github.com/weaveworks/ignite/pkg/dmlegacy"
+	"github.com/weaveworks/ignite/pkg/operations"
+	"github.com/weaveworks/ignite/pkg/storage/cache"
+	"github.com/weaveworks/ignite/pkg/storage/manifest"
+	"github.com/weaveworks/ignite/pkg/util"
+	"github.com/weaveworks/ignite/pkg/util/watcher"
+)
+
+var c *client.Client
+
+func ReconcileManifests(s *manifest.ManifestStorage) {
+
+	startMetricsThread()
+
+	// Wrap the Manifest Storage with a cache for better performance, and create a client
+	c = client.NewClient(cache.NewCache(s))
+
+	// These updates are coming from the SyncStorage
+	for upd := range s.GetUpdateStream() {
+
+		// Only care about VMs
+		if upd.APIType.GetKind() != api.KindVM {
+			log.Tracef("GitOps: Ignoring kind %s", upd.APIType.GetKind())
+			continue
+		}
+
+		var vm *api.VM
+		var err error
+		if upd.Event == watcher.EventDelete {
+			// As we know this VM was deleted, it wouldn't show up in a Get() call
+			// Construct a temporary VM object for passing to the delete function
+			vm = &api.VM{
+				TypeMeta:   *upd.APIType.GetTypeMeta(),
+				ObjectMeta: *upd.APIType.GetObjectMeta(),
+				Status: api.VMStatus{
+					State: api.VMStateStopped,
+				},
+			}
+		} else {
+			// Get the real API object
+			vm, err = c.VMs().Get(upd.APIType.GetUID())
+			if err != nil {
+				log.Errorf("Getting VM %q returned an error: %v", upd.APIType.GetUID(), err)
+				continue
+			}
+
+			// If the object was existent in the storage; validate it
+			// Validate the VM object
+			if err := validation.ValidateVM(vm).ToAggregate(); err != nil {
+				log.Warn("Skipping %s of %s with UID %s, VM not valid %v.", upd.Event, upd.APIType.GetKind(), upd.APIType.GetUID(), err)
+				continue
+			}
+		}
+
+		// TODO: Paralellization
+		switch upd.Event {
+		case watcher.EventCreate:
+			runHandle(func() error {
+				return handleCreate(vm)
+			})
+		case watcher.EventModify:
+			runHandle(func() error {
+				return handleChange(vm)
+			})
+		case watcher.EventDelete:
+			runHandle(func() error {
+				// TODO: Temporary VM Object for removal
+				return handleDelete(vm)
+			})
+		default:
+			log.Infof("Unrecognized Git update type %s\n", upd.Event)
+			continue
+		}
+	}
+}
+
+// TODO: Maybe paralellize these commands?
+func runHandle(fn func() error) {
+	if err := fn(); err != nil {
+		log.Errorf("An error occurred when processing a VM update: %v\n", err)
+	}
+}
+
+func handleCreate(vm *api.VM) error {
+	var err error
+
+	switch vm.Status.State {
+	case api.VMStateCreated:
+		err = create(vm)
+	case api.VMStateRunning:
+		err = start(vm)
+	case api.VMStateStopped:
+		log.Infof("VM %q was added to git with status Stopped, nothing to do\n", vm.GetUID())
+	default:
+		log.Infof("Unknown state of VM %q: %s", vm.GetUID().String(), vm.Status.State)
+	}
+
+	return err
+}
+
+func handleChange(vm *api.VM) error {
+	var err error
+
+	switch vm.Status.State {
+	case api.VMStateCreated:
+		err = fmt.Errorf("VM %q cannot changed into the Created state", vm.GetUID())
+	case api.VMStateRunning:
+		err = start(vm)
+	case api.VMStateStopped:
+		err = stop(vm)
+	default:
+		log.Infof("Unknown state of VM %q: %s", vm.GetUID().String(), vm.Status.State)
+	}
+
+	return err
+}
+
+func handleDelete(vm *api.VM) error {
+	return remove(vm)
+}
+
+// TODO: Unify this with the "real" Create() method currently in cmd/
+func create(vm *api.VM) error {
+	log.Infof("Creating VM %q with name %q...", vm.GetUID(), vm.GetName())
+	if err := ensureOCIImages(vm); err != nil {
+		return err
+	}
+
+	// Allocate and populate the overlay file
+	return dmlegacy.AllocateAndPopulateOverlay(vm)
+}
+
+// ensureOCIImages imports the base/kernel OCI images if needed
+func ensureOCIImages(vm *api.VM) error {
+	// Check if a image with this name already exists, or import it
+	image, err := operations.FindOrImportImage(c, vm.Spec.Image.OCIClaim.Ref)
+	if err != nil {
+		return err
+	}
+
+	// Populate relevant data from the Image on the VM object
+	vm.SetImage(image)
+
+	// Check if a kernel with this name already exists, or import it
+	kernel, err := operations.FindOrImportKernel(c, vm.Spec.Kernel.OCIClaim.Ref)
+	if err != nil {
+		return err
+	}
+
+	// Populate relevant data from the Kernel on the VM object
+	vm.SetKernel(kernel)
+
+	// Save the file to disk. This will also write the file to /var/lib/firecracker for compability
+	return c.VMs().Set(vm)
+}
+
+func start(vm *api.VM) error {
+	// create the overlay if it doesn't exist
+	if !util.FileExists(vm.OverlayFile()) {
+		if err := create(vm); err != nil {
+			return err
+		}
+	}
+
+	log.Infof("Starting VM %q with name %q...", vm.GetUID(), vm.GetName())
+	return operations.StartVM(vm, true)
+}
+
+func stop(vm *api.VM) error {
+	log.Infof("Stopping VM %q with name %q...", vm.GetUID(), vm.GetName())
+	return operations.StopVM(vm, true, false)
+}
+
+func remove(vm *api.VM) error {
+	log.Infof("Removing VM %q with name %q...", vm.GetUID(), vm.GetName())
+	return operations.RemoveVM(c, vm)
+}

--- a/pkg/operations/reconcile/reconcile.go
+++ b/pkg/operations/reconcile/reconcile.go
@@ -18,7 +18,6 @@ import (
 var c *client.Client
 
 func ReconcileManifests(s *manifest.ManifestStorage) {
-
 	startMetricsThread()
 
 	// Wrap the Manifest Storage with a cache for better performance, and create a client

--- a/pkg/providers/manifeststorage/storage.go
+++ b/pkg/providers/manifeststorage/storage.go
@@ -8,12 +8,14 @@ import (
 	"github.com/weaveworks/ignite/pkg/storage/manifest"
 )
 
-func SetManifestStorage() error {
+var ManifestStorage *manifest.ManifestStorage
+
+func SetManifestStorage() (err error) {
 	log.Trace("Initializing the ManifestStorage provider...")
-	ms, err := manifest.NewManifestStorage(constants.MANIFEST_DIR)
+	ManifestStorage, err = manifest.NewManifestStorage(constants.MANIFEST_DIR)
 	if err != nil {
-		return err
+		return
 	}
-	providers.Storage = cache.NewCache(ms)
-	return nil
+	providers.Storage = cache.NewCache(ManifestStorage)
+	return
 }


### PR DESCRIPTION
 - Factor out the generic reconciliation logic from GitOps
 - Make `ignited daemon` actually usable; reuse the same code from the gitops mode
 - Add prometheus metrics to the daemon