### PR TITLE
Move VM network removal to logically correct place

### DIFF
--- a/pkg/network/cni/cni.go
+++ b/pkg/network/cni/cni.go
@@ -134,13 +134,13 @@ func cniToIgniteResult(r *gocni.CNIResult) *network.Result {
 	return result
 }
 
-func (plugin *cniNetworkPlugin) RemoveContainerNetwork(containerid string) error {
+func (plugin *cniNetworkPlugin) RemoveContainerNetwork(containerID string) error {
 	if err := plugin.initialize(); err != nil {
 		return err
 	}
 
 	// Lack of namespace should not be fatal on teardown
-	c, err := plugin.runtime.InspectContainer(containerid)
+	c, err := plugin.runtime.InspectContainer(containerID)
 	if err != nil {
 		log.Infof("CNI failed to retrieve network namespace path: %v", err)
 		return nil
@@ -152,5 +152,5 @@ func (plugin *cniNetworkPlugin) RemoveContainerNetwork(containerid string) error
 		return nil
 	}
 
-	return plugin.cni.Remove(context.Background(), containerid, netnsPath)
+	return plugin.cni.Remove(context.Background(), containerID, netnsPath)
 }

--- a/pkg/operations/start.go
+++ b/pkg/operations/start.go
@@ -23,9 +23,7 @@ import (
 func StartVM(vm *api.VM, debug bool) error {
 	// Inspect the VM container and remove it if it exists
 	inspectResult, _ := providers.Runtime.InspectContainer(util.NewPrefixer().Prefix(vm.GetUID()))
-	if err := RemoveVMContainer(inspectResult); err != nil {
-		return err
-	}
+	RemoveVMContainer(inspectResult)
 
 	// Setup the snapshot overlay filesystem
 	if err := dmlegacy.ActivateSnapshot(vm); err != nil {

--- a/pkg/runtime/containerd/client.go
+++ b/pkg/runtime/containerd/client.go
@@ -199,7 +199,7 @@ func (cc *ctdClient) InspectContainer(container string) (*runtime.ContainerInspe
 		return nil, err
 	}
 
-	t, err := cont.Task(cc.ctx, nil)
+	task, err := cont.Task(cc.ctx, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -209,21 +209,12 @@ func (cc *ctdClient) InspectContainer(container string) (*runtime.ContainerInspe
 		return nil, err
 	}
 
-	pids, err := t.Pids(cc.ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	if len(pids) == 0 {
-		return nil, fmt.Errorf("no running tasks found for container %q", container)
-	}
-
 	return &runtime.ContainerInspectResult{
 		ID:        info.ID,
-		Image:     info.Image,  // TODO: This may be incorrect
-		Status:    "",          // TODO: This
-		IPAddress: nil,         // TODO: This, containerd only supports CNI
-		PID:       pids[0].Pid, // TODO: This should respect multiple tasks, we need a way to identify ignite-spawn
+		Image:     info.Image, // TODO: This may be incorrect
+		Status:    "",         // TODO: This
+		IPAddress: nil,        // TODO: This, containerd only supports CNI
+		PID:       task.Pid(),
 	}, nil
 }
 


### PR DESCRIPTION
Enables `cni` to remove VM networks correctly.

cc @luxas 