### PR TITLE
update ignite version to v0.5.1

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -90,7 +90,7 @@ If the installation was successful, the `ignite` command should now be available
 
 ```
 # ignite version
-Ignite version: version.Info{Major:"0", Minor:"4+", GitVersion:"v0.4.0-rc.1", GitCommit:"7e03dc80be894250f9f97ec4d80261fd2fdcd8f4", GitTreeState:"clean", BuildDate:"2019-07-09T19:03:30Z", GoVersion:"go1.12.1", Compiler:"gc", Platform:"linux/amd64"}
+Ignite version: version.Info{Major:"0", Minor:"5", GitVersion:"v0.5.1", GitCommit:"a80939c0952f59a8ebd7e6734539e7a138ef68ab", GitTreeState:"clean", BuildDate:"2019-08-16T15:18:05Z", GoVersion:"go1.12.6", Compiler:"gc", Platform:"linux/amd64"}
 Firecracker version: v0.17.0
 ```
 


### PR DESCRIPTION
As the VERSION has been changed to v0.5.1, the output of ignite version should be updated corresponding.

```
export VERSION=v0.5.1
export GOARCH=$(go env GOARCH 2>/dev/null || echo "amd64")
```