### PR TITLE
e2e docker+cni and curl google.com

### DIFF
--- a/e2e/run_test.go
+++ b/e2e/run_test.go
@@ -19,56 +19,70 @@ import (
 	"gotest.tools/assert"
 )
 
-var e2eHome = os.Getenv("IGNITE_E2E_HOME")
+var (
+	e2eHome   = os.Getenv("IGNITE_E2E_HOME")
+	igniteBin = path.Join(e2eHome, "bin/ignite")
+)
 
-func TestIgniteRunWithDockerAndDockerBridge(t *testing.T) {
-	// vmName should be unique for each test
-	const vmName = "e2e_test_ignite_run_docker_and_docker_bridge"
-
-	assert.Assert(t, e2eHome != "", "IGNITE_E2E_HOME should be set")
-
-	binary := path.Join(e2eHome, "bin/ignite")
-	cmd := exec.Command(binary,
-		"--runtime=docker",
-		"--network-plugin=docker-bridge",
-		"run", "--name="+vmName,
-		"weaveworks/ignite-ubuntu")
+// stdCmd builds an *exec.Cmd hooked up to Stdout/Stderr by default
+func stdCmd(name string, arg ...string) *exec.Cmd {
+	cmd := exec.Command(name, arg...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	err := cmd.Run()
+	return cmd
+}
+
+// runWithRuntimeAndNetworkPlugin is a helper for running a vm then forcing removal
+// vmName should be unique for each test
+func runWithRuntimeAndNetworkPlugin(t *testing.T, vmName, runtime, networkPlugin string) {
+	assert.Assert(t, e2eHome != "", "IGNITE_E2E_HOME should be set")
+
+	runCmd := stdCmd(
+		igniteBin,
+		"--runtime="+runtime,
+		"--network-plugin="+networkPlugin,
+		"run", "--name="+vmName,
+		"weaveworks/ignite-ubuntu",
+	)
+	runErr := runCmd.Run()
 
 	defer func() {
-		cmd := exec.Command(binary,
-			"--runtime=docker",
-			"--network-plugin=docker-bridge",
-			"rm", "-f", vmName)
-		assert.Check(t, cmd.Run(), "vm removal should not fail")
+		rmvCmd := stdCmd(
+			igniteBin,
+			"--runtime="+runtime,
+			"--network-plugin="+networkPlugin,
+			"rm", "-f", vmName,
+		)
+		rmvErr := rmvCmd.Run()
+		assert.Check(t, rmvErr, fmt.Sprintf("vm removal should not fail: %q", rmvCmd.Args))
 	}()
 
-	assert.Check(t, err, fmt.Sprintf("%q should not fail to run", cmd.Args))
+	assert.Check(t, runErr, fmt.Sprintf("%q should not fail to run", runCmd.Args))
+}
+
+func TestIgniteRunWithDockerAndDockerBridge(t *testing.T) {
+	runWithRuntimeAndNetworkPlugin(
+		t,
+		"e2e_test_ignite_run_docker_and_docker_bridge",
+		"docker",
+		"docker-bridge",
+	)
+}
+
+func TestIgniteRunWithDockerAndCNI(t *testing.T) {
+	runWithRuntimeAndNetworkPlugin(
+		t,
+		"e2e_test_ignite_run_docker_and_cni",
+		"docker",
+		"cni",
+	)
 }
 
 func TestIgniteRunWithContainerdAndCNI(t *testing.T) {
-	// vmName should be unique for each test
-	const vmName = "e2e_test_ignite_run_containerd_and_cni"
-
-	binary := path.Join(e2eHome, "bin/ignite")
-	cmd := exec.Command(binary,
-		"--runtime=containerd",
-		"--network-plugin=cni",
-		"run", "--name="+vmName,
-		"weaveworks/ignite-ubuntu")
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	err := cmd.Run()
-
-	defer func() {
-		cmd := exec.Command(binary,
-			"--runtime=containerd",
-			"--network-plugin=cni",
-			"rm", "-f", vmName)
-		assert.Check(t, cmd.Run(), "vm removal should not fail")
-	}()
-
-	assert.Check(t, err, fmt.Sprintf("%q should not fail to run", cmd.Args))
+	runWithRuntimeAndNetworkPlugin(
+		t,
+		"e2e_test_ignite_run_containerd_and_cni",
+		"containerd",
+		"cni",
+	)
 }


### PR DESCRIPTION
Changes:
- Add e2e tests for internet connectivity
- Refactor e2e and add docker+cni

`TestCurlWithDockerAndDockerBridge` passes with sleep 0
`TestCurlWithDockerAndCNI` fails the curl with sleep 0
`TestCurlWithDockerAndCNISLeep2` curl succeeds :upside_down_face: 

It's very reproducible.
Setting up CNI appears to be latent.
This is very undesirable -- we should fix it. (opened #423)

```shell
sudo IGNITE_E2E_HOME=$(pwd) $(which go) test ./e2e/. -count 1 -run TestCurlWithDocker | egrep -i 'fail|assert'                                                         19/09/11  6:54:12 am
time="2019-09-11T06:54:22-06:00" level=fatal msg="failed to dial: dial tcp 172.18.0.102:22: connect: connection refused"
--- FAIL: TestCurlWithDockerAndCNI (3.72s)
    run_test.go:131: assertion failed: error is not nil: exit status 1: curl should not fail: ["/home/stealthybox/Repos/ignite/bin/ignite" "--runtime=docker" "--network-plugin=cni" "exec" "e2e_test_curl_docker_and_cni" "curl" "google.com"]
    run_test.go:114: assertion failed: error is not nil: exit status 1: vm removal should not fail: ["/home/stealthybox/Repos/ignite/bin/ignite" "--runtime=docker" "--network-plugin=cni" "rm" "-f" "e2e_test_curl_docker_and_cni"]
--- FAIL: TestCurlWithDockerAndCNISleep2 (4.97s)
    run_test.go:114: assertion failed: error is not nil: exit status 1: vm removal should not fail: ["/home/stealthybox/Repos/ignite/bin/ignite" "--runtime=docker" "--network-plugin=cni" "rm" "-f" "e2e_test_curl_docker_and_cni_sleep2"]
FAIL
FAIL	github.com/weaveworks/ignite/e2e	14.554s
FAIL

```