### PR TITLE
Clean up ignite-spawn networking, don't depend on `errors` package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,8 @@ FROM BASEIMAGE AS build
 # If we're building normally, for amd64, this line is removed
 COPY qemu-QEMUARCH-static /usr/bin/
 
-# Install iproute2 for access to the "ip" command. In the future this dependency will be removed
-# device-mapper is needed for the snapshot functionalities
+# device-mapper is needed for snapshot functionalities
 RUN apk add --no-cache \
-    iproute2 \
     device-mapper
 
 # Download the Firecracker binary from Github

--- a/pkg/container/dhcp.go
+++ b/pkg/container/dhcp.go
@@ -3,7 +3,6 @@ package container
 import (
 	"fmt"
 	"net"
-	"os"
 	"time"
 
 	dhcp "github.com/krolaw/dhcp4"
@@ -48,9 +47,9 @@ func StartDHCPServers(vm *api.VM, dhcpIfaces []DHCPInterface) ([]net.IP, error) 
 		ipAddrs = append(ipAddrs, dhcpIface.VMIPNet.IP)
 
 		go func() {
-			log.Infof("Starting DHCP server for interface %s (%s)\n", dhcpIface.Bridge, dhcpIface.VMIPNet.IP)
+			log.Infof("Starting DHCP server for interface %q (%s)\n", dhcpIface.Bridge, dhcpIface.VMIPNet.IP)
 			if err := dhcpIface.StartBlockingServer(); err != nil {
-				fmt.Fprintf(os.Stderr, "%s DHCP server error: %v\n", dhcpIface.Bridge, err)
+				log.Errorf("%q DHCP server error: %v\n", dhcpIface.Bridge, err)
 			}
 		}()
 	}


### PR DESCRIPTION
This extends @alexeldeib's amazing work in https://github.com/weaveworks/ignite/pull/279.
I noticed we still depend on the `errors` package and have a potential nil indexing in `ignite-spawn`'s networking, so went ahead and cleaned up a little.

cc @luxas 