### PR TITLE
show runtime name when ignite version

### DIFF
--- a/pkg/version/cmd/command.go
+++ b/pkg/version/cmd/command.go
@@ -6,6 +6,7 @@ import (
 	"io"
 
 	"github.com/spf13/cobra"
+	igniteruntime "github.com/weaveworks/ignite/pkg/runtime"
 	"github.com/weaveworks/ignite/pkg/util"
 	"github.com/weaveworks/ignite/pkg/version"
 	"sigs.k8s.io/yaml"
@@ -13,8 +14,9 @@ import (
 
 // versionData provides the version information of ignite.
 type versionData struct {
-	Ignite      version.Info `json:"igniteVersion"`
-	Firecracker version.Info `json:"firecrackerVersion"`
+	Ignite      version.Info       `json:"igniteVersion"`
+	Firecracker version.Info       `json:"firecrackerVersion"`
+	Runtime     igniteruntime.Name `json:"runtime"`
 }
 
 // NewCmdVersion provides the version information of ignite
@@ -39,12 +41,14 @@ func RunVersion(out io.Writer, output string) error {
 	v := versionData{
 		Ignite:      version.GetIgnite(),
 		Firecracker: version.GetFirecracker(),
+		Runtime:     version.GetCurrentRuntime(),
 	}
 
 	switch output {
 	case "":
 		fmt.Fprintf(out, "Ignite version: %#v\n", v.Ignite)
 		fmt.Fprintf(out, "Firecracker version: %s\n", v.Firecracker.String())
+		fmt.Fprintf(out, "Runtime: %v\n", v.Runtime)
 	case "short":
 		fmt.Fprintf(out, "%s\n", v.Ignite.GitVersion)
 	case "yaml":

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -4,6 +4,9 @@ import (
 	"fmt"
 	"runtime"
 	"strings"
+
+	"github.com/weaveworks/ignite/pkg/providers"
+	igniteruntime "github.com/weaveworks/ignite/pkg/runtime"
 )
 
 var (
@@ -66,4 +69,8 @@ func GetFirecracker() Info {
 	return Info{
 		GitVersion: firecrackerVersion,
 	}
+}
+
+func GetCurrentRuntime() igniteruntime.Name {
+	return providers.RuntimeName
 }


### PR DESCRIPTION
Add container runtime information to `ignite version` so that we could better help users troubleshoot.

Signed-off-by: Chanwit Kaewkasi <chanwit@gmail.com>