### PR TITLE
default cni network does not support multi-node

### DIFF
--- a/docs/networking.md
+++ b/docs/networking.md
@@ -23,7 +23,6 @@ Automatically installed to `/etc/cni/net.d/10-ignite.conflist` unless you have p
 
 **Pros:**
 
-- **Multi-node support**: CNI implementations can often route packets between multiple physical hosts. External computers can access the VM's IP.
 - **Kubernetes-compatible**: You can use the same overlay networks as you use with Kubernetes, and hence get your VMs on the same network as your containers.
 - **Port mapping support**: This mode supports port mappings from the VM to the host
 


### PR DESCRIPTION
If the network is default cni, I think we cannot access vm's IIP from other computers as the IP is like `172.18.0.0/16`.