### PR TITLE
Runtime state set by Ignite (StartVM), ignite-spawn only handles shutdown

### DIFF
--- a/cmd/ignite-spawn/ignite-spawn.go
+++ b/cmd/ignite-spawn/ignite-spawn.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"net"
 	"os"
 	"path"
 
@@ -28,11 +27,13 @@ func decodeVM(vmID string) (*api.VM, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	vm, ok := obj.(*api.VM)
 	if !ok {
 		return nil, fmt.Errorf("object couldn't be converted to VM")
 	}
-	// Explicitely set the GVK on this object
+
+	// Explicitly set the GVK on this object
 	vm.SetGroupVersionKind(api.SchemeGroupVersion.WithKind(api.KindVM.Title()))
 	return vm, nil
 }
@@ -47,7 +48,7 @@ func StartVM(vm *api.VM) error {
 	// Serve DHCP requests for those interfaces
 	// This function returns the available IP addresses that are being
 	// served over DHCP now
-	ipAddrs, err := container.StartDHCPServers(vm, dhcpIfaces)
+	_, err = container.StartDHCPServers(vm, dhcpIfaces)
 	if err != nil {
 		return err
 	}
@@ -55,11 +56,6 @@ func StartVM(vm *api.VM) error {
 	// Serve metrics over an unix socket in the VM's own directory
 	metricsSocket := path.Join(vm.ObjectPath(), constants.PROMETHEUS_SOCKET)
 	serveMetrics(metricsSocket)
-
-	// Update the VM status and IP address information
-	if err := patchRunning(vm, ipAddrs); err != nil {
-		return fmt.Errorf("failed to patch VM state: %v", err)
-	}
 
 	// Patches the VM object to set state to stopped, and clear IP addresses
 	defer patchStopped(vm)
@@ -80,20 +76,12 @@ func StartVM(vm *api.VM) error {
 
 func serveMetrics(metricsSocket string) {
 	go func() {
-		// create a new registry and http.Server. don't register custom metrics to the registry quite yet
+		// Create a new registry and http.Server. Don't register custom metrics to the registry quite yet.
 		_, server := prometheus.New()
 		if err := prometheus.ServeOnSocket(server, metricsSocket); err != nil {
 			log.Errorf("prometheus server was stopped with error: %v", err)
 		}
 	}()
-}
-
-func patchRunning(vm *api.VM, ipAddrs []net.IP) error {
-	return patchVM(vm, func(patchVM *api.VM) error {
-		patchVM.Status.Running = true
-		patchVM.Status.IPAddresses = ipAddrs
-		return nil
-	})
 }
 
 func patchStopped(vm *api.VM) error {
@@ -114,6 +102,7 @@ func patchVM(vm *api.VM, fn func(*api.VM) error) error {
 	if err != nil {
 		return err
 	}
+
 	// Perform the patch
 	return patchutil.ApplyOnFile(constants.IGNITE_SPAWN_VM_FILE_PATH, patch, vm.GroupVersionKind())
 }

--- a/cmd/ignite-spawn/ignite-spawn.go
+++ b/cmd/ignite-spawn/ignite-spawn.go
@@ -8,7 +8,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	api "github.com/weaveworks/ignite/pkg/apis/ignite"
 	"github.com/weaveworks/ignite/pkg/apis/ignite/scheme"
-	meta "github.com/weaveworks/ignite/pkg/apis/meta/v1alpha1"
 	"github.com/weaveworks/ignite/pkg/constants"
 	"github.com/weaveworks/ignite/pkg/container"
 	dmcleanup "github.com/weaveworks/ignite/pkg/dmlegacy/cleanup"
@@ -48,8 +47,7 @@ func StartVM(vm *api.VM) error {
 	// Serve DHCP requests for those interfaces
 	// This function returns the available IP addresses that are being
 	// served over DHCP now
-	_, err = container.StartDHCPServers(vm, dhcpIfaces)
-	if err != nil {
+	if err = container.StartDHCPServers(vm, dhcpIfaces); err != nil {
 		return err
 	}
 
@@ -67,7 +65,7 @@ func StartVM(vm *api.VM) error {
 	defer os.Remove(metricsSocket)
 
 	// Execute Firecracker
-	if err := container.ExecuteFirecracker(vm, dhcpIfaces); err != nil {
+	if err = container.ExecuteFirecracker(vm, dhcpIfaces); err != nil {
 		return fmt.Errorf("runtime error for VM %q: %v", vm.GetUID(), err)
 	}
 
@@ -84,25 +82,16 @@ func serveMetrics(metricsSocket string) {
 	}()
 }
 
+// TODO: Get rid of this with the daemon architecture
 func patchStopped(vm *api.VM) error {
-	return patchVM(vm, func(patchVM *api.VM) error {
-		patchVM.Status.Running = false
-		patchVM.Status.IPAddresses = nil
-		patchVM.Status.Runtime = nil
-		patchVM.Status.StartTime = nil
-		return nil
-	})
-}
+	/*
+		Perform a static patch, setting the following:
+		vm.status.running = false
+		vm.status.ipAddresses = nil
+		vm.status.runtime = nil
+		vm.status.startTime = nil
+	*/
 
-func patchVM(vm *api.VM, fn func(*api.VM) error) error {
-	patch, err := patchutil.Create(vm, func(obj meta.Object) error {
-		patchVM := obj.(*api.VM)
-		return fn(patchVM)
-	})
-	if err != nil {
-		return err
-	}
-
-	// Perform the patch
+	patch := []byte(`{"status":{"running":false,"ipAddresses":null,"runtime":null,"startTime":null}}`)
 	return patchutil.ApplyOnFile(constants.IGNITE_SPAWN_VM_FILE_PATH, patch, vm.GroupVersionKind())
 }

--- a/pkg/operations/start.go
+++ b/pkg/operations/start.go
@@ -132,6 +132,8 @@ func StartVM(vm *api.VM, debug bool) error {
 		return err
 	}
 
+	// This is used to fetch the IP address the runtime gives to the VM container
+	// TODO: This needs to be handled differently for CNI, the IP address will be blank
 	result, err := providers.Runtime.InspectContainer(containerID)
 	if err != nil {
 		return fmt.Errorf("failed to inspect container for VM %q: %v", vm.GetUID(), err)

--- a/pkg/operations/start.go
+++ b/pkg/operations/start.go
@@ -132,12 +132,19 @@ func StartVM(vm *api.VM, debug bool) error {
 		return err
 	}
 
-	// TODO: Enable this when ignite-spawn doesn't write to the file anymore
-	//if err := providers.Client.VMs().Set(vm); err != nil {
-	//	return err
-	//}
+	result, err := providers.Runtime.InspectContainer(containerID)
+	if err != nil {
+		return fmt.Errorf("failed to inspect container for VM %q: %v", vm.GetUID(), err)
+	}
 
-	return nil
+	// Append the runtime IP address of the VM to its state
+	vm.Status.IPAddresses = append(vm.Status.IPAddresses, result.IPAddress)
+
+	// Set the VM's status to running
+	vm.Status.Running = true
+
+	// Write the state changes
+	return providers.Client.VMs().Set(vm)
 }
 
 func verifyPulled(image string) error {

--- a/pkg/runtime/docker/client.go
+++ b/pkg/runtime/docker/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net"
 	"time"
 
 	"github.com/docker/docker/api/types"
@@ -81,9 +82,10 @@ func (dc *dockerClient) InspectContainer(container string) (*runtime.ContainerIn
 	}
 
 	return &runtime.ContainerInspectResult{
-		ID:     res.ID,
-		Image:  res.Image,
-		Status: res.State.Status,
+		ID:        res.ID,
+		Image:     res.Image,
+		Status:    res.State.Status,
+		IPAddress: net.ParseIP(res.NetworkSettings.IPAddress),
 	}, nil
 }
 

--- a/pkg/runtime/types.go
+++ b/pkg/runtime/types.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"io"
+	"net"
 	"time"
 
 	meta "github.com/weaveworks/ignite/pkg/apis/meta/v1alpha1"
@@ -14,9 +15,10 @@ type ImageInspectResult struct {
 }
 
 type ContainerInspectResult struct {
-	ID     string
-	Image  string
-	Status string
+	ID        string
+	Image     string
+	Status    string
+	IPAddress net.IP
 }
 
 type Bind struct {


### PR DESCRIPTION
With this `ignite-spawn` no longer writes to the VM metadata file on startup, it only performs cleanup on after VM shutdown. The running state, container ID, start time and VM IP addresses are now set by `StartVM` after starting the container (and waiting for `ignite-spawn`).

cc @luxas 