### PR TITLE
Storage cleanup: document RawStorage, make RawStorage and MappedRawStorage more compatible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,7 +189,7 @@ bin/cache/go/bin/godoc2md:
 	chmod +x $@
 
 /go/bin/goimports:
-	go get golang.org/x/tools/cmd/goimports
+	GOFLAGS= go get golang.org/x/tools/cmd/goimports
 
 # QEMU stuff
 qemu: bin/$(GOARCH)/qemu-$(QEMUARCH)-static

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,8 @@ CACHE_DIR = $(shell pwd)/bin/cache
 DOCS_PORT = 8000
 # Specifies if this is a CI build or not; if it is, it will save the docker image created to bin/$(GOARCH)/image.tar
 IS_CI_BUILD ?= 0
+# Unset any GOFLAGS that would interfere with the build
+undefine GOFLAGS
 
 ## Multi-platform-related stuff
 GOHOSTARCH = $(shell go env GOARCH 2>/dev/null || echo "amd64")
@@ -189,7 +191,7 @@ bin/cache/go/bin/godoc2md:
 	chmod +x $@
 
 /go/bin/goimports:
-	GOFLAGS= go get golang.org/x/tools/cmd/goimports
+	go get golang.org/x/tools/cmd/goimports
 
 # QEMU stuff
 qemu: bin/$(GOARCH)/qemu-$(QEMUARCH)-static

--- a/docs/api/meta_v1alpha1.md
+++ b/docs/api/meta_v1alpha1.md
@@ -25,6 +25,7 @@
   - [type IPAddresses](#IPAddresses)
       - [func (i IPAddresses) String() string](#IPAddresses.String)
   - [type Kind](#Kind)
+      - [func ParseKind(input string) Kind](#ParseKind)
       - [func (k Kind) Lower() string](#Kind.Lower)
       - [func (k Kind) String() string](#Kind.String)
       - [func (k Kind) Title() string](#Kind.Title)
@@ -216,6 +217,14 @@ func (i IPAddresses) String() string
 type Kind string
 ```
 
+### <a name="ParseKind">func</a> [ParseKind](https://github.com/weaveworks/ignite/tree/master/pkg/apis/meta/v1alpha1/meta.go?s=2055:2088#L95)
+
+``` go
+func ParseKind(input string) Kind
+```
+
+Returns a Kind parsed from the given string
+
 ### <a name="Kind.Lower">func</a> (Kind) [Lower](https://github.com/weaveworks/ignite/tree/master/pkg/apis/meta/v1alpha1/meta.go?s=1933:1961#L90)
 
 ``` go
@@ -279,7 +288,7 @@ func (i OCIImageRef) String() string
 func (i *OCIImageRef) UnmarshalJSON(b []byte) error
 ```
 
-## <a name="Object">type</a> [Object](https://github.com/weaveworks/ignite/tree/master/pkg/apis/meta/v1alpha1/meta.go?s=4013:4448#L174)
+## <a name="Object">type</a> [Object](https://github.com/weaveworks/ignite/tree/master/pkg/apis/meta/v1alpha1/meta.go?s=4245:4680#L186)
 
 ``` go
 type Object interface {
@@ -312,7 +321,7 @@ type Object interface {
 Object extends k8s.io/apimachinery’s runtime.Object with extra GetName()
 and GetUID() methods from ObjectMeta
 
-## <a name="ObjectMeta">type</a> [ObjectMeta](https://github.com/weaveworks/ignite/tree/master/pkg/apis/meta/v1alpha1/meta.go?s=2168:2460#L97)
+## <a name="ObjectMeta">type</a> [ObjectMeta](https://github.com/weaveworks/ignite/tree/master/pkg/apis/meta/v1alpha1/meta.go?s=2400:2692#L109)
 
 ``` go
 type ObjectMeta struct {
@@ -328,7 +337,7 @@ ObjectMeta have to be embedded into any serializable object. It provides
 the .GetName() and .GetUID() methods that help implement the Object
 interface
 
-### <a name="ObjectMeta.GetAnnotation">func</a> (\*ObjectMeta) [GetAnnotation](https://github.com/weaveworks/ignite/tree/master/pkg/apis/meta/v1alpha1/meta.go?s=3568:3621#L157)
+### <a name="ObjectMeta.GetAnnotation">func</a> (\*ObjectMeta) [GetAnnotation](https://github.com/weaveworks/ignite/tree/master/pkg/apis/meta/v1alpha1/meta.go?s=3800:3853#L169)
 
 ``` go
 func (o *ObjectMeta) GetAnnotation(key string) string
@@ -336,7 +345,7 @@ func (o *ObjectMeta) GetAnnotation(key string) string
 
 GetAnnotation returns the label value for the key
 
-### <a name="ObjectMeta.GetCreated">func</a> (\*ObjectMeta) [GetCreated](https://github.com/weaveworks/ignite/tree/master/pkg/apis/meta/v1alpha1/meta.go?s=3005:3043#L131)
+### <a name="ObjectMeta.GetCreated">func</a> (\*ObjectMeta) [GetCreated](https://github.com/weaveworks/ignite/tree/master/pkg/apis/meta/v1alpha1/meta.go?s=3237:3275#L143)
 
 ``` go
 func (o *ObjectMeta) GetCreated() Time
@@ -344,7 +353,7 @@ func (o *ObjectMeta) GetCreated() Time
 
 GetCreated returns when the Object was created
 
-### <a name="ObjectMeta.GetLabel">func</a> (\*ObjectMeta) [GetLabel](https://github.com/weaveworks/ignite/tree/master/pkg/apis/meta/v1alpha1/meta.go?s=3226:3274#L141)
+### <a name="ObjectMeta.GetLabel">func</a> (\*ObjectMeta) [GetLabel](https://github.com/weaveworks/ignite/tree/master/pkg/apis/meta/v1alpha1/meta.go?s=3458:3506#L153)
 
 ``` go
 func (o *ObjectMeta) GetLabel(key string) string
@@ -352,7 +361,7 @@ func (o *ObjectMeta) GetLabel(key string) string
 
 GetLabel returns the label value for the key
 
-### <a name="ObjectMeta.GetName">func</a> (\*ObjectMeta) [GetName](https://github.com/weaveworks/ignite/tree/master/pkg/apis/meta/v1alpha1/meta.go?s=2611:2648#L111)
+### <a name="ObjectMeta.GetName">func</a> (\*ObjectMeta) [GetName](https://github.com/weaveworks/ignite/tree/master/pkg/apis/meta/v1alpha1/meta.go?s=2843:2880#L123)
 
 ``` go
 func (o *ObjectMeta) GetName() string
@@ -360,7 +369,7 @@ func (o *ObjectMeta) GetName() string
 
 GetName returns the name of the Object
 
-### <a name="ObjectMeta.GetObjectMeta">func</a> (\*ObjectMeta) [GetObjectMeta](https://github.com/weaveworks/ignite/tree/master/pkg/apis/meta/v1alpha1/meta.go?s=2505:2553#L106)
+### <a name="ObjectMeta.GetObjectMeta">func</a> (\*ObjectMeta) [GetObjectMeta](https://github.com/weaveworks/ignite/tree/master/pkg/apis/meta/v1alpha1/meta.go?s=2737:2785#L118)
 
 ``` go
 func (o *ObjectMeta) GetObjectMeta() *ObjectMeta
@@ -368,7 +377,7 @@ func (o *ObjectMeta) GetObjectMeta() *ObjectMeta
 
 This is a helper for APIType generation
 
-### <a name="ObjectMeta.GetUID">func</a> (\*ObjectMeta) [GetUID](https://github.com/weaveworks/ignite/tree/master/pkg/apis/meta/v1alpha1/meta.go?s=2810:2843#L121)
+### <a name="ObjectMeta.GetUID">func</a> (\*ObjectMeta) [GetUID](https://github.com/weaveworks/ignite/tree/master/pkg/apis/meta/v1alpha1/meta.go?s=3042:3075#L133)
 
 ``` go
 func (o *ObjectMeta) GetUID() UID
@@ -376,7 +385,7 @@ func (o *ObjectMeta) GetUID() UID
 
 GetUID returns the UID of the Object
 
-### <a name="ObjectMeta.SetAnnotation">func</a> (\*ObjectMeta) [SetAnnotation](https://github.com/weaveworks/ignite/tree/master/pkg/apis/meta/v1alpha1/meta.go?s=3742:3795#L165)
+### <a name="ObjectMeta.SetAnnotation">func</a> (\*ObjectMeta) [SetAnnotation](https://github.com/weaveworks/ignite/tree/master/pkg/apis/meta/v1alpha1/meta.go?s=3974:4027#L177)
 
 ``` go
 func (o *ObjectMeta) SetAnnotation(key, value string)
@@ -384,7 +393,7 @@ func (o *ObjectMeta) SetAnnotation(key, value string)
 
 SetAnnotation sets a label value for a key
 
-### <a name="ObjectMeta.SetCreated">func</a> (\*ObjectMeta) [SetCreated](https://github.com/weaveworks/ignite/tree/master/pkg/apis/meta/v1alpha1/meta.go?s=3118:3157#L136)
+### <a name="ObjectMeta.SetCreated">func</a> (\*ObjectMeta) [SetCreated](https://github.com/weaveworks/ignite/tree/master/pkg/apis/meta/v1alpha1/meta.go?s=3350:3389#L148)
 
 ``` go
 func (o *ObjectMeta) SetCreated(t Time)
@@ -392,7 +401,7 @@ func (o *ObjectMeta) SetCreated(t Time)
 
 SetCreated sets the creation time of the Object
 
-### <a name="ObjectMeta.SetLabel">func</a> (\*ObjectMeta) [SetLabel](https://github.com/weaveworks/ignite/tree/master/pkg/apis/meta/v1alpha1/meta.go?s=3380:3428#L149)
+### <a name="ObjectMeta.SetLabel">func</a> (\*ObjectMeta) [SetLabel](https://github.com/weaveworks/ignite/tree/master/pkg/apis/meta/v1alpha1/meta.go?s=3612:3660#L161)
 
 ``` go
 func (o *ObjectMeta) SetLabel(key, value string)
@@ -400,7 +409,7 @@ func (o *ObjectMeta) SetLabel(key, value string)
 
 SetLabel sets a label value for a key
 
-### <a name="ObjectMeta.SetName">func</a> (\*ObjectMeta) [SetName](https://github.com/weaveworks/ignite/tree/master/pkg/apis/meta/v1alpha1/meta.go?s=2708:2749#L116)
+### <a name="ObjectMeta.SetName">func</a> (\*ObjectMeta) [SetName](https://github.com/weaveworks/ignite/tree/master/pkg/apis/meta/v1alpha1/meta.go?s=2940:2981#L128)
 
 ``` go
 func (o *ObjectMeta) SetName(name string)
@@ -408,7 +417,7 @@ func (o *ObjectMeta) SetName(name string)
 
 SetName sets the name of the Object
 
-### <a name="ObjectMeta.SetUID">func</a> (\*ObjectMeta) [SetUID](https://github.com/weaveworks/ignite/tree/master/pkg/apis/meta/v1alpha1/meta.go?s=2900:2936#L126)
+### <a name="ObjectMeta.SetUID">func</a> (\*ObjectMeta) [SetUID](https://github.com/weaveworks/ignite/tree/master/pkg/apis/meta/v1alpha1/meta.go?s=3132:3168#L138)
 
 ``` go
 func (o *ObjectMeta) SetUID(uid UID)

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/gogo/protobuf v1.2.2-0.20190723190241-65acae22fc9d // indirect
 	github.com/goombaio/namegenerator v0.0.0-20181006234301-989e774b106e
 	github.com/gorilla/mux v1.7.2 // indirect
+	github.com/json-iterator/go v1.1.7 // indirect
 	github.com/krolaw/dhcp4 v0.0.0-20190531080455-7b64900047ae
 	github.com/lithammer/dedent v1.1.0
 	github.com/miekg/dns v1.1.14

--- a/go.sum
+++ b/go.sum
@@ -125,6 +125,8 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/gofuzz v0.0.0-20161122191042-44d81051d367/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
 github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf h1:+RRA9JqSOZFfKrOeqr2z77+8R2RKyh8PG66dcu1V0ck=
 github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
+github.com/google/gofuzz v1.0.0 h1:A8PeW59pxE9IoFRqBp37U+mSNaQoZ46F1f0f863XSXw=
+github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.0.0 h1:b4Gk+7WdP/d3HZH8EJsZpvV7EtDOgaZLtnaNGIu1adA=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gnostic v0.0.0-20170426233943-68f4ded48ba9/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
@@ -144,6 +146,8 @@ github.com/json-iterator/go v0.0.0-20180612202835-f2b4162afba3/go.mod h1:+SdeFBv
 github.com/json-iterator/go v0.0.0-20180701071628-ab8a2e0c74be/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.6 h1:MrUvLMLTMxbqFJ9kzlvat/rYZqZnW3u4wkLzWTaFwKs=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
+github.com/json-iterator/go v1.1.7 h1:KfgG9LzI+pYjr4xvmz/5H4FXjokeP+rlHLhv3iH62Fo=
+github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
@@ -174,9 +178,11 @@ github.com/miekg/dns v1.1.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3N
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
+github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180320133207-05fbef0ca5da/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
+github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9AWI=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/morikuni/aec v0.0.0-20170113033406-39771216ff4c h1:nXxl5PrvVm2L/wCy8dQu6DMTwH4oIuGN8GJDAlqDdVE=

--- a/pkg/apis/meta/v1alpha1/meta.go
+++ b/pkg/apis/meta/v1alpha1/meta.go
@@ -91,6 +91,18 @@ func (k Kind) Lower() string {
 	return string(bytes.ToLower([]byte(k)))
 }
 
+// Returns a Kind parsed from the given string
+func ParseKind(input string) Kind {
+	b := bytes.ToUpper([]byte(input))
+
+	// Leave TLAs as uppercase
+	if len(b) > 3 {
+		b = append(b[:1], bytes.ToLower(b[1:])...)
+	}
+
+	return Kind(b)
+}
+
 // ObjectMeta have to be embedded into any serializable object.
 // It provides the .GetName() and .GetUID() methods that help
 // implement the Object interface

--- a/pkg/providers/storage/storage.go
+++ b/pkg/providers/storage/storage.go
@@ -13,6 +13,6 @@ func SetGenericStorage() error {
 	log.Trace("Initializing the GenericStorage provider...")
 	providers.Storage = cache.NewCache(
 		storage.NewGenericStorage(
-			storage.NewDefaultRawStorage(constants.DATA_DIR), scheme.Serializer))
+			storage.NewGenericRawStorage(constants.DATA_DIR), scheme.Serializer))
 	return nil
 }

--- a/pkg/storage/key.go
+++ b/pkg/storage/key.go
@@ -2,7 +2,10 @@ package storage
 
 import (
 	"fmt"
+	"os"
 	"path"
+	"path/filepath"
+	"strings"
 
 	meta "github.com/weaveworks/ignite/pkg/apis/meta/v1alpha1"
 )
@@ -34,6 +37,19 @@ func NewKey(kind meta.Kind, uid meta.UID) Key {
 		NewKindKey(kind),
 		uid,
 	}
+}
+
+// ParseKey parses the given string and returns a Key
+func ParseKey(input string) (k Key, err error) {
+	splitInput := strings.Split(filepath.Clean(input), string(os.PathSeparator))
+	if len(splitInput) != 2 {
+		err = fmt.Errorf("invalid input for key parsing: %s", input)
+	} else {
+		k.Kind = meta.ParseKind(splitInput[0])
+		k.UID = meta.UID(splitInput[1])
+	}
+
+	return
 }
 
 // String returns the virtual path for the Kind

--- a/pkg/storage/manifest/storage.go
+++ b/pkg/storage/manifest/storage.go
@@ -16,7 +16,7 @@ func NewManifestStorage(dataDir string) (*ManifestStorage, error) {
 
 	ss := sync.NewSyncStorage(
 		storage.NewGenericStorage(
-			storage.NewDefaultRawStorage(constants.DATA_DIR), scheme.Serializer),
+			storage.NewGenericRawStorage(constants.DATA_DIR), scheme.Serializer),
 		ws)
 
 	return &ManifestStorage{

--- a/pkg/storage/mappedrawstorage.go
+++ b/pkg/storage/mappedrawstorage.go
@@ -135,7 +135,7 @@ func (r *GenericMappedRawStorage) Format(key Key) (f Format) {
 	return
 }
 
-func (r *GenericMappedRawStorage) Dir() string {
+func (r *GenericMappedRawStorage) WatchDir() string {
 	return r.dir
 }
 

--- a/pkg/storage/mappedrawstorage.go
+++ b/pkg/storage/mappedrawstorage.go
@@ -18,9 +18,6 @@ type MappedRawStorage interface {
 
 	// AddMapping binds a Key's virtual path to a physical file path
 	AddMapping(key Key, path string)
-	// GetMapping retrieves the Key containing the virtual
-	// path based on the given physical file path
-	GetMapping(path string) (Key, error)
 	// RemoveMapping removes the physical file
 	// path mapping matching the given Key
 	RemoveMapping(key Key)
@@ -139,12 +136,7 @@ func (r *GenericMappedRawStorage) WatchDir() string {
 	return r.dir
 }
 
-func (r *GenericMappedRawStorage) AddMapping(key Key, path string) {
-	log.Debugf("GenericMappedRawStorage: AddMapping: %q -> %q", key, path)
-	r.fileMappings[key] = path
-}
-
-func (r *GenericMappedRawStorage) GetMapping(path string) (Key, error) {
+func (r *GenericMappedRawStorage) GetKey(path string) (Key, error) {
 	for key, p := range r.fileMappings {
 		if p == path {
 			return key, nil
@@ -152,6 +144,11 @@ func (r *GenericMappedRawStorage) GetMapping(path string) (Key, error) {
 	}
 
 	return Key{}, fmt.Errorf("no mapping found for path %q", path)
+}
+
+func (r *GenericMappedRawStorage) AddMapping(key Key, path string) {
+	log.Debugf("GenericMappedRawStorage: AddMapping: %q -> %q", key, path)
+	r.fileMappings[key] = path
 }
 
 func (r *GenericMappedRawStorage) RemoveMapping(key Key) {

--- a/pkg/storage/rawstorage.go
+++ b/pkg/storage/rawstorage.go
@@ -40,17 +40,17 @@ type RawStorage interface {
 	GetKey(path string) (Key, error)
 }
 
-func NewDefaultRawStorage(dir string) RawStorage {
-	return &DefaultRawStorage{
+func NewGenericRawStorage(dir string) RawStorage {
+	return &GenericRawStorage{
 		dir: dir,
 	}
 }
 
-type DefaultRawStorage struct {
+type GenericRawStorage struct {
 	dir string
 }
 
-func (r *DefaultRawStorage) realPath(key AnyKey) string {
+func (r *GenericRawStorage) realPath(key AnyKey) string {
 	var file string
 
 	switch key.(type) {
@@ -66,15 +66,15 @@ func (r *DefaultRawStorage) realPath(key AnyKey) string {
 	return path.Join(r.dir, key.String(), file)
 }
 
-func (r *DefaultRawStorage) Read(key Key) ([]byte, error) {
+func (r *GenericRawStorage) Read(key Key) ([]byte, error) {
 	return ioutil.ReadFile(r.realPath(key))
 }
 
-func (r *DefaultRawStorage) Exists(key Key) bool {
+func (r *GenericRawStorage) Exists(key Key) bool {
 	return util.FileExists(r.realPath(key))
 }
 
-func (r *DefaultRawStorage) Write(key Key, content []byte) error {
+func (r *GenericRawStorage) Write(key Key, content []byte) error {
 	file := r.realPath(key)
 
 	// Create the underlying directories if they do not exist already
@@ -87,11 +87,11 @@ func (r *DefaultRawStorage) Write(key Key, content []byte) error {
 	return ioutil.WriteFile(file, content, 0644)
 }
 
-func (r *DefaultRawStorage) Delete(key Key) error {
+func (r *GenericRawStorage) Delete(key Key) error {
 	return os.RemoveAll(path.Dir(r.realPath(key)))
 }
 
-func (r *DefaultRawStorage) List(key KindKey) ([]Key, error) {
+func (r *GenericRawStorage) List(key KindKey) ([]Key, error) {
 	entries, err := ioutil.ReadDir(r.realPath(key))
 	if err != nil {
 		return nil, err
@@ -107,7 +107,7 @@ func (r *DefaultRawStorage) List(key KindKey) ([]Key, error) {
 
 // This returns the modification time as a UnixNano string
 // If the file doesn't exist, return blank
-func (r *DefaultRawStorage) Checksum(key Key) (s string, err error) {
+func (r *GenericRawStorage) Checksum(key Key) (s string, err error) {
 	var fi os.FileInfo
 
 	if r.Exists(key) {
@@ -119,15 +119,15 @@ func (r *DefaultRawStorage) Checksum(key Key) (s string, err error) {
 	return
 }
 
-func (r *DefaultRawStorage) Format(key Key) Format {
-	return FormatJSON // The DefaultRawStorage always uses JSON
+func (r *GenericRawStorage) Format(key Key) Format {
+	return FormatJSON // The GenericRawStorage always uses JSON
 }
 
-func (r *DefaultRawStorage) WatchDir() string {
+func (r *GenericRawStorage) WatchDir() string {
 	return r.dir
 }
 
-func (r *DefaultRawStorage) GetKey(p string) (key Key, err error) {
+func (r *GenericRawStorage) GetKey(p string) (key Key, err error) {
 	splitDir := strings.Split(filepath.Clean(r.dir), string(os.PathSeparator))
 	splitPath := strings.Split(filepath.Clean(p), string(os.PathSeparator))
 

--- a/pkg/storage/rawstorage.go
+++ b/pkg/storage/rawstorage.go
@@ -12,15 +12,26 @@ import (
 	"github.com/weaveworks/ignite/pkg/util"
 )
 
+// RawStorage is a Key-indexed low-level interface to
+// store byte-encoded Objects (resources) in non-volatile
+// memory.
 type RawStorage interface {
+	// Read returns a resource's content based on key
 	Read(key Key) ([]byte, error)
+	// Exists checks if the resource indicated by key exists
 	Exists(key Key) bool
+	// Write writes the given content to the resource indicated by key
 	Write(key Key, content []byte) error
+	// Delete deletes the resource indicated by key
 	Delete(key Key) error
+	// List returns all matching resource Keys based on the given KindKey
 	List(key KindKey) ([]Key, error)
+	// Checksum returns a string checksum for the resource indicated by key
 	Checksum(key Key) (string, error)
+	// Format returns the format of the contents of the resource indicated by key
 	Format(key Key) Format
-	Dir() string
+	// WatchDir returns the path for Watchers to watch changes in
+	WatchDir() string
 }
 
 func NewDefaultRawStorage(dir string) RawStorage {
@@ -106,6 +117,6 @@ func (r *DefaultRawStorage) Format(key Key) Format {
 	return FormatJSON // The DefaultRawStorage always uses JSON
 }
 
-func (r *DefaultRawStorage) Dir() string {
+func (r *DefaultRawStorage) WatchDir() string {
 	return r.dir
 }

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -8,7 +8,7 @@ import (
 	meta "github.com/weaveworks/ignite/pkg/apis/meta/v1alpha1"
 )
 
-var s = NewGenericStorage(NewDefaultRawStorage("/tmp/bar"), scheme.Serializer)
+var s = NewGenericStorage(NewGenericRawStorage("/tmp/bar"), scheme.Serializer)
 var vmGVK = api.SchemeGroupVersion.WithKind("VM")
 
 func TestStorageNew(t *testing.T) {

--- a/pkg/storage/watch/storage.go
+++ b/pkg/storage/watch/storage.go
@@ -38,7 +38,7 @@ func NewGenericWatchStorage(s storage.Storage) (WatchStorage, error) {
 
 	var err error
 	var files []string
-	if ws.watcher, files, err = watcher.NewFileWatcher(s.RawStorage().Dir()); err != nil {
+	if ws.watcher, files, err = watcher.NewFileWatcher(s.RawStorage().WatchDir()); err != nil {
 		return nil, err
 	}
 

--- a/pkg/storage/watch/storage.go
+++ b/pkg/storage/watch/storage.go
@@ -42,11 +42,9 @@ func NewGenericWatchStorage(s storage.Storage) (WatchStorage, error) {
 		return nil, err
 	}
 
-	if mapped, ok := ws.RawStorage().(storage.MappedRawStorage); ok {
-		ws.monitor = sync.RunMonitor(func() {
-			ws.monitorFunc(mapped, files) // Offload the file registration to the goroutine
-		})
-	}
+	ws.monitor = sync.RunMonitor(func() {
+		ws.monitorFunc(ws.RawStorage(), files) // Offload the file registration to the goroutine
+	})
 
 	return ws, nil
 }
@@ -89,16 +87,19 @@ func (s *GenericWatchStorage) Close() error {
 	return nil
 }
 
-func (s *GenericWatchStorage) monitorFunc(mapped storage.MappedRawStorage, files []string) {
+func (s *GenericWatchStorage) monitorFunc(raw storage.RawStorage, files []string) {
 	log.Debug("GenericWatchStorage: Monitoring thread started")
 	defer log.Debug("GenericWatchStorage: Monitoring thread stopped")
 
-	// Fill the mappings of the MappedRawStorage before starting to monitor changes
+	// Send a MODIFY event for all files (and fill the mappings
+	// of the MappedRawStorage) before starting to monitor changes
 	for _, file := range files {
 		if obj, err := resolveAPIType(file); err != nil {
 			log.Warnf("Ignoring %q: %v", file, err)
 		} else {
-			mapped.AddMapping(storage.NewKey(obj.GetKind(), obj.GetUID()), file)
+			if mapped, ok := raw.(storage.MappedRawStorage); ok {
+				mapped.AddMapping(storage.NewKey(obj.GetKind(), obj.GetUID()), file)
+			}
 			// Send the event to the events channel
 			s.sendEvent(update.ObjectEventModify, obj)
 		}
@@ -120,7 +121,7 @@ func (s *GenericWatchStorage) monitorFunc(mapped storage.MappedRawStorage, files
 			log.Tracef("GenericWatchStorage: Processing event: %s", event.Event)
 			if event.Event == watcher.FileEventDelete {
 				var key storage.Key
-				if key, err = mapped.GetMapping(event.Path); err != nil {
+				if key, err = raw.GetKey(event.Path); err != nil {
 					log.Warnf("Failed to retrieve data for %q: %v", event.Path, err)
 					continue
 				}
@@ -143,8 +144,10 @@ func (s *GenericWatchStorage) monitorFunc(mapped storage.MappedRawStorage, files
 
 				// This is based on the key's existence instead of watcher.EventCreate,
 				// as Objects can get updated (via watcher.FileEventModify) to be conformant
-				if _, err = mapped.GetMapping(event.Path); err != nil {
-					mapped.AddMapping(storage.NewKey(obj.GetKind(), obj.GetUID()), event.Path)
+				if _, err = raw.GetKey(event.Path); err != nil {
+					if mapped, ok := raw.(storage.MappedRawStorage); ok {
+						mapped.AddMapping(storage.NewKey(obj.GetKind(), obj.GetUID()), event.Path)
+					}
 					// This is what actually determines if an Object is created,
 					// so update the event to update.ObjectEventCreate here
 					objectEvent = update.ObjectEventCreate

--- a/vendor/github.com/google/gofuzz/go.mod
+++ b/vendor/github.com/google/gofuzz/go.mod
@@ -1,0 +1,3 @@
+module github.com/google/gofuzz
+
+go 1.12

--- a/vendor/github.com/json-iterator/go/adapter.go
+++ b/vendor/github.com/json-iterator/go/adapter.go
@@ -16,7 +16,7 @@ func Unmarshal(data []byte, v interface{}) error {
 	return ConfigDefault.Unmarshal(data, v)
 }
 
-// UnmarshalFromString convenient method to read from string instead of []byte
+// UnmarshalFromString is a convenient method to read from string instead of []byte
 func UnmarshalFromString(str string, v interface{}) error {
 	return ConfigDefault.UnmarshalFromString(str, v)
 }

--- a/vendor/github.com/json-iterator/go/go.mod
+++ b/vendor/github.com/json-iterator/go/go.mod
@@ -1,0 +1,11 @@
+module github.com/json-iterator/go
+
+go 1.12
+
+require (
+	github.com/davecgh/go-spew v1.1.1
+	github.com/google/gofuzz v1.0.0
+	github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421
+	github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742
+	github.com/stretchr/testify v1.3.0
+)

--- a/vendor/github.com/json-iterator/go/go.sum
+++ b/vendor/github.com/json-iterator/go/go.sum
@@ -1,0 +1,14 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/gofuzz v1.0.0 h1:A8PeW59pxE9IoFRqBp37U+mSNaQoZ46F1f0f863XSXw=
+github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421 h1:ZqeYNhU3OHLH3mGKHDcjJRFFRrJa6eAM5H+CtDdOsPc=
+github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
+github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742 h1:Esafd1046DLDQ0W1YjYsBW+p8U2u7vzgW2SQVmlNazg=
+github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/vendor/github.com/json-iterator/go/reflect_native.go
+++ b/vendor/github.com/json-iterator/go/reflect_native.go
@@ -432,17 +432,19 @@ func (codec *base64Codec) Decode(ptr unsafe.Pointer, iter *Iterator) {
 }
 
 func (codec *base64Codec) Encode(ptr unsafe.Pointer, stream *Stream) {
-	src := *((*[]byte)(ptr))
-	if len(src) == 0 {
+	if codec.sliceType.UnsafeIsNil(ptr) {
 		stream.WriteNil()
 		return
 	}
+	src := *((*[]byte)(ptr))
 	encoding := base64.StdEncoding
 	stream.writeByte('"')
-	size := encoding.EncodedLen(len(src))
-	buf := make([]byte, size)
-	encoding.Encode(buf, src)
-	stream.buf = append(stream.buf, buf...)
+	if len(src) != 0 {
+		size := encoding.EncodedLen(len(src))
+		buf := make([]byte, size)
+		encoding.Encode(buf, src)
+		stream.buf = append(stream.buf, buf...)
+	}
 	stream.writeByte('"')
 }
 

--- a/vendor/github.com/json-iterator/go/reflect_struct_decoder.go
+++ b/vendor/github.com/json-iterator/go/reflect_struct_decoder.go
@@ -530,8 +530,8 @@ func (decoder *generalStructDecoder) decodeOneField(ptr unsafe.Pointer, iter *It
 		}
 	}
 	if fieldDecoder == nil {
-		msg := "found unknown field: " + field
 		if decoder.disallowUnknownFields {
+			msg := "found unknown field: " + field
 			iter.ReportError("ReadObject", msg)
 		}
 		c := iter.nextToken()

--- a/vendor/github.com/json-iterator/go/stream_float.go
+++ b/vendor/github.com/json-iterator/go/stream_float.go
@@ -1,6 +1,7 @@
 package jsoniter
 
 import (
+	"fmt"
 	"math"
 	"strconv"
 )
@@ -13,6 +14,10 @@ func init() {
 
 // WriteFloat32 write float32 to stream
 func (stream *Stream) WriteFloat32(val float32) {
+	if math.IsInf(float64(val), 0) || math.IsNaN(float64(val)) {
+		stream.Error = fmt.Errorf("unsupported value: %f", val)
+		return
+	}
 	abs := math.Abs(float64(val))
 	fmt := byte('f')
 	// Note: Must use float32 comparisons for underlying float32 value to get precise cutoffs right.
@@ -26,6 +31,10 @@ func (stream *Stream) WriteFloat32(val float32) {
 
 // WriteFloat32Lossy write float32 to stream with ONLY 6 digits precision although much much faster
 func (stream *Stream) WriteFloat32Lossy(val float32) {
+	if math.IsInf(float64(val), 0) || math.IsNaN(float64(val)) {
+		stream.Error = fmt.Errorf("unsupported value: %f", val)
+		return
+	}
 	if val < 0 {
 		stream.writeByte('-')
 		val = -val
@@ -54,6 +63,10 @@ func (stream *Stream) WriteFloat32Lossy(val float32) {
 
 // WriteFloat64 write float64 to stream
 func (stream *Stream) WriteFloat64(val float64) {
+	if math.IsInf(val, 0) || math.IsNaN(val) {
+		stream.Error = fmt.Errorf("unsupported value: %f", val)
+		return
+	}
 	abs := math.Abs(val)
 	fmt := byte('f')
 	// Note: Must use float32 comparisons for underlying float32 value to get precise cutoffs right.
@@ -67,6 +80,10 @@ func (stream *Stream) WriteFloat64(val float64) {
 
 // WriteFloat64Lossy write float64 to stream with ONLY 6 digits precision although much much faster
 func (stream *Stream) WriteFloat64Lossy(val float64) {
+	if math.IsInf(val, 0) || math.IsNaN(val) {
+		stream.Error = fmt.Errorf("unsupported value: %f", val)
+		return
+	}
 	if val < 0 {
 		stream.writeByte('-')
 		val = -val

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -102,7 +102,7 @@ github.com/golang/protobuf/ptypes
 github.com/golang/protobuf/ptypes/any
 github.com/golang/protobuf/ptypes/duration
 github.com/golang/protobuf/ptypes/timestamp
-# github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf
+# github.com/google/gofuzz v1.0.0
 github.com/google/gofuzz
 # github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d
 github.com/googleapis/gnostic/OpenAPIv2
@@ -112,7 +112,7 @@ github.com/googleapis/gnostic/extensions
 github.com/goombaio/namegenerator
 # github.com/inconshreveable/mousetrap v1.0.0
 github.com/inconshreveable/mousetrap
-# github.com/json-iterator/go v1.1.6
+# github.com/json-iterator/go v1.1.7
 github.com/json-iterator/go
 # github.com/konsorten/go-windows-terminal-sequences v1.0.1
 github.com/konsorten/go-windows-terminal-sequences


### PR DESCRIPTION
- Documents the `RawStorage` interface
- Reduces the delta between `MappedRawStorage` and `RawStorage` by introducing `GetKey(path)`
- Enables `WatchStorage` to handle generic `RawStorages`
- Renames `DefaultRawStorage` to `GenericRawStorage` to follow the pattern
- (Small Makefile improvement for various environments)

cc @luxas 