### PR TITLE
fix unnecessary commit

### DIFF
--- a/pkg/gitops/gitdir/gitdir.go
+++ b/pkg/gitops/gitdir/gitdir.go
@@ -174,7 +174,7 @@ func (d *GitDirectory) commitLoop() error {
 			continue
 		}
 
-		files, err := d.checkout.ChangedFiles(context.Background(), d.branch)
+		files, err := d.checkout.ChangedFiles(context.Background(), d.lastCommit)
 		if err != nil {
 			log.Errorf("couldn't get changed files: %v")
 			continue


### PR DESCRIPTION
I have met an error when using gitops. Here are the steps to reproduce the error.

1. create a github repo and use ignited to watch the repo
2. add a yaml file like [gitops sample code](https://github.com/weaveworks/ignite/blob/master/docs/gitops.md#try-it-out) to git repo
3. ignited creates a new vm, and update the yaml and commit&push to git
4. in the git repo dir, update the yaml, change the diskSize to 4GB, and git add&commit&push to master branch
5. ignited do updated the vm, but it exits.

here is the log when ignited exits:

```
INFO[0214] New commit observed on branch "master": 32979b36abdbadd445fd949f4442728ef8eed5a0. User initiated: true
FATA[0215] The GitOps commit loop terminated with an error git commit and/or push error: no changes made in repo
```

There is nothing to commit, but ignited still try to commit and push, and caused the error.

I think the code below maybe is the spot:

```go
func (d *GitDirectory) commitLoop() error {
...
		files, err := d.checkout.ChangedFiles(context.Background(), d. branch)
```

It equals to `git  diff --name-only --diff-filter=ACMRT master --`. In the tmp dir like `/tmp/flux-working259394949`, this command always output `git-vm.yaml`, no matter I update the yaml file or not.

Is it better to use `d.lastCommit` as ref? It do fix my problem.
