### PR TITLE
Implement runtime selection, only load necessary providers

### DIFF
--- a/cmd/ignite/ignite.go
+++ b/cmd/ignite/ignite.go
@@ -25,8 +25,8 @@ func Run() error {
 	// Create the directories needed for running
 	util.GenericCheckErr(util.CreateDirectories())
 
-	// Populate the providers
-	util.GenericCheckErr(providers.Populate(ignite.Providers))
+	// Preload necessary providers
+	util.GenericCheckErr(providers.Populate(ignite.Preload))
 
 	c := cmd.NewIgniteCommand(os.Stdin, os.Stdout, os.Stderr)
 	return c.Execute()

--- a/cmd/ignited/ignited.go
+++ b/cmd/ignited/ignited.go
@@ -25,8 +25,8 @@ func Run() error {
 	// Create the directories needed for running
 	util.GenericCheckErr(util.CreateDirectories())
 
-	// Populate the providers
-	util.GenericCheckErr(providers.Populate(ignited.Providers))
+	// Preload necessary providers
+	util.GenericCheckErr(providers.Populate(ignited.Preload))
 
 	c := cmd.NewIgnitedCommand(os.Stdin, os.Stdout, os.Stderr)
 	return c.Execute()

--- a/docs/cli/ignite/ignite.md
+++ b/docs/cli/ignite/ignite.md
@@ -37,6 +37,7 @@ Example usage:
       --log-level loglevel      Specify the loglevel for the program (default info)
       --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
   -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_attach.md
+++ b/docs/cli/ignite/ignite_attach.md
@@ -26,6 +26,7 @@ ignite attach <vm> [flags]
       --log-level loglevel      Specify the loglevel for the program (default info)
       --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
   -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_completion.md
+++ b/docs/cli/ignite/ignite_completion.md
@@ -30,6 +30,7 @@ ignite completion [flags]
       --log-level loglevel      Specify the loglevel for the program (default info)
       --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
   -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_create.md
+++ b/docs/cli/ignite/ignite_create.md
@@ -54,6 +54,7 @@ ignite create <OCI image> [flags]
       --log-level loglevel      Specify the loglevel for the program (default info)
       --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
   -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_exec.md
+++ b/docs/cli/ignite/ignite_exec.md
@@ -29,6 +29,7 @@ ignite exec <vm> <command...> [flags]
       --log-level loglevel      Specify the loglevel for the program (default info)
       --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
   -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_image.md
+++ b/docs/cli/ignite/ignite_image.md
@@ -25,6 +25,7 @@ ignite image [flags]
       --log-level loglevel      Specify the loglevel for the program (default info)
       --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
   -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_image_import.md
+++ b/docs/cli/ignite/ignite_image_import.md
@@ -26,6 +26,7 @@ ignite image import <OCI image> [flags]
       --log-level loglevel      Specify the loglevel for the program (default info)
       --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
   -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_image_ls.md
+++ b/docs/cli/ignite/ignite_image_ls.md
@@ -24,6 +24,7 @@ ignite image ls [flags]
       --log-level loglevel      Specify the loglevel for the program (default info)
       --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
   -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_image_rm.md
+++ b/docs/cli/ignite/ignite_image_rm.md
@@ -27,6 +27,7 @@ ignite image rm <image>... [flags]
       --log-level loglevel      Specify the loglevel for the program (default info)
       --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
   -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_inspect.md
+++ b/docs/cli/ignite/ignite_inspect.md
@@ -28,6 +28,7 @@ ignite inspect <kind> <object> [flags]
       --log-level loglevel      Specify the loglevel for the program (default info)
       --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
   -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_kernel.md
+++ b/docs/cli/ignite/ignite_kernel.md
@@ -25,6 +25,7 @@ ignite kernel [flags]
       --log-level loglevel      Specify the loglevel for the program (default info)
       --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
   -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_kernel_import.md
+++ b/docs/cli/ignite/ignite_kernel_import.md
@@ -26,6 +26,7 @@ ignite kernel import <OCI image> [flags]
       --log-level loglevel      Specify the loglevel for the program (default info)
       --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
   -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_kernel_ls.md
+++ b/docs/cli/ignite/ignite_kernel_ls.md
@@ -24,6 +24,7 @@ ignite kernel ls [flags]
       --log-level loglevel      Specify the loglevel for the program (default info)
       --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
   -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_kernel_rm.md
+++ b/docs/cli/ignite/ignite_kernel_rm.md
@@ -27,6 +27,7 @@ ignite kernel rm <kernel>... [flags]
       --log-level loglevel      Specify the loglevel for the program (default info)
       --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
   -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_kill.md
+++ b/docs/cli/ignite/ignite_kill.md
@@ -26,6 +26,7 @@ ignite kill <vm>... [flags]
       --log-level loglevel      Specify the loglevel for the program (default info)
       --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
   -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_logs.md
+++ b/docs/cli/ignite/ignite_logs.md
@@ -25,6 +25,7 @@ ignite logs <vm> [flags]
       --log-level loglevel      Specify the loglevel for the program (default info)
       --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
   -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_ps.md
+++ b/docs/cli/ignite/ignite_ps.md
@@ -26,6 +26,7 @@ ignite ps [flags]
       --log-level loglevel      Specify the loglevel for the program (default info)
       --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
   -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_rm.md
+++ b/docs/cli/ignite/ignite_rm.md
@@ -28,6 +28,7 @@ ignite rm <vm>... [flags]
       --log-level loglevel      Specify the loglevel for the program (default info)
       --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
   -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_rmi.md
+++ b/docs/cli/ignite/ignite_rmi.md
@@ -27,6 +27,7 @@ ignite rmi <image> [flags]
       --log-level loglevel      Specify the loglevel for the program (default info)
       --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
   -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_rmk.md
+++ b/docs/cli/ignite/ignite_rmk.md
@@ -27,6 +27,7 @@ ignite rmk <kernel> [flags]
       --log-level loglevel      Specify the loglevel for the program (default info)
       --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
   -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_run.md
+++ b/docs/cli/ignite/ignite_run.md
@@ -49,6 +49,7 @@ ignite run <OCI image> [flags]
       --log-level loglevel      Specify the loglevel for the program (default info)
       --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
   -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_ssh.md
+++ b/docs/cli/ignite/ignite_ssh.md
@@ -29,6 +29,7 @@ ignite ssh <vm> [flags]
       --log-level loglevel      Specify the loglevel for the program (default info)
       --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
   -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_start.md
+++ b/docs/cli/ignite/ignite_start.md
@@ -28,6 +28,7 @@ ignite start <vm> [flags]
       --log-level loglevel      Specify the loglevel for the program (default info)
       --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
   -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_stop.md
+++ b/docs/cli/ignite/ignite_stop.md
@@ -31,6 +31,7 @@ ignite stop <vm>... [flags]
       --log-level loglevel      Specify the loglevel for the program (default info)
       --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
   -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_version.md
+++ b/docs/cli/ignite/ignite_version.md
@@ -23,6 +23,7 @@ ignite version [flags]
       --log-level loglevel      Specify the loglevel for the program (default info)
       --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
   -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_vm.md
+++ b/docs/cli/ignite/ignite_vm.md
@@ -24,6 +24,7 @@ ignite vm [flags]
       --log-level loglevel      Specify the loglevel for the program (default info)
       --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
   -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_vm_attach.md
+++ b/docs/cli/ignite/ignite_vm_attach.md
@@ -26,6 +26,7 @@ ignite vm attach <vm> [flags]
       --log-level loglevel      Specify the loglevel for the program (default info)
       --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
   -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_vm_create.md
+++ b/docs/cli/ignite/ignite_vm_create.md
@@ -54,6 +54,7 @@ ignite vm create <OCI image> [flags]
       --log-level loglevel      Specify the loglevel for the program (default info)
       --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
   -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_vm_kill.md
+++ b/docs/cli/ignite/ignite_vm_kill.md
@@ -26,6 +26,7 @@ ignite vm kill <vm>... [flags]
       --log-level loglevel      Specify the loglevel for the program (default info)
       --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
   -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_vm_logs.md
+++ b/docs/cli/ignite/ignite_vm_logs.md
@@ -25,6 +25,7 @@ ignite vm logs <vm> [flags]
       --log-level loglevel      Specify the loglevel for the program (default info)
       --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
   -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_vm_ps.md
+++ b/docs/cli/ignite/ignite_vm_ps.md
@@ -26,6 +26,7 @@ ignite vm ps [flags]
       --log-level loglevel      Specify the loglevel for the program (default info)
       --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
   -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_vm_rm.md
+++ b/docs/cli/ignite/ignite_vm_rm.md
@@ -28,6 +28,7 @@ ignite vm rm <vm>... [flags]
       --log-level loglevel      Specify the loglevel for the program (default info)
       --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
   -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_vm_run.md
+++ b/docs/cli/ignite/ignite_vm_run.md
@@ -49,6 +49,7 @@ ignite vm run <OCI image> [flags]
       --log-level loglevel      Specify the loglevel for the program (default info)
       --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
   -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_vm_ssh.md
+++ b/docs/cli/ignite/ignite_vm_ssh.md
@@ -29,6 +29,7 @@ ignite vm ssh <vm> [flags]
       --log-level loglevel      Specify the loglevel for the program (default info)
       --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
   -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_vm_start.md
+++ b/docs/cli/ignite/ignite_vm_start.md
@@ -28,6 +28,7 @@ ignite vm start <vm> [flags]
       --log-level loglevel      Specify the loglevel for the program (default info)
       --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
   -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_vm_stop.md
+++ b/docs/cli/ignite/ignite_vm_stop.md
@@ -31,6 +31,7 @@ ignite vm stop <vm>... [flags]
       --log-level loglevel      Specify the loglevel for the program (default info)
       --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
   -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignited/ignited.md
+++ b/docs/cli/ignited/ignited.md
@@ -17,6 +17,7 @@ TODO: ignited documentation
   -h, --help                    help for ignited
       --log-level loglevel      Specify the loglevel for the program (default info)
       --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignited/ignited_completion.md
+++ b/docs/cli/ignited/ignited_completion.md
@@ -29,6 +29,7 @@ ignited completion [flags]
 ```
       --log-level loglevel      Specify the loglevel for the program (default info)
       --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignited/ignited_daemon.md
+++ b/docs/cli/ignited/ignited_daemon.md
@@ -21,6 +21,7 @@ ignited daemon [flags]
 ```
       --log-level loglevel      Specify the loglevel for the program (default info)
       --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignited/ignited_gitops.md
+++ b/docs/cli/ignited/ignited_gitops.md
@@ -31,6 +31,7 @@ ignited gitops <repo-url> [flags]
 ```
       --log-level loglevel      Specify the loglevel for the program (default info)
       --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignited/ignited_version.md
+++ b/docs/cli/ignited/ignited_version.md
@@ -22,6 +22,7 @@ ignited version [flags]
 ```
       --log-level loglevel      Specify the loglevel for the program (default info)
       --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
 ```
 
 ### SEE ALSO

--- a/hack/cobra.go
+++ b/hack/cobra.go
@@ -15,7 +15,8 @@ import (
 )
 
 func main() {
-	if err := providers.Populate(ignite.Providers); err != nil {
+	// Only preloaded providers are needed
+	if err := providers.Populate(ignite.Preload); err != nil {
 		log.Fatal(err)
 	}
 
@@ -28,6 +29,7 @@ func main() {
 		if err := doc.GenMarkdownTree(cmd, fmt.Sprintf("./docs/cli/%s", name)); err != nil {
 			log.Fatal(err)
 		}
+
 		sedCmd := fmt.Sprintf(`sed -e "/Auto generated/d" -i docs/cli/%s/*.md`, name)
 		if output, err := exec.Command("/bin/bash", "-c", sedCmd).CombinedOutput(); err != nil {
 			log.Fatal(string(output), err)

--- a/pkg/network/flag/networkflag.go
+++ b/pkg/network/flag/networkflag.go
@@ -39,8 +39,3 @@ var _ pflag.Value = &NetworkPluginFlag{}
 func NetworkPluginVar(fs *pflag.FlagSet, ptr *network.PluginName) {
 	fs.Var(&NetworkPluginFlag{value: ptr}, "network-plugin", fmt.Sprintf("Network plugin to use. Available options are: %v", plugins))
 }
-
-// RegisterNetworkPluginFlag binds network.ActivePlugin to the --network-plugin flag
-func RegisterNetworkPluginFlag(fs *pflag.FlagSet) {
-	NetworkPluginVar(fs, &network.ActivePlugin)
-}

--- a/pkg/network/types.go
+++ b/pkg/network/types.go
@@ -41,10 +41,6 @@ func (pn PluginName) String() string {
 	return string(pn)
 }
 
-// ActivePlugin is set at runtime to the plugin that is chosen to be active.
-// The default mode is docker-bridge
-var ActivePlugin = PluginDockerBridge
-
 const (
 	// PluginCNI specifies the network mode where CNI is used
 	PluginCNI PluginName = "cni"

--- a/pkg/providers/cni/network.go
+++ b/pkg/providers/cni/network.go
@@ -8,10 +8,6 @@ import (
 
 func SetCNINetworkPlugin() (err error) {
 	log.Trace("Initializing the CNI provider...")
-	plugin, err := cni.GetCNINetworkPlugin(providers.Runtime)
-	if err != nil {
-		return err
-	}
-	providers.NetworkPlugins[plugin.Name()] = plugin
+	providers.NetworkPlugin, err = cni.GetCNINetworkPlugin(providers.Runtime)
 	return
 }

--- a/pkg/providers/containerd/runtime.go
+++ b/pkg/providers/containerd/runtime.go
@@ -3,11 +3,11 @@ package containerd
 import (
 	log "github.com/sirupsen/logrus"
 	"github.com/weaveworks/ignite/pkg/providers"
-	runtime "github.com/weaveworks/ignite/pkg/runtime/containerd"
+	containerdruntime "github.com/weaveworks/ignite/pkg/runtime/containerd"
 )
 
 func SetContainerdRuntime() (err error) {
 	log.Trace("Initializing the containerd runtime provider...")
-	providers.Runtime, err = runtime.GetContainerdClient()
+	providers.Runtime, err = containerdruntime.GetContainerdClient()
 	return
 }

--- a/pkg/providers/docker/network.go
+++ b/pkg/providers/docker/network.go
@@ -1,0 +1,21 @@
+package docker
+
+import (
+	"fmt"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/weaveworks/ignite/pkg/network"
+	dockernetwork "github.com/weaveworks/ignite/pkg/network/docker"
+	"github.com/weaveworks/ignite/pkg/providers"
+	"github.com/weaveworks/ignite/pkg/runtime"
+)
+
+func SetDockerNetwork() error {
+	log.Trace("Initializing the Docker network provider...")
+	if providers.Runtime.Name() != runtime.RuntimeDocker {
+		return fmt.Errorf("the %q network plugin can only be used with the %q runtime", network.PluginDockerBridge, runtime.RuntimeDocker)
+	}
+
+	providers.NetworkPlugin = dockernetwork.GetDockerNetworkPlugin(providers.Runtime)
+	return nil
+}

--- a/pkg/providers/docker/runtime.go
+++ b/pkg/providers/docker/runtime.go
@@ -2,20 +2,12 @@ package docker
 
 import (
 	log "github.com/sirupsen/logrus"
-	network "github.com/weaveworks/ignite/pkg/network/docker"
 	"github.com/weaveworks/ignite/pkg/providers"
-	runtime "github.com/weaveworks/ignite/pkg/runtime/docker"
+	dockerruntime "github.com/weaveworks/ignite/pkg/runtime/docker"
 )
 
 func SetDockerRuntime() (err error) {
 	log.Trace("Initializing the Docker runtime provider...")
-	providers.Runtime, err = runtime.GetDockerClient()
+	providers.Runtime, err = dockerruntime.GetDockerClient()
 	return
-}
-
-func SetDockerNetwork() error {
-	log.Trace("Initializing the Docker network provider...")
-	plugin := network.GetDockerNetworkPlugin(providers.Runtime)
-	providers.NetworkPlugins[plugin.Name()] = plugin
-	return nil
 }

--- a/pkg/providers/ignite/providers.go
+++ b/pkg/providers/ignite/providers.go
@@ -3,20 +3,20 @@ package ignite
 import (
 	"github.com/weaveworks/ignite/pkg/providers"
 	clientprovider "github.com/weaveworks/ignite/pkg/providers/client"
-	cniprovider "github.com/weaveworks/ignite/pkg/providers/cni"
-
-	//containerdprovider "github.com/weaveworks/ignite/pkg/providers/containerd"
-	dockerprovider "github.com/weaveworks/ignite/pkg/providers/docker"
+	"github.com/weaveworks/ignite/pkg/providers/network"
+	"github.com/weaveworks/ignite/pkg/providers/runtime"
 	storageprovider "github.com/weaveworks/ignite/pkg/providers/storage"
 )
+
+// Preload providers need to be loaded before flag parsing has finished
+var Preload = []providers.ProviderInitFunc{
+	storageprovider.SetGenericStorage, // Use a generic storage implementation backed by a cache
+	clientprovider.SetClient,          // Set the globally available client
+}
 
 // NOTE: Provider initialization is order-dependent!
 // E.g. the network plugin depends on the runtime.
 var Providers = []providers.ProviderInitFunc{
-	dockerprovider.SetDockerRuntime, // Use the Docker runtime
-	//containerdprovider.SetContainerdRuntime, // Use the containerd runtime
-	dockerprovider.SetDockerNetwork,   // Use the Docker bridge network
-	cniprovider.SetCNINetworkPlugin,   // Use the CNI Network plugin
-	storageprovider.SetGenericStorage, // Use a generic storage implementation backed by a cache
-	clientprovider.SetClient,          // Set the globally available client
+	runtime.SetRuntime,       // Set the selected runtime
+	network.SetNetworkPlugin, // Set the selected network plugin
 }

--- a/pkg/providers/ignited/providers.go
+++ b/pkg/providers/ignited/providers.go
@@ -3,20 +3,20 @@ package ignited
 import (
 	"github.com/weaveworks/ignite/pkg/providers"
 	clientprovider "github.com/weaveworks/ignite/pkg/providers/client"
-	cniprovider "github.com/weaveworks/ignite/pkg/providers/cni"
-
-	//containerdprovider "github.com/weaveworks/ignite/pkg/providers/containerd"
-	dockerprovider "github.com/weaveworks/ignite/pkg/providers/docker"
 	manifeststorageprovider "github.com/weaveworks/ignite/pkg/providers/manifeststorage"
+	"github.com/weaveworks/ignite/pkg/providers/network"
+	"github.com/weaveworks/ignite/pkg/providers/runtime"
 )
+
+// Preload providers need to be loaded before flag parsing has finished
+var Preload = []providers.ProviderInitFunc{
+	manifeststorageprovider.SetManifestStorage, // Use the ManifestStorage implementation, backed by a cache
+	clientprovider.SetClient,                   // Set the globally available client
+}
 
 // NOTE: Provider initialization is order-dependent!
 // E.g. the network plugin depends on the runtime.
 var Providers = []providers.ProviderInitFunc{
-	dockerprovider.SetDockerRuntime, // Use the Docker runtime
-	//containerdprovider.SetContainerdRuntime,  // Use the containerd runtime
-	dockerprovider.SetDockerNetwork,            // Use the Docker bridge network
-	cniprovider.SetCNINetworkPlugin,            // Use the CNI Network plugin
-	manifeststorageprovider.SetManifestStorage, // Use the ManifestStorage implementation, backed by a cache
-	clientprovider.SetClient,                   // Set the globally available client
+	runtime.SetRuntime,       // Set the selected runtime
+	network.SetNetworkPlugin, // Set the selected network plugin
 }

--- a/pkg/providers/network/networkplugin.go
+++ b/pkg/providers/network/networkplugin.go
@@ -1,0 +1,21 @@
+package network
+
+import (
+	"fmt"
+
+	"github.com/weaveworks/ignite/pkg/network"
+	"github.com/weaveworks/ignite/pkg/providers"
+	cniprovider "github.com/weaveworks/ignite/pkg/providers/cni"
+	dockerprovider "github.com/weaveworks/ignite/pkg/providers/docker"
+)
+
+func SetNetworkPlugin() error {
+	switch providers.NetworkPluginName {
+	case network.PluginDockerBridge:
+		return dockerprovider.SetDockerNetwork() // Use the Docker bridge network
+	case network.PluginCNI:
+		return cniprovider.SetCNINetworkPlugin() // Use the CNI Network plugin
+	}
+
+	return fmt.Errorf("unknown network plugin %q", providers.NetworkPluginName)
+}

--- a/pkg/providers/providers.go
+++ b/pkg/providers/providers.go
@@ -8,14 +8,20 @@ import (
 	"github.com/weaveworks/ignite/pkg/runtime"
 )
 
-// NetworkPlugins provides the initialized network plugins indexed by their name
-var NetworkPlugins = make(map[network.PluginName]network.Plugin)
+// NetworkPluginName binds to the global flag to select the network plugin
+// The default network plugin is "docker-bridge"
+var NetworkPluginName = network.PluginDockerBridge
 
 // NetworkPlugin provides the chosen network plugin that should be used
-// This should be set after parsing user input on what network mode to use
+// This should be set after parsing user input on what network plugin to use
 var NetworkPlugin network.Plugin
 
-// Runtime provides the container runtime for retrieving OCI images and running VM containers
+// RuntimeName binds to the global flag to select the container runtime
+// The default runtime is "docker"
+var RuntimeName = runtime.RuntimeDocker
+
+// Runtime provides the chosen container runtime for retrieving OCI images and running VM containers
+// This should be set after parsing user input on what runtime to use
 var Runtime runtime.Interface
 
 // Client is the default client that can be easily used
@@ -26,11 +32,10 @@ var Storage storage.Storage
 
 type ProviderInitFunc func() error
 
-// Populate initializes all providers
+// Populate initializes all given providers
 func Populate(providers []ProviderInitFunc) error {
 	log.Trace("Populating providers...")
-	for i, init := range providers {
-		log.Tracef("Provider %d...", i)
+	for _, init := range providers {
 		if err := init(); err != nil {
 			return err
 		}

--- a/pkg/providers/runtime/runtime.go
+++ b/pkg/providers/runtime/runtime.go
@@ -1,0 +1,21 @@
+package runtime
+
+import (
+	"fmt"
+
+	"github.com/weaveworks/ignite/pkg/providers"
+	containerdprovider "github.com/weaveworks/ignite/pkg/providers/containerd"
+	dockerprovider "github.com/weaveworks/ignite/pkg/providers/docker"
+	"github.com/weaveworks/ignite/pkg/runtime"
+)
+
+func SetRuntime() error {
+	switch providers.RuntimeName {
+	case runtime.RuntimeDocker:
+		return dockerprovider.SetDockerRuntime() // Use the Docker runtime
+	case runtime.RuntimeContainerd:
+		return containerdprovider.SetContainerdRuntime() // Use the containerd runtime
+	}
+
+	return fmt.Errorf("unknown runtime %q", providers.RuntimeName)
+}

--- a/pkg/runtime/containerd/client.go
+++ b/pkg/runtime/containerd/client.go
@@ -45,6 +45,8 @@ var _ runtime.Interface = &ctdClient{}
 
 // GetContainerdClient builds a client for talking to containerd
 func GetContainerdClient() (*ctdClient, error) {
+	log.Warn("The containerd runtime is unstable/incomplete, here be dragons")
+
 	cli, err := containerd.New(ctdSocket)
 	if err != nil {
 		return nil, err
@@ -489,6 +491,10 @@ func (cc *ctdClient) RemoveContainer(container string) error {
 func (cc *ctdClient) ContainerLogs(container string) (io.ReadCloser, error) {
 	// TODO: Implement logs for containerd
 	return nil, unsupported("logs")
+}
+
+func (cc *ctdClient) Name() runtime.Name {
+	return runtime.RuntimeContainerd
 }
 
 func (cc *ctdClient) RawClient() interface{} {

--- a/pkg/runtime/docker/client.go
+++ b/pkg/runtime/docker/client.go
@@ -37,10 +37,6 @@ func GetDockerClient() (*dockerClient, error) {
 	}, nil
 }
 
-func (dc *dockerClient) RawClient() interface{} {
-	return dc.client
-}
-
 func (dc *dockerClient) PullImage(image meta.OCIImageRef) (err error) {
 	var rc io.ReadCloser
 	if rc, err = dc.client.ImagePull(context.Background(), image.Normalized(), types.ImagePullOptions{}); err == nil {
@@ -213,6 +209,14 @@ func (dc *dockerClient) ContainerLogs(container string) (io.ReadCloser, error) {
 	return dc.client.ContainerLogs(context.Background(), container, types.ContainerLogsOptions{
 		ShowStdout: true, // We only need stdout, as TTY mode merges stderr into it
 	})
+}
+
+func (cc *dockerClient) Name() runtime.Name {
+	return runtime.RuntimeDocker
+}
+
+func (dc *dockerClient) RawClient() interface{} {
+	return dc.client
 }
 
 func (dc *dockerClient) waitForContainer(container string, condition cont.WaitCondition, readyC *chan struct{}) error {

--- a/pkg/runtime/flag/runtimeflag.go
+++ b/pkg/runtime/flag/runtimeflag.go
@@ -1,0 +1,43 @@
+package flag
+
+import (
+	"fmt"
+
+	"github.com/spf13/pflag"
+	"github.com/weaveworks/ignite/pkg/runtime"
+)
+
+var runtimes = runtime.ListRuntimes()
+
+type RuntimeFlag struct {
+	value *runtime.Name
+}
+
+func (nf *RuntimeFlag) Set(val string) error {
+	for _, r := range runtimes {
+		if r.String() == val {
+			*nf.value = r
+			return nil
+		}
+	}
+
+	return fmt.Errorf("invalid runtime %q, must be one of %v", val, runtimes)
+}
+
+func (nf *RuntimeFlag) String() string {
+	if nf.value == nil {
+		return ""
+	}
+
+	return nf.value.String()
+}
+
+func (nf *RuntimeFlag) Type() string {
+	return "runtime"
+}
+
+var _ pflag.Value = &RuntimeFlag{}
+
+func RuntimeVar(fs *pflag.FlagSet, ptr *runtime.Name) {
+	fs.Var(&RuntimeFlag{value: ptr}, "runtime", fmt.Sprintf("Container runtime to use. Available options are: %v", runtimes))
+}

--- a/pkg/runtime/types.go
+++ b/pkg/runtime/types.go
@@ -1,6 +1,7 @@
 package runtime
 
 import (
+	"fmt"
 	"io"
 	"net"
 	"time"
@@ -60,5 +61,30 @@ type Interface interface {
 	RemoveContainer(container string) error
 	ContainerLogs(container string) (io.ReadCloser, error)
 
+	Name() Name
 	RawClient() interface{}
+}
+
+// Name defines a name for a runtime
+type Name string
+
+var _ fmt.Stringer = Name("")
+
+func (n Name) String() string {
+	return string(n)
+}
+
+const (
+	// RuntimeDocker specifies the Docker runtime
+	RuntimeDocker Name = "docker"
+	// RuntimeContainerd specifies the containerd runtime
+	RuntimeContainerd Name = "containerd"
+)
+
+// ListRuntimes gets the list of available runtimes
+func ListRuntimes() []Name {
+	return []Name{
+		RuntimeDocker,
+		RuntimeContainerd,
+	}
 }


### PR DESCRIPTION
- Adds a `--runtime` flag to select which runtime to use similar to the `--network-plugin` flag.
- Providers are loaded on-demand instead of always initializing everything.
- Added a check to fail if the `docker-network` plugin is used with a runtime other than `docker`.
- Added a warning for the `containerd` runtime being unstable/incomplete.