### PR TITLE
On release, use tidy-in-docker to prevent module differences from differing versions of go

### DIFF
--- a/hack/release-common.sh
+++ b/hack/release-common.sh
@@ -16,7 +16,7 @@ run_gren() {
 }
 
 make_tidy_autogen() {
-    make autogen tidy graph
+    make autogen tidy-in-docker graph
     if [[ $(git status --short) != "" ]]; then
         git add -A
         git commit -m "Ran 'make autogen tidy graph'"


### PR DESCRIPTION
v0.5.3 deps were calculated using my on-host version of go 1.13
CircleCI picks up on this difference:
https://github.com/weaveworks/ignite/commits/v0.5.3

Running `tidy-in-docker` instead will use the same version of go as the build.