### PR TITLE
specify the minimum version of make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,8 @@
+MIN_MAKE_VERSION = 3.82
+ifneq ($(MIN_MAKE_VERSION), $(firstword $(sort $(MAKE_VERSION) $(MIN_MAKE_VERSION))))
+$(error this project requires make version $(MIN_MAKE_VERSION) or higher)
+endif
+
 SHELL:=/bin/bash
 UID_GID?=$(shell id -u):$(shell id -g)
 FIRECRACKER_VERSION:=$(shell cat hack/FIRECRACKER_VERSION)


### PR DESCRIPTION
fix #383

`undefine` (line 20) exists in GNU make 3.82 and higher, however on some os `make` is still 3.81 or even lower, for example macOS 10.14.

We should check make version in Makefile.
