### PR TITLE
make rm command more robust with addition check

### DIFF
--- a/pkg/operations/remove.go
+++ b/pkg/operations/remove.go
@@ -2,6 +2,7 @@ package operations
 
 import (
 	"fmt"
+	"os"
 
 	log "github.com/sirupsen/logrus"
 	api "github.com/weaveworks/ignite/pkg/apis/ignite"
@@ -42,9 +43,12 @@ func CleanupVM(vm *api.VM) error {
 	// TODO should this function return a proper error?
 	RemoveVMContainer(inspectResult)
 
-	// After removal is successful, remove the dm snapshots
-	if err := cleanup.DeactivateSnapshot(vm); err != nil {
-		return err
+	// After remove the VM container, and the SnapshotDev still there
+	if _, err := os.Stat(vm.SnapshotDev()); err == nil {
+		// try remove it again with DeactivateSnapshot
+		if err := cleanup.DeactivateSnapshot(vm); err != nil {
+			return err
+		}
 	}
 
 	if logs.Quiet {


### PR DESCRIPTION
Snapshot dev leak happens randomly after `rm -f`, but sometime it won't.
The default behavior of `rm -f` works mostly correct. So that the snapshot dev will be removed after `RemoveVMContainer`. However, there are some glitches reported by #365 and we merged #381 to fix it.

Unfortunately, cleanup in PR #381 add an extra step. If the `RemoveVMContainer` works correctly, there's no mapping device left to remove. So an error occurred and `rm -f` returned non-zero. This PR adds more check to correct that behavior.

Signed-off-by: Chanwit Kaewkasi <chanwit@gmail.com>