### PR TITLE
Make containerd the default runtime and CNI the default network plugin

### DIFF
--- a/docs/cli/ignite/ignite.md
+++ b/docs/cli/ignite/ignite.md
@@ -35,9 +35,9 @@ Example usage:
 ```
   -h, --help                    help for ignite
       --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
+      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
   -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_attach.md
+++ b/docs/cli/ignite/ignite_attach.md
@@ -24,9 +24,9 @@ ignite attach <vm> [flags]
 
 ```
       --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
+      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
   -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_completion.md
+++ b/docs/cli/ignite/ignite_completion.md
@@ -28,9 +28,9 @@ ignite completion [flags]
 
 ```
       --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
+      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
   -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_create.md
+++ b/docs/cli/ignite/ignite_create.md
@@ -52,9 +52,9 @@ ignite create <OCI image> [flags]
 
 ```
       --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
+      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
   -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_exec.md
+++ b/docs/cli/ignite/ignite_exec.md
@@ -27,9 +27,9 @@ ignite exec <vm> <command...> [flags]
 
 ```
       --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
+      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
   -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_image.md
+++ b/docs/cli/ignite/ignite_image.md
@@ -23,9 +23,9 @@ ignite image [flags]
 
 ```
       --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
+      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
   -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_image_import.md
+++ b/docs/cli/ignite/ignite_image_import.md
@@ -24,9 +24,9 @@ ignite image import <OCI image> [flags]
 
 ```
       --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
+      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
   -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_image_ls.md
+++ b/docs/cli/ignite/ignite_image_ls.md
@@ -22,9 +22,9 @@ ignite image ls [flags]
 
 ```
       --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
+      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
   -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_image_rm.md
+++ b/docs/cli/ignite/ignite_image_rm.md
@@ -25,9 +25,9 @@ ignite image rm <image>... [flags]
 
 ```
       --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
+      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
   -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_inspect.md
+++ b/docs/cli/ignite/ignite_inspect.md
@@ -26,9 +26,9 @@ ignite inspect <kind> <object> [flags]
 
 ```
       --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
+      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
   -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_kernel.md
+++ b/docs/cli/ignite/ignite_kernel.md
@@ -23,9 +23,9 @@ ignite kernel [flags]
 
 ```
       --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
+      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
   -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_kernel_import.md
+++ b/docs/cli/ignite/ignite_kernel_import.md
@@ -24,9 +24,9 @@ ignite kernel import <OCI image> [flags]
 
 ```
       --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
+      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
   -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_kernel_ls.md
+++ b/docs/cli/ignite/ignite_kernel_ls.md
@@ -22,9 +22,9 @@ ignite kernel ls [flags]
 
 ```
       --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
+      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
   -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_kernel_rm.md
+++ b/docs/cli/ignite/ignite_kernel_rm.md
@@ -25,9 +25,9 @@ ignite kernel rm <kernel>... [flags]
 
 ```
       --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
+      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
   -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_kill.md
+++ b/docs/cli/ignite/ignite_kill.md
@@ -24,9 +24,9 @@ ignite kill <vm>... [flags]
 
 ```
       --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
+      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
   -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_logs.md
+++ b/docs/cli/ignite/ignite_logs.md
@@ -23,9 +23,9 @@ ignite logs <vm> [flags]
 
 ```
       --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
+      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
   -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_ps.md
+++ b/docs/cli/ignite/ignite_ps.md
@@ -24,9 +24,9 @@ ignite ps [flags]
 
 ```
       --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
+      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
   -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_rm.md
+++ b/docs/cli/ignite/ignite_rm.md
@@ -26,9 +26,9 @@ ignite rm <vm>... [flags]
 
 ```
       --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
+      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
   -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_rmi.md
+++ b/docs/cli/ignite/ignite_rmi.md
@@ -25,9 +25,9 @@ ignite rmi <image> [flags]
 
 ```
       --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
+      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
   -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_rmk.md
+++ b/docs/cli/ignite/ignite_rmk.md
@@ -25,9 +25,9 @@ ignite rmk <kernel> [flags]
 
 ```
       --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
+      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
   -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_run.md
+++ b/docs/cli/ignite/ignite_run.md
@@ -47,9 +47,9 @@ ignite run <OCI image> [flags]
 
 ```
       --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
+      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
   -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_ssh.md
+++ b/docs/cli/ignite/ignite_ssh.md
@@ -27,9 +27,9 @@ ignite ssh <vm> [flags]
 
 ```
       --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
+      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
   -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_start.md
+++ b/docs/cli/ignite/ignite_start.md
@@ -26,9 +26,9 @@ ignite start <vm> [flags]
 
 ```
       --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
+      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
   -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_stop.md
+++ b/docs/cli/ignite/ignite_stop.md
@@ -29,9 +29,9 @@ ignite stop <vm>... [flags]
 
 ```
       --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
+      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
   -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_version.md
+++ b/docs/cli/ignite/ignite_version.md
@@ -21,9 +21,9 @@ ignite version [flags]
 
 ```
       --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
+      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
   -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_vm.md
+++ b/docs/cli/ignite/ignite_vm.md
@@ -22,9 +22,9 @@ ignite vm [flags]
 
 ```
       --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
+      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
   -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_vm_attach.md
+++ b/docs/cli/ignite/ignite_vm_attach.md
@@ -24,9 +24,9 @@ ignite vm attach <vm> [flags]
 
 ```
       --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
+      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
   -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_vm_create.md
+++ b/docs/cli/ignite/ignite_vm_create.md
@@ -52,9 +52,9 @@ ignite vm create <OCI image> [flags]
 
 ```
       --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
+      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
   -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_vm_kill.md
+++ b/docs/cli/ignite/ignite_vm_kill.md
@@ -24,9 +24,9 @@ ignite vm kill <vm>... [flags]
 
 ```
       --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
+      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
   -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_vm_logs.md
+++ b/docs/cli/ignite/ignite_vm_logs.md
@@ -23,9 +23,9 @@ ignite vm logs <vm> [flags]
 
 ```
       --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
+      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
   -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_vm_ps.md
+++ b/docs/cli/ignite/ignite_vm_ps.md
@@ -24,9 +24,9 @@ ignite vm ps [flags]
 
 ```
       --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
+      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
   -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_vm_rm.md
+++ b/docs/cli/ignite/ignite_vm_rm.md
@@ -26,9 +26,9 @@ ignite vm rm <vm>... [flags]
 
 ```
       --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
+      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
   -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_vm_run.md
+++ b/docs/cli/ignite/ignite_vm_run.md
@@ -47,9 +47,9 @@ ignite vm run <OCI image> [flags]
 
 ```
       --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
+      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
   -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_vm_ssh.md
+++ b/docs/cli/ignite/ignite_vm_ssh.md
@@ -27,9 +27,9 @@ ignite vm ssh <vm> [flags]
 
 ```
       --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
+      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
   -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_vm_start.md
+++ b/docs/cli/ignite/ignite_vm_start.md
@@ -26,9 +26,9 @@ ignite vm start <vm> [flags]
 
 ```
       --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
+      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
   -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_vm_stop.md
+++ b/docs/cli/ignite/ignite_vm_stop.md
@@ -29,9 +29,9 @@ ignite vm stop <vm>... [flags]
 
 ```
       --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
+      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
   -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignited/ignited.md
+++ b/docs/cli/ignited/ignited.md
@@ -16,8 +16,8 @@ TODO: ignited documentation
 ```
   -h, --help                    help for ignited
       --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
+      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignited/ignited_completion.md
+++ b/docs/cli/ignited/ignited_completion.md
@@ -28,8 +28,8 @@ ignited completion [flags]
 
 ```
       --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
+      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignited/ignited_daemon.md
+++ b/docs/cli/ignited/ignited_daemon.md
@@ -20,8 +20,8 @@ ignited daemon [flags]
 
 ```
       --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
+      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignited/ignited_gitops.md
+++ b/docs/cli/ignited/ignited_gitops.md
@@ -30,8 +30,8 @@ ignited gitops <repo-url> [flags]
 
 ```
       --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
+      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignited/ignited_version.md
+++ b/docs/cli/ignited/ignited_version.md
@@ -21,8 +21,8 @@ ignited version [flags]
 
 ```
       --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default docker-bridge)
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default docker)
+      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
+      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
 ```
 
 ### SEE ALSO

--- a/pkg/providers/providers.go
+++ b/pkg/providers/providers.go
@@ -9,16 +9,16 @@ import (
 )
 
 // NetworkPluginName binds to the global flag to select the network plugin
-// The default network plugin is "docker-bridge"
-var NetworkPluginName = network.PluginDockerBridge
+// The default network plugin is "cni"
+var NetworkPluginName = network.PluginCNI
 
 // NetworkPlugin provides the chosen network plugin that should be used
 // This should be set after parsing user input on what network plugin to use
 var NetworkPlugin network.Plugin
 
 // RuntimeName binds to the global flag to select the container runtime
-// The default runtime is "docker"
-var RuntimeName = runtime.RuntimeDocker
+// The default runtime is "containerd"
+var RuntimeName = runtime.RuntimeContainerd
 
 // Runtime provides the chosen container runtime for retrieving OCI images and running VM containers
 // This should be set after parsing user input on what runtime to use


### PR DESCRIPTION
The `docker` runtime and `docker-bridge` network plugin can still be accessed via flags if needed. This change is made as the `containerd` backend is now feature complete, and moves Ignite towards independence from the Docker daemon. Make sure to report any bugs/issues you encounter with the containerd runtime.

cc @luxas 