### PR TITLE
quick fix typo umount as unmount in preflight check

### DIFF
--- a/pkg/constants/dependencies.go
+++ b/pkg/constants/dependencies.go
@@ -2,7 +2,7 @@ package constants
 
 var Dependencies = [...]string{
 	"mount",
-	"unmount",
+	"umount",
 	"tar",
 	"mkfs.ext4",
 	"e2fsck",


### PR DESCRIPTION
This PR fixed typo in the preflight checker. We just overlooked it.

Signed-off-by: Chanwit Kaewkasi <chanwit@gmail.com>