### PR TITLE
Update Makefile for containerd with overridable commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@ $(error this project requires make version $(MIN_MAKE_VERSION) or higher)
 endif
 
 SHELL:=/bin/bash
+# Set the command for running `docker`
+# -- allows user to override for things like sudo usage or container images 
+DOCKER := docker
 UID_GID?=$(shell id -u):$(shell id -g)
 FIRECRACKER_VERSION:=$(shell cat hack/FIRECRACKER_VERSION)
 GO_VERSION=1.12.9
@@ -71,25 +74,25 @@ ifeq ($(GOARCH),amd64)
 	sed -i "/qemu/d" bin/$(GOARCH)/Dockerfile
 else
 	# Register /usr/bin/qemu-ARCH-static as the handler for non-x86 binaries in the kernel
-	docker run --rm --privileged multiarch/qemu-user-static:register --reset
+	$(DOCKER) run --rm --privileged multiarch/qemu-user-static:register --reset
 endif
-	docker build -t $(IMAGE):${IMAGE_DEV_TAG}-$(GOARCH) \
+	$(DOCKER) build -t $(IMAGE):${IMAGE_DEV_TAG}-$(GOARCH) \
 		--build-arg FIRECRACKER_VERSION=${FIRECRACKER_VERSION} \
 		--build-arg ARCH_SUFFIX=${ARCH_SUFFIX} bin/$(GOARCH)
 ifeq ($(GOARCH),$(GOHOSTARCH))
 	# Only tag the development image if its architecture matches the host
-	docker tag $(IMAGE):${IMAGE_DEV_TAG}-$(GOARCH) $(IMAGE):${IMAGE_DEV_TAG}
+	$(DOCKER) tag $(IMAGE):${IMAGE_DEV_TAG}-$(GOARCH) $(IMAGE):${IMAGE_DEV_TAG}
 endif
 ifeq ($(IS_DIRTY),0)
-	docker tag $(IMAGE):${IMAGE_DEV_TAG}-$(GOARCH) $(IMAGE):${IMAGE_TAG}-$(GOARCH)
+	$(DOCKER) tag $(IMAGE):${IMAGE_DEV_TAG}-$(GOARCH) $(IMAGE):${IMAGE_TAG}-$(GOARCH)
 ifeq ($(GOARCH),$(GOHOSTARCH))
 	# For dev builds for a clean (non-dirty) environment; "simulate" that
 	# a manifest list has been built by tagging the docker image
-	docker tag $(IMAGE):${IMAGE_TAG}-$(GOARCH) $(IMAGE):${IMAGE_TAG}
+	$(DOCKER) tag $(IMAGE):${IMAGE_TAG}-$(GOARCH) $(IMAGE):${IMAGE_TAG}
 endif
 endif
 ifeq ($(IS_CI_BUILD),1)
-	docker save $(IMAGE):${IMAGE_TAG}-$(GOARCH) -o bin/$(GOARCH)/image.tar
+	$(DOCKER) save $(IMAGE):${IMAGE_TAG}-$(GOARCH) -o bin/$(GOARCH)/image.tar
 endif
 
 build-all: $(addprefix build-all-,$(GOARCH_LIST))
@@ -99,7 +102,7 @@ build-all-%:
 push-all: $(addprefix push-all-,$(GOARCH_LIST))
 push-all-%:
 	$(MAKE) build-all-$*
-	docker push $(IMAGE):${IMAGE_TAG}-$*
+	$(DOCKER) push $(IMAGE):${IMAGE_TAG}-$*
 
 release: push-all
 ifneq ($(IS_DIRTY),0)
@@ -107,9 +110,9 @@ ifneq ($(IS_DIRTY),0)
 endif
 	mkdir -p bin/releases/${GIT_VERSION}
 	cp -r bin/{amd64,arm64} bin/releases/${GIT_VERSION}
-	docker manifest create --amend $(IMAGE):$(IMAGE_TAG) $(shell echo $(GOARCH_LIST) | sed -e "s~[^ ]*~$(IMAGE):$(IMAGE_TAG)\-&~g")
-	@for arch in $(GOARCH_LIST); do docker manifest annotate --arch=$${arch} $(IMAGE):$(IMAGE_TAG) $(IMAGE):$(IMAGE_TAG)-$${arch}; done
-	docker manifest push --purge $(IMAGE):$(IMAGE_TAG)
+	$(DOCKER) manifest create --amend $(IMAGE):$(IMAGE_TAG) $(shell echo $(GOARCH_LIST) | sed -e "s~[^ ]*~$(IMAGE):$(IMAGE_TAG)\-&~g")
+	@for arch in $(GOARCH_LIST); do $(DOCKER) manifest annotate --arch=$${arch} $(IMAGE):$(IMAGE_TAG) $(IMAGE):$(IMAGE_TAG)-$${arch}; done
+	$(DOCKER) manifest push --purge $(IMAGE):$(IMAGE_TAG)
 
 tidy: /go/bin/goimports
 	go mod tidy
@@ -139,7 +142,7 @@ api-doc:
 	mv bin/tmp/${GROUPVERSION}/*.go $(shell pwd)/pkg/apis/${GROUPVERSION}/
 	rm -r bin/tmp/${GROUPVERSION}
 	# Format the docs with pandoc
-	docker run -it --rm \
+	$(DOCKER) run -it --rm \
 		-v $(shell pwd):/data \
 		-u $(shell id -u):$(shell id -g) \
 		pandoc/core \
@@ -149,7 +152,7 @@ api-doc:
 
 shell:
 	mkdir -p $(CACHE_DIR)/go $(CACHE_DIR)/cache
-	docker run -it --rm \
+	$(DOCKER) run -it --rm \
 		-v $(CACHE_DIR)/go:/go \
 		-v $(CACHE_DIR)/cache:/.cache/go-build \
 		-v $(shell pwd):/go/src/${PROJECT} \
@@ -215,19 +218,19 @@ endif
 # Read the docs stuff
 bin/docs/builder-image.tar:
 	mkdir -p bin/docs
-	docker build -t ignite-docs-builder -f docs/Dockerfile.build docs
-	docker save ignite-docs-builder -o $@
+	$(DOCKER) build -t ignite-docs-builder -f docs/Dockerfile.build docs
+	$(DOCKER) save ignite-docs-builder -o $@
 
 build-docs: bin/docs/builder-image.tar
-	docker load -i bin/docs/builder-image.tar
-	docker build -t ignite-docs docs
+	$(DOCKER) load -i bin/docs/builder-image.tar
+	$(DOCKER) build -t ignite-docs docs
 
 test-docs: build-docs
-	docker run -it --rm ignite-docs /usr/bin/linkchecker _build/html/index.html
+	$(DOCKER) run -it --rm ignite-docs /usr/bin/linkchecker _build/html/index.html
 
 serve-docs: build-docs
 	@echo Stating docs website on http://localhost:${DOCS_PORT}/_build/html/index.html
-	@docker run -i --rm -p ${DOCS_PORT}:8000 -e USER_ID=$$UID ignite-docs
+	@$(DOCKER) run -i --rm -p ${DOCS_PORT}:8000 -e USER_ID=$$UID ignite-docs
 
 e2e: build-all
 	sudo IGNITE_E2E_HOME=$(shell pwd) $(shell which go) test ./e2e/. -count 1


### PR DESCRIPTION
This loads the dev image into containerd when you run either:
```shell
make bin/$(go env GOARCH)/Dockerfile
```
or
```shell
make build-all
```

Changes:
- Load `ignite:dev` image into containerd using root via `ctr` in a docker container
- Allow user to override docker command: `make DOCKER="sudo docker" <target>`

@chanwit