### PR TITLE
fix possible dm snapshot leaks

### DIFF
--- a/pkg/dmlegacy/vm.go
+++ b/pkg/dmlegacy/vm.go
@@ -83,16 +83,17 @@ func AllocateAndPopulateOverlay(vm *api.VM) error {
 }
 
 func copyToOverlay(vm *api.VM) error {
-	if err := ActivateSnapshot(vm); err != nil {
-		return err
-	}
+	err := ActivateSnapshot(vm)
 	defer cleanup.DeactivateSnapshot(vm)
-
-	mp, err := util.Mount(vm.SnapshotDev())
 	if err != nil {
 		return err
 	}
+
+	mp, err := util.Mount(vm.SnapshotDev())
 	defer mp.Umount()
+	if err != nil {
+		return err
+	}
 
 	// Copy the kernel files to the VM. TODO: Use snapshot overlaying instead.
 	if err := copyKernelToOverlay(vm, mp.Path); err != nil {


### PR DESCRIPTION
There are some defers that won't be called if an error occurred by `ActivateSnapshot`.
It's gonna defer to `DeactivateSnapshot` anyway even if `ActivateSnapshot` return an error.

Signed-off-by: Chanwit Kaewkasi <chanwit@gmail.com>