### PR TITLE
add err as a param for log.Errorf

### DIFF
--- a/pkg/gitops/gitdir/gitdir.go
+++ b/pkg/gitops/gitdir/gitdir.go
@@ -176,7 +176,7 @@ func (d *GitDirectory) commitLoop() error {
 
 		files, err := d.checkout.ChangedFiles(context.Background(), d.branch)
 		if err != nil {
-			log.Errorf("couldn't get changed files: %v")
+			log.Errorf("couldn't get changed files: %v", err)
 			continue
 		}
 


### PR DESCRIPTION
Add `err` as a param for `log.Errorf`.