### PR TITLE
Two-way SyncStorage support for ManifestStorage

### DIFF
--- a/pkg/apis/meta/v1alpha1/meta.go
+++ b/pkg/apis/meta/v1alpha1/meta.go
@@ -91,6 +91,18 @@ func (k Kind) Lower() string {
 	return string(bytes.ToLower([]byte(k)))
 }
 
+// Returns a Kind parsed from the given string
+func ParseKind(input string) Kind {
+	b := bytes.ToUpper([]byte(input))
+
+	// Leave TLAs as uppercase
+	if len(b) > 3 {
+		b = append(b[:1], bytes.ToLower(b[1:])...)
+	}
+
+	return Kind(b)
+}
+
 // ObjectMeta have to be embedded into any serializable object.
 // It provides the .GetName() and .GetUID() methods that help
 // implement the Object interface

--- a/pkg/storage/key.go
+++ b/pkg/storage/key.go
@@ -1,7 +1,6 @@
 package storage
 
 import (
-	"bytes"
 	"fmt"
 	"os"
 	"path"
@@ -46,7 +45,7 @@ func ParseKey(input string) (k Key, err error) {
 	if len(splitInput) != 2 {
 		err = fmt.Errorf("invalid input for key parsing: %s", input)
 	} else {
-		k.Kind = parseKind(splitInput[0])
+		k.Kind = meta.ParseKind(splitInput[0])
 		k.UID = meta.UID(splitInput[1])
 	}
 
@@ -66,16 +65,4 @@ func (k Key) String() string {
 // ToKindKey creates a KindKey out of a Key
 func (k Key) ToKindKey() KindKey {
 	return k.KindKey
-}
-
-// TODO: Move to meta
-func parseKind(input string) meta.Kind {
-	b := bytes.ToUpper([]byte(input))
-
-	// Leave TLAs as uppercase
-	if len(b) > 3 {
-		b = append(b[:1], bytes.ToLower(b[1:])...)
-	}
-
-	return meta.Kind(b)
 }

--- a/pkg/storage/key.go
+++ b/pkg/storage/key.go
@@ -1,8 +1,12 @@
 package storage
 
 import (
+	"bytes"
 	"fmt"
+	"os"
 	"path"
+	"path/filepath"
+	"strings"
 
 	meta "github.com/weaveworks/ignite/pkg/apis/meta/v1alpha1"
 )
@@ -36,6 +40,19 @@ func NewKey(kind meta.Kind, uid meta.UID) Key {
 	}
 }
 
+// ParseKey parses the given string and returns a Key
+func ParseKey(input string) (k Key, err error) {
+	splitInput := strings.Split(filepath.Clean(input), string(os.PathSeparator))
+	if len(splitInput) != 2 {
+		err = fmt.Errorf("invalid input for key parsing: %s", input)
+	} else {
+		k.Kind = parseKind(splitInput[0])
+		k.UID = meta.UID(splitInput[1])
+	}
+
+	return
+}
+
 // String returns the virtual path for the Kind
 func (k KindKey) String() string {
 	return k.Lower()
@@ -49,4 +66,16 @@ func (k Key) String() string {
 // ToKindKey creates a KindKey out of a Key
 func (k Key) ToKindKey() KindKey {
 	return k.KindKey
+}
+
+// TODO: Move to meta
+func parseKind(input string) meta.Kind {
+	b := bytes.ToUpper([]byte(input))
+
+	// Leave TLAs as uppercase
+	if len(b) > 3 {
+		b = append(b[:1], bytes.ToLower(b[1:])...)
+	}
+
+	return meta.Kind(b)
 }

--- a/pkg/storage/manifest/storage.go
+++ b/pkg/storage/manifest/storage.go
@@ -14,10 +14,12 @@ func NewManifestStorage(dataDir string) (*ManifestStorage, error) {
 		return nil, err
 	}
 
-	ss := sync.NewSyncStorage(
-		storage.NewGenericStorage(
-			storage.NewDefaultRawStorage(constants.DATA_DIR), scheme.Serializer),
-		ws)
+	ws2, err := watch.NewGenericWatchStorage(storage.NewGenericStorage(storage.NewDefaultRawStorage(constants.DATA_DIR), scheme.Serializer))
+	if err != nil {
+		return nil, err
+	}
+
+	ss := sync.NewSyncStorage(ws2, ws)
 
 	return &ManifestStorage{
 		Storage: ss,

--- a/pkg/storage/rawstorage.go
+++ b/pkg/storage/rawstorage.go
@@ -5,7 +5,9 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"path/filepath"
 	"strconv"
+	"strings"
 
 	meta "github.com/weaveworks/ignite/pkg/apis/meta/v1alpha1"
 	"github.com/weaveworks/ignite/pkg/constants"
@@ -28,6 +30,9 @@ func NewDefaultRawStorage(dir string) RawStorage {
 		dir: dir,
 	}
 }
+
+// TODO: This is a test: Make DefaultRawStorage MappedRawStorage compliant
+var _ MappedRawStorage = &DefaultRawStorage{}
 
 type DefaultRawStorage struct {
 	dir string
@@ -109,3 +114,26 @@ func (r *DefaultRawStorage) Format(key Key) Format {
 func (r *DefaultRawStorage) Dir() string {
 	return r.dir
 }
+
+func (r *DefaultRawStorage) AddMapping(key Key, path string) {} // Stub
+
+func (r *DefaultRawStorage) GetMapping(p string) (key Key, err error) {
+	splitDir := strings.Split(filepath.Clean(r.dir), string(os.PathSeparator))
+	splitPath := strings.Split(filepath.Clean(p), string(os.PathSeparator))
+
+	if len(splitPath) < len(splitDir)+2 {
+		err = fmt.Errorf("path not long enough: %s", p)
+		return
+	}
+
+	for i := 0; i < len(splitDir); i++ {
+		if splitDir[i] != splitPath[i] {
+			err = fmt.Errorf("path has wrong base: %s", p)
+			return
+		}
+	}
+
+	return ParseKey(path.Join(splitPath[len(splitDir)], splitPath[len(splitDir)+1]))
+}
+
+func (r *DefaultRawStorage) RemoveMapping(key Key) {} // Stub

--- a/pkg/storage/rawstorage.go
+++ b/pkg/storage/rawstorage.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 
+	api "github.com/weaveworks/ignite/pkg/apis/ignite"
 	meta "github.com/weaveworks/ignite/pkg/apis/meta/v1alpha1"
 	"github.com/weaveworks/ignite/pkg/constants"
 	"github.com/weaveworks/ignite/pkg/util"
@@ -111,8 +112,9 @@ func (r *DefaultRawStorage) Format(key Key) Format {
 	return FormatJSON // The DefaultRawStorage always uses JSON
 }
 
+// This is for watchers, direct them to only the VM directory
 func (r *DefaultRawStorage) Dir() string {
-	return r.dir
+	return path.Join(r.dir, NewKindKey(api.KindVM).String())
 }
 
 func (r *DefaultRawStorage) AddMapping(key Key, path string) {} // Stub

--- a/pkg/storage/sync/storage.go
+++ b/pkg/storage/sync/storage.go
@@ -139,6 +139,7 @@ func (ss *SyncStorage) monitorFunc() {
 	// For now, only update the state on write when Ignite is running
 	for {
 		upd, ok := <-ss.eventStream
+		// TODO: ignite-spawn's updates also fire events
 		log.Debugf("SyncStorage: Received update %v %t", upd, ok)
 		if ok {
 			switch upd.Event {


### PR DESCRIPTION
This enables changes to propagate both ways between `/var/lib/firecracker` and `/etc/firecracker/manifests` :tada:

There are a couple of issues that need to be fixed for reliability:
- [ ] `ignite-spawn` IP updates cause events, which for some reason makes Ignite attempt VM startup again
- [ ] Deletion is also performed twice, we probably should limit object updates to one Storage

cc @luxas 