### PR TITLE
use image weaveworks/ubuntu instead of centos:7 in command examples

### DIFF
--- a/cmd/ignite/cmd/root.go
+++ b/cmd/ignite/cmd/root.go
@@ -56,7 +56,7 @@ func NewIgniteCommand(in io.Reader, out, err io.Writer) *cobra.Command {
 
 			Example usage:
 
-				$ ignite run centos:7 \
+				$ ignite run weaveworks/ignite-ubuntu \
 					--cpus 2 \
 					--memory 2GB \
 					--ssh \

--- a/cmd/ignite/cmd/vmcmd/create.go
+++ b/cmd/ignite/cmd/vmcmd/create.go
@@ -34,7 +34,7 @@ func NewCmdCreate(out io.Writer) *cobra.Command {
 			/host/path:/vm/path.
 
 			Example usage:
-				$ ignite create centos:7 \
+				$ ignite create weaveworks/ignite-ubuntu \
 					--name my-vm \
 					--cpus 2 \
 					--ssh \

--- a/cmd/ignite/cmd/vmcmd/run.go
+++ b/cmd/ignite/cmd/vmcmd/run.go
@@ -27,7 +27,7 @@ func NewCmdRun(out io.Writer) *cobra.Command {
 			specified to immediately attach to the started VM after creation.
 
 			Example usage:
-				$ ignite run centos:7 \
+				$ ignite run weaveworks/ignite-ubuntu \
 					--interactive \
 					--name my-vm \
 					--cpus 2 \

--- a/docs/cli/ignite/ignite.md
+++ b/docs/cli/ignite/ignite.md
@@ -18,7 +18,7 @@ Combining an Image and a Kernel gives you a runnable VM.
 
 Example usage:
 
-	$ ignite run centos:7 \
+	$ ignite run weaveworks/ignite-ubuntu \
 		--cpus 2 \
 		--memory 2GB \
 		--ssh \

--- a/docs/cli/ignite/ignite_create.md
+++ b/docs/cli/ignite/ignite_create.md
@@ -19,7 +19,7 @@ can be added to the VM during creation with the syntax
 /host/path:/vm/path.
 
 Example usage:
-	$ ignite create centos:7 \
+	$ ignite create weaveworks/ignite-ubuntu \
 		--name my-vm \
 		--cpus 2 \
 		--ssh \

--- a/docs/cli/ignite/ignite_run.md
+++ b/docs/cli/ignite/ignite_run.md
@@ -11,7 +11,7 @@ create and start a VM. The interactive flag (-i, --interactive) can be
 specified to immediately attach to the started VM after creation.
 
 Example usage:
-	$ ignite run centos:7 \
+	$ ignite run weaveworks/ignite-ubuntu \
 		--interactive \
 		--name my-vm \
 		--cpus 2 \

--- a/docs/cli/ignite/ignite_vm_create.md
+++ b/docs/cli/ignite/ignite_vm_create.md
@@ -19,7 +19,7 @@ can be added to the VM during creation with the syntax
 /host/path:/vm/path.
 
 Example usage:
-	$ ignite create centos:7 \
+	$ ignite create weaveworks/ignite-ubuntu \
 		--name my-vm \
 		--cpus 2 \
 		--ssh \

--- a/docs/cli/ignite/ignite_vm_run.md
+++ b/docs/cli/ignite/ignite_vm_run.md
@@ -11,7 +11,7 @@ create and start a VM. The interactive flag (-i, --interactive) can be
 specified to immediately attach to the started VM after creation.
 
 Example usage:
-	$ ignite run centos:7 \
+	$ ignite run weaveworks/ignite-ubuntu \
 		--interactive \
 		--name my-vm \
 		--cpus 2 \


### PR DESCRIPTION
The `centos:7` image does not include ssh server, so if I run:

```
	$ ignite run centos:7 \
		--interactive \
		--name my-vm \
		--cpus 2 \
		--ssh \
		--memory 2GB \
		--size 10G
```

As the image has no ssh server, I cannot ssh to the vm. Here is the steps.

```
# ignite  run centos:7 --interactive --cpus 1 --memory 4GB --ssh --name vm-centos
.....
# ignite ps
VM ID			IMAGE				KERNEL					SIZE	CPUS	MEMORY	CREATED	STATUS	IPSPORTS	NAME		vm-1
ef0bb86f13f9bcd5	centos:7			weaveworks/ignite-kernel:4.19.47	4.0 GB	1	4.0 GB	14s ago	Up 14s	172.18.0.11		vm-centos
# ignite ssh vm-centos
ssh: connect to host 172.18.0.11 port 22: Connection refused
WARN[0000] SSH command terminated
```

I think the `weaveworks/ignite-ubuntu` is a better choice, as mentioned [here](https://github.com/weaveworks/ignite/blob/edd7ee643d3a616b922d84f16fe4d5ebc37c190b/docs/usage.md#creating-a-new-vm-based-on-the-imported-image).