### PR TITLE
specify image of runtime when ignite run

### DIFF
--- a/pkg/source/docker.go
+++ b/pkg/source/docker.go
@@ -32,7 +32,7 @@ func (ds *DockerSource) Ref() meta.OCIImageRef {
 func (ds *DockerSource) Parse(ociRef meta.OCIImageRef) (*api.OCIImageSource, error) {
 	res, err := providers.Runtime.InspectImage(ociRef)
 	if err != nil {
-		log.Infof("Docker image %q not found locally, pulling...", ociRef)
+		log.Infof("%s image %q not found locally, pulling...", providers.Runtime.Name(), ociRef)
 		if err := providers.Runtime.PullImage(ociRef); err != nil {
 			return nil, err
 		}
@@ -43,7 +43,7 @@ func (ds *DockerSource) Parse(ociRef meta.OCIImageRef) (*api.OCIImageSource, err
 	}
 
 	if res.Size == 0 || res.ID == nil {
-		return nil, fmt.Errorf("parsing docker image %q data failed", ociRef)
+		return nil, fmt.Errorf("parsing %s image %q data failed", providers.Runtime.Name(), ociRef)
 	}
 
 	ds.imageRef = ociRef


### PR DESCRIPTION
ignite runtime  support both docker and containerd, we need to specify that in the logs.

For example, no matter I use docker runtime or containerd runtime, the log is always `Docker`.

```
# ignite --runtime docker run silenceshell/weave:docker2  --cpus 1 --memory 4GB --ssh --size 20GB --name vm-docker-2
INFO[0000] Docker image "silenceshell/weave:docker2" not found locally, pulling...
^C
# ignite --runtime containerd run silenceshell/weave:docker2  --cpus 1 --memory 4GB --ssh --size 20GB --name vm-docker-2
INFO[0000] Docker image "silenceshell/weave:docker2" not found locally, pulling...
^C
# ignite run silenceshell/weave:docker2  --cpus 1 --memory 4GB --ssh --size 20GB --name vm-docker-2
INFO[0000] Docker image "silenceshell/weave:docker2" not found locally, pulling...
```

Also the size checking needs a fix.