### PR TITLE
skip root requirement for ignite version

### DIFF
--- a/cmd/ignite/ignite.go
+++ b/cmd/ignite/ignite.go
@@ -17,14 +17,6 @@ func main() {
 
 // Run runs the main cobra command of this application
 func Run() error {
-	// Ignite needs to run as root for now, see
-	// https://github.com/weaveworks/ignite/issues/46
-	// TODO: Remove this when ready
-	util.GenericCheckErr(util.TestRoot())
-
-	// Create the directories needed for running
-	util.GenericCheckErr(util.CreateDirectories())
-
 	// Preload necessary providers
 	util.GenericCheckErr(providers.Populate(ignite.Preload))
 


### PR DESCRIPTION
Root user should not be a requirement when doing `ignite run`.

How I did:
Use a simple check for `cmd.Name()` to see if it is `version`, then skip the root check.

To verify:
run `ignite version` **without** `sudo`.

This PR fixes #406.

Signed-off-by: Chanwit Kaewkasi <chanwit@gmail.com>