### PR TITLE
Use util.Prefixer in place of manual concatenation, use IGNITE_PREFIX in util.Prefixer

### DIFF
--- a/pkg/apis/ignite/helpers.go
+++ b/pkg/apis/ignite/helpers.go
@@ -4,6 +4,7 @@ import (
 	"path"
 
 	"github.com/weaveworks/ignite/pkg/constants"
+	"github.com/weaveworks/ignite/pkg/util"
 )
 
 // SetImage populates relevant fields to an Image on the VM object
@@ -20,8 +21,7 @@ func (vm *VM) SetKernel(kernel *Kernel) {
 
 // SnapshotDev returns the path where the (legacy) DM snapshot exists
 func (vm *VM) SnapshotDev() string {
-	// TODO: Reuse the prefixer here
-	return path.Join("/dev/mapper", constants.IGNITE_PREFIX+vm.GetUID().String())
+	return path.Join("/dev/mapper", util.NewPrefixer().Prefix(vm.GetUID()))
 }
 
 // Running returns true if the VM is running, otherwise false

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -2,7 +2,7 @@ package constants
 
 const (
 	// Common Ignite prefix
-	IGNITE_PREFIX = "ignite-"
+	IGNITE_PREFIX = "ignite"
 
 	// Ignite data base directory
 	DATA_DIR = "/var/lib/firecracker"

--- a/pkg/dmlegacy/cleanup/deactivate.go
+++ b/pkg/dmlegacy/cleanup/deactivate.go
@@ -1,10 +1,7 @@
 package cleanup
 
 import (
-	"fmt"
-
 	api "github.com/weaveworks/ignite/pkg/apis/ignite"
-	"github.com/weaveworks/ignite/pkg/constants"
 	"github.com/weaveworks/ignite/pkg/util"
 )
 
@@ -18,7 +15,7 @@ func DeactivateSnapshot(vm *api.VM) error {
 	// If the base device is visible in "dmsetup", we should remove it
 	// The device itself is not forwarded to docker, so we can't query its path
 	// TODO: Improve this detection
-	baseDev := fmt.Sprintf("%s-base", constants.IGNITE_PREFIX+vm.GetUID())
+	baseDev := util.NewPrefixer().Prefix(vm.GetUID(), "base")
 	if _, err := util.ExecuteCommand("dmsetup", "info", baseDev); err == nil {
 		dmArgs = append(dmArgs, baseDev)
 	}

--- a/pkg/dmlegacy/snapshot.go
+++ b/pkg/dmlegacy/snapshot.go
@@ -14,7 +14,7 @@ import (
 
 // ActivateSnapshot sets up the snapshot with devicemapper so that it is active and can be used
 func ActivateSnapshot(vm *api.VM) error {
-	device := constants.IGNITE_PREFIX + vm.GetUID().String()
+	device := util.NewPrefixer().Prefix(vm.GetUID())
 	devicePath := vm.SnapshotDev()
 
 	// Return if the snapshot is already setup

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/goombaio/namegenerator"
 	log "github.com/sirupsen/logrus"
+	"github.com/weaveworks/ignite/pkg/constants"
 )
 
 // GenericCheckErr is used by the commands to check if the action failed
@@ -161,7 +162,7 @@ type Prefixer struct {
 
 func NewPrefixer() *Prefixer {
 	return &Prefixer{
-		prefix:    "ignite", // TODO: Remove the dash from IGNITE_PREFIX and use it here
+		prefix:    constants.IGNITE_PREFIX,
 		separator: "-",
 	}
 }


### PR DESCRIPTION
Just a small cleanup to still include in v0.5.1. Removes manual concatenations in favor of `util.Prefixer` and makes it use `constants.IGNITE_PREFIX`. Builds on top of https://github.com/weaveworks/ignite/pull/341.

cc @luxas 