### PR TITLE
implement --dns flag to allow overriding nameservers

### DIFF
--- a/cmd/ignite/cmd/vmcmd/create.go
+++ b/cmd/ignite/cmd/vmcmd/create.go
@@ -38,6 +38,7 @@ func NewCmdCreate(out io.Writer) *cobra.Command {
 					--name my-vm \
 					--cpus 2 \
 					--ssh \
+					--dns 8.8.8.8 \
 					--memory 2GB \
 					--size 6GB
 		`, constants.DEFAULT_KERNEL_IMAGE)),
@@ -66,6 +67,7 @@ func addCreateFlags(fs *pflag.FlagSet, cf *run.CreateFlags) {
 	// Register flags bound to temporary holder values
 	fs.StringSliceVarP(&cf.PortMappings, "ports", "p", cf.PortMappings, "Map host ports to VM ports")
 	fs.StringSliceVarP(&cf.CopyFiles, "copy-files", "f", cf.CopyFiles, "Copy files/directories from the host to the created VM")
+	fs.StringSliceVarP(&cf.DNS, "dns", "", cf.DNS, "Override the default name servers in VM /etc/resolv.conf")
 
 	// Register flags for simple types (int, string, etc.)
 	fs.Uint64Var(&cf.VM.Spec.CPUs, "cpus", cf.VM.Spec.CPUs, "VM vCPU count, 1 or even numbers between 1 and 32")

--- a/cmd/ignite/cmd/vmcmd/run.go
+++ b/cmd/ignite/cmd/vmcmd/run.go
@@ -31,6 +31,7 @@ func NewCmdRun(out io.Writer) *cobra.Command {
 					--interactive \
 					--name my-vm \
 					--cpus 2 \
+					--dns 8.8.8.8 \
 					--ssh \
 					--memory 2GB \
 					--size 10G

--- a/cmd/ignite/run/create.go
+++ b/cmd/ignite/run/create.go
@@ -5,6 +5,8 @@ import (
 	"path"
 	"strings"
 
+	"github.com/weaveworks/ignite/pkg/constants"
+
 	api "github.com/weaveworks/ignite/pkg/apis/ignite"
 	"github.com/weaveworks/ignite/pkg/apis/ignite/scheme"
 	"github.com/weaveworks/ignite/pkg/apis/ignite/validation"
@@ -24,6 +26,7 @@ func NewCreateFlags() *CreateFlags {
 type CreateFlags struct {
 	PortMappings []string
 	CopyFiles    []string
+	DNS          []string
 	// This is a placeholder value here for now.
 	// If it was set using flags, it will be copied over to
 	// the API type. TODO: When we later have internal types
@@ -58,6 +61,14 @@ func (cf *CreateFlags) constructVMFromCLI(args []string) error {
 	// Parse the given port mappings
 	if cf.VM.Spec.Network.Ports, err = meta.ParsePortMappings(cf.PortMappings); err != nil {
 		return err
+	}
+
+	if len(cf.DNS) > 0 {
+		// Assign DNS server to VM spec
+		if cf.VM.Annotations == nil {
+			cf.VM.Annotations = make(map[string]string)
+		}
+		cf.VM.Annotations[constants.DNS_ANNOTATION] = strings.Join(cf.DNS, ",")
 	}
 
 	// If the SSH flag was set, copy it over to the API type

--- a/docs/cli/ignite/ignite_create.md
+++ b/docs/cli/ignite/ignite_create.md
@@ -23,6 +23,7 @@ Example usage:
 		--name my-vm \
 		--cpus 2 \
 		--ssh \
+		--dns 8.8.8.8 \
 		--memory 2GB \
 		--size 6GB
 
@@ -37,6 +38,7 @@ ignite create <OCI image> [flags]
       --config string            Specify a path to a file with the API resources you want to pass
   -f, --copy-files strings       Copy files/directories from the host to the created VM
       --cpus uint                VM vCPU count, 1 or even numbers between 1 and 32 (default 1)
+      --dns strings              Override the default name servers in VM /etc/resolv.conf
   -h, --help                     help for create
       --kernel-args string       Set the command line for the kernel (default "console=ttyS0 reboot=k panic=1 pci=off ip=dhcp")
   -k, --kernel-image oci-image   Specify an OCI image containing the kernel at /boot/vmlinux and optionally, modules (default weaveworks/ignite-kernel:4.19.47)

--- a/docs/cli/ignite/ignite_run.md
+++ b/docs/cli/ignite/ignite_run.md
@@ -15,6 +15,7 @@ Example usage:
 		--interactive \
 		--name my-vm \
 		--cpus 2 \
+		--dns 8.8.8.8 \
 		--ssh \
 		--memory 2GB \
 		--size 10G
@@ -31,6 +32,7 @@ ignite run <OCI image> [flags]
   -f, --copy-files strings       Copy files/directories from the host to the created VM
       --cpus uint                VM vCPU count, 1 or even numbers between 1 and 32 (default 1)
   -d, --debug                    Debug mode, keep container after VM shutdown
+      --dns strings              Override the default name servers in VM /etc/resolv.conf
   -h, --help                     help for run
   -i, --interactive              Attach to the VM after starting
       --kernel-args string       Set the command line for the kernel (default "console=ttyS0 reboot=k panic=1 pci=off ip=dhcp")

--- a/docs/cli/ignite/ignite_vm_create.md
+++ b/docs/cli/ignite/ignite_vm_create.md
@@ -23,6 +23,7 @@ Example usage:
 		--name my-vm \
 		--cpus 2 \
 		--ssh \
+		--dns 8.8.8.8 \
 		--memory 2GB \
 		--size 6GB
 
@@ -37,6 +38,7 @@ ignite vm create <OCI image> [flags]
       --config string            Specify a path to a file with the API resources you want to pass
   -f, --copy-files strings       Copy files/directories from the host to the created VM
       --cpus uint                VM vCPU count, 1 or even numbers between 1 and 32 (default 1)
+      --dns strings              Override the default name servers in VM /etc/resolv.conf
   -h, --help                     help for create
       --kernel-args string       Set the command line for the kernel (default "console=ttyS0 reboot=k panic=1 pci=off ip=dhcp")
   -k, --kernel-image oci-image   Specify an OCI image containing the kernel at /boot/vmlinux and optionally, modules (default weaveworks/ignite-kernel:4.19.47)

--- a/docs/cli/ignite/ignite_vm_run.md
+++ b/docs/cli/ignite/ignite_vm_run.md
@@ -15,6 +15,7 @@ Example usage:
 		--interactive \
 		--name my-vm \
 		--cpus 2 \
+		--dns 8.8.8.8 \
 		--ssh \
 		--memory 2GB \
 		--size 10G
@@ -31,6 +32,7 @@ ignite vm run <OCI image> [flags]
   -f, --copy-files strings       Copy files/directories from the host to the created VM
       --cpus uint                VM vCPU count, 1 or even numbers between 1 and 32 (default 1)
   -d, --debug                    Debug mode, keep container after VM shutdown
+      --dns strings              Override the default name servers in VM /etc/resolv.conf
   -h, --help                     help for run
   -i, --interactive              Attach to the VM after starting
       --kernel-args string       Set the command line for the kernel (default "console=ttyS0 reboot=k panic=1 pci=off ip=dhcp")

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -46,4 +46,7 @@ const (
 
 	// How many characters Ignite UIDs should have
 	IGNITE_UID_LENGTH = 16
+
+	// An extension in v1alpha2. TODO(chanwit): It would be implemented as a part of v1alpha3 in v0.7.0
+	DNS_ANNOTATION = "ignite.weave.works/dns"
 )

--- a/pkg/container/dhcp.go
+++ b/pkg/container/dhcp.go
@@ -3,6 +3,7 @@ package container
 import (
 	"fmt"
 	"net"
+	"strings"
 	"time"
 
 	dhcp "github.com/krolaw/dhcp4"
@@ -29,6 +30,12 @@ func StartDHCPServers(vm *api.VM, dhcpIfaces []DHCPInterface) error {
 	clientConfig, err := dns.ClientConfigFromFile("/etc/resolv.conf")
 	if err != nil {
 		return fmt.Errorf("failed to get DNS configuration: %v", err)
+	}
+
+	// If there's the dns annotation, override dns
+	if dns, exist := vm.Annotations[constants.DNS_ANNOTATION]; exist {
+		log.Infof("Overriding DNS with value %q", dns)
+		clientConfig.Servers = strings.Split(dns, ",")
 	}
 
 	for i := range dhcpIfaces {


### PR DESCRIPTION
This PR implements a new flag, `--dns`, to allow overriding DNS nameservers in the VM's `/etc/resolv.conf`.

Signed-off-by: Chanwit Kaewkasi <chanwit@gmail.com>