### PR TITLE
Add openSUSE images

### DIFF
--- a/images/Makefile
+++ b/images/Makefile
@@ -31,10 +31,12 @@ push-all: build-all
 
 build-all:
 	$(MAKE) ${OP} WHAT=amazon-kernel
-	$(MAKE) ${OP} WHAT=amazonlinux   RELEASE=2     IS_LATEST=true
+	$(MAKE) ${OP} WHAT=amazonlinux   RELEASE=2          IS_LATEST=true
 	$(MAKE) ${OP} WHAT=alpine
+	$(MAKE) ${OP} WHAT=opensuse      RELEASE=leap       IS_LATEST=true
+	$(MAKE) ${OP} WHAT=opensuse      RELEASE=tumbleweed
 	$(MAKE) ${OP} WHAT=ubuntu        RELEASE=16.04
-	$(MAKE) ${OP} WHAT=ubuntu        RELEASE=18.04 IS_LATEST=true
+	$(MAKE) ${OP} WHAT=ubuntu        RELEASE=18.04      IS_LATEST=true
 	$(MAKE) ${OP} WHAT=ubuntu        RELEASE=19.04
-	$(MAKE) ${OP} WHAT=centos        RELEASE=7     IS_LATEST=true
+	$(MAKE) ${OP} WHAT=centos        RELEASE=7          IS_LATEST=true
 	$(MAKE) ${OP} WHAT=kubeadm

--- a/images/opensuse/Dockerfile
+++ b/images/opensuse/Dockerfile
@@ -1,0 +1,23 @@
+ARG RELEASE
+
+FROM opensuse/${RELEASE}
+
+# Install common utilities
+RUN zypper -n install \
+        iproute \
+        iputils \
+        openssh \
+        net-tools \
+        systemd-sysvinit \
+        udev \
+        sudo \
+        wget && \
+    zypper clean --all
+
+# systemctl enable creates the symlinks to enable the service
+# it doesn't need systemd running
+RUN systemctl enable sshd
+
+# Set the root password to root when logging in through the VM's ttyS0 console
+RUN echo "root:root" | chpasswd
+


### PR DESCRIPTION
openSUSE has two different versions that release [independently](https://en.opensuse.org/Lifetime):

* openSUSE Tumbleweed is openSUSE's rolling release, which is constantly updated and always at the 'latest release'
* openSUSE Leap is openSUSE's regular release

This PR adds openSUSE images based on the versions because of the [Dockerfile base images naming](https://hub.docker.com/_/opensuse), i.e. Tumbleweed and Leap, not based in the releases, i.e Leap 15.1, 15.2, ... 

If there is more demand I can add a new parameter to the Makefile, but I think that's enough to have some images working with ignite at this moment.
