### PR TITLE
Store e2e command output /w errors + remove variable sleep

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,9 @@ BASEIMAGE=arm64v8/alpine:3.9
 ARCH_SUFFIX=-aarch64
 endif
 
+E2E_REGEX := Test
+E2E_COUNT := 1
+
 all: ignite
 install: ignite
 	sudo cp bin/$(GOARCH)/ignite /usr/local/bin
@@ -253,5 +256,11 @@ serve-docs: build-docs
 	@echo Stating docs website on http://localhost:${DOCS_PORT}/_build/html/index.html
 	@$(DOCKER) run -i --rm -p ${DOCS_PORT}:8000 -e USER_ID=$$UID ignite-docs
 
-e2e: build-all
-	sudo IGNITE_E2E_HOME=$(shell pwd) $(shell which go) test ./e2e/. -count 1
+e2e: build-all e2e-nobuild
+
+e2e-nobuild:
+	sudo IGNITE_E2E_HOME=$(shell pwd) \
+		$(shell which go) test \
+		./e2e/. -v \
+		-count $(E2E_COUNT) \
+		-run $(E2E_REGEX)

--- a/e2e/run_test.go
+++ b/e2e/run_test.go
@@ -4,7 +4,7 @@
 // we have to wait until the CI setup to allow Ignite to run with sudo and in a KVM environment.
 //
 // How to run tests:
-// sudo IGNITE_E2E_HOME=$PWD $(which go) test ./e2e/. -count 1
+// sudo IGNITE_E2E_HOME=$PWD $(which go) test ./e2e/. -v -count 1 -run Test
 //
 
 package e2e
@@ -25,40 +25,32 @@ var (
 	igniteBin = path.Join(e2eHome, "bin/ignite")
 )
 
-// stdCmd builds an *exec.Cmd hooked up to Stdout/Stderr by default
-func stdCmd(name string, arg ...string) *exec.Cmd {
-	cmd := exec.Command(name, arg...)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	return cmd
-}
-
 // runWithRuntimeAndNetworkPlugin is a helper for running a vm then forcing removal
 // vmName should be unique for each test
 func runWithRuntimeAndNetworkPlugin(t *testing.T, vmName, runtime, networkPlugin string) {
 	assert.Assert(t, e2eHome != "", "IGNITE_E2E_HOME should be set")
 
-	runCmd := stdCmd(
+	runCmd := exec.Command(
 		igniteBin,
 		"--runtime="+runtime,
 		"--network-plugin="+networkPlugin,
 		"run", "--name="+vmName,
 		"weaveworks/ignite-ubuntu",
 	)
-	runErr := runCmd.Run()
+	runOut, runErr := runCmd.CombinedOutput()
 
 	defer func() {
-		rmvCmd := stdCmd(
+		rmvCmd := exec.Command(
 			igniteBin,
 			"--runtime="+runtime,
 			"--network-plugin="+networkPlugin,
 			"rm", "-f", vmName,
 		)
-		rmvErr := rmvCmd.Run()
-		assert.Check(t, rmvErr, fmt.Sprintf("vm removal should not fail: %q", rmvCmd.Args))
+		rmvOut, rmvErr := rmvCmd.CombinedOutput()
+		assert.Check(t, rmvErr, fmt.Sprintf("vm removal: \n%q\n%s", rmvCmd.Args, rmvOut))
 	}()
 
-	assert.Check(t, runErr, fmt.Sprintf("%q should not fail to run", runCmd.Args))
+	assert.Check(t, runErr, fmt.Sprintf("vm run: \n%q\n%s", runCmd.Args, runOut))
 }
 
 func TestIgniteRunWithDockerAndDockerBridge(t *testing.T) {
@@ -90,10 +82,10 @@ func TestIgniteRunWithContainerdAndCNI(t *testing.T) {
 
 // runCurl is a helper for testing network connectivity
 // vmName should be unique for each test
-func runCurl(t *testing.T, vmName, runtime, networkPlugin string, sleepDuration time.Duration) {
+func runCurl(t *testing.T, vmName, runtime, networkPlugin string) {
 	assert.Assert(t, e2eHome != "", "IGNITE_E2E_HOME should be set")
 
-	runCmd := stdCmd(
+	runCmd := exec.Command(
 		igniteBin,
 		"--runtime="+runtime,
 		"--network-plugin="+networkPlugin,
@@ -101,34 +93,34 @@ func runCurl(t *testing.T, vmName, runtime, networkPlugin string, sleepDuration 
 		"weaveworks/ignite-ubuntu",
 		"--ssh",
 	)
-	runErr := runCmd.Run()
+	runOut, runErr := runCmd.CombinedOutput()
 
 	defer func() {
-		rmvCmd := stdCmd(
+		rmvCmd := exec.Command(
 			igniteBin,
 			"--runtime="+runtime,
 			"--network-plugin="+networkPlugin,
 			"rm", "-f", vmName,
 		)
-		rmvErr := rmvCmd.Run()
-		assert.Check(t, rmvErr, fmt.Sprintf("vm removal should not fail: %q", rmvCmd.Args))
+		rmvOut, rmvErr := rmvCmd.CombinedOutput()
+		assert.Check(t, rmvErr, fmt.Sprintf("vm removal: \n%q\n%s", rmvCmd.Args, rmvOut))
 	}()
 
-	assert.Check(t, runErr, fmt.Sprintf("%q should not fail to run", runCmd.Args))
+	assert.Check(t, runErr, fmt.Sprintf("vm run: \n%q\n%s", runCmd.Args, runOut))
 	if runErr != nil {
 		return
 	}
 
-	time.Sleep(sleepDuration)
-	curlCmd := stdCmd(
+	time.Sleep(2 * time.Second) // TODO(https://github.com/weaveworks/ignite/issues/423): why is this necessary? Can we work to eliminate this?
+	curlCmd := exec.Command(
 		igniteBin,
 		"--runtime="+runtime,
 		"--network-plugin="+networkPlugin,
 		"exec", vmName,
 		"curl", "google.com",
 	)
-	curlErr := curlCmd.Run()
-	assert.Check(t, curlErr, fmt.Sprintf("curl should not fail: %q", curlCmd.Args))
+	curlOut, curlErr := curlCmd.CombinedOutput()
+	assert.Check(t, curlErr, fmt.Sprintf("curl: \n%q\n%s", curlCmd.Args, curlOut))
 }
 
 func TestCurlWithDockerAndDockerBridge(t *testing.T) {
@@ -137,7 +129,6 @@ func TestCurlWithDockerAndDockerBridge(t *testing.T) {
 		"e2e_test_curl_docker_and_docker_bridge",
 		"docker",
 		"docker-bridge",
-		0,
 	)
 }
 
@@ -147,7 +138,6 @@ func TestCurlWithDockerAndCNI(t *testing.T) {
 		"e2e_test_curl_docker_and_cni",
 		"docker",
 		"cni",
-		0,
 	)
 }
 
@@ -157,26 +147,5 @@ func TestCurlWithContainerdAndCNI(t *testing.T) {
 		"e2e_test_curl_containerd_and_cni",
 		"containerd",
 		"cni",
-		0,
-	)
-}
-
-func TestCurlWithDockerAndCNISleep2(t *testing.T) {
-	runCurl(
-		t,
-		"e2e_test_curl_docker_and_cni_sleep2",
-		"docker",
-		"cni",
-		2 * time.Second, // TODO: why is this necessary? Can we work to eliminate this?
-	)
-}
-
-func TestCurlWithContainerdAndCNISleep2(t *testing.T) {
-	runCurl(
-		t,
-		"e2e_test_curl_containerd_and_cni_sleep2",
-		"containerd",
-		"cni",
-		2 * time.Second,
 	)
 }


### PR DESCRIPTION
This makes the test output much more readable. Errors are nested with their command args.
It also allows you to read parallel output.
I haven't enabled parallel, because vm run appears to have a bug using dmsetup in parallel.

Successful commands no longer output to stdout, but we could add a gate for this if desired.

I removed the variable sleep because it appears to have less impact on the docker-bridge behavior in #423 than I previously observed.