### PR TITLE
Fix containerd resolv.conf + DHCP behavior

### DIFF
--- a/pkg/operations/start.go
+++ b/pkg/operations/start.go
@@ -102,7 +102,7 @@ func StartVM(vm *api.VM, debug bool) error {
 	}
 
 	// Run the VM container in Docker
-	containerID, err := providers.Runtime.RunContainer(igniteImage, config, util.NewPrefixer().Prefix(vm.GetUID()))
+	containerID, err := providers.Runtime.RunContainer(igniteImage, config, util.NewPrefixer().Prefix(vm.GetUID()), vm.GetUID().String())
 	if err != nil {
 		return fmt.Errorf("failed to start container for VM %q: %v", vm.GetUID(), err)
 	}

--- a/pkg/resolvconf/resolvconf.go
+++ b/pkg/resolvconf/resolvconf.go
@@ -1,0 +1,109 @@
+package resolvconf
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"strings"
+
+	"github.com/weaveworks/ignite/pkg/util"
+
+	"github.com/miekg/dns"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	resolvDefault = "/etc/resolv.conf"
+	resolvSystemd = "/run/systemd/resolve/resolv.conf"
+)
+
+var (
+	// fallbackNameServers uses Google DNS
+	fallbackNameServers = []string{
+		"8.8.8.8",
+		"8.8.4.4",
+	}
+)
+
+// EnsureResolvConf ensures a valid, usable resolvConf is written to the filepath
+func EnsureResolvConf(filepath string, perm os.FileMode) error {
+	cfg, err := readDNSConfig()
+	if err != nil {
+		log.Warn(err)
+	}
+
+	filterLoopback(cfg)
+	// Fallback to default DNS servers
+	if len(cfg.Servers) == 0 {
+		for _, s := range fallbackNameServers {
+			cfg.Servers = append(cfg.Servers, s)
+		}
+	}
+
+	data := buildResolvConf(cfg)
+	err = util.WriteFileIfChanged(filepath, data, perm)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// readDNSConfig reads settings from /etc/resolv.conf -- if those settings indicate
+// systemd-resolved is in use, it reads them again from /run/systemd/resolve/resolv.conf.
+// If an error occurs, cfg will be defaulted to an empty dns.ClientConfig{}.
+func readDNSConfig() (*dns.ClientConfig, error) {
+	cfg, err := dns.ClientConfigFromFile(resolvDefault)
+	if err != nil {
+		return &dns.ClientConfig{}, fmt.Errorf("Using default DNS config: %v", err)
+	}
+
+	if isSystemdResolved(cfg) {
+		systemdCfg, err := dns.ClientConfigFromFile(resolvSystemd)
+		if err == nil {
+			return systemdCfg, nil
+		}
+	}
+
+	return cfg, nil
+}
+
+// isSystemdResolved returns whether the cfg likely indicate usage of systemd-resolved.
+// This function should be used with the ClientConfig from /etc/resolv.conf.
+func isSystemdResolved(cfg *dns.ClientConfig) bool {
+	if len(cfg.Servers) == 1 {
+		ip := net.ParseIP(cfg.Servers[0])
+		if ip != nil && ip.IsLoopback() && ip[len(ip)-1] == 53 {
+			return true // cfg.Servers is equivalent to ["127.0.0.53"] or ["::FFff:127.0.0.53"]
+		}
+	}
+	return false
+}
+
+// filterLoopback removes loopback addresses from cfg.Servers since they're
+// not usable as an upstream resolver for a vm
+func filterLoopback(cfg *dns.ClientConfig) {
+	servers := make([]string, 0)
+	for _, s := range cfg.Servers {
+		ip := net.ParseIP(s)
+		if ip != nil && !ip.IsLoopback() {
+			servers = append(servers, s)
+		}
+	}
+	cfg.Servers = servers
+}
+
+// buildResolvConf returns the bytes for a resolv.conf representing clientConfig
+func buildResolvConf(cfg *dns.ClientConfig) []byte {
+	s := "# The following config was built by ignite:\n"
+	if len(cfg.Servers) > 0 {
+		s += "nameserver " +
+			strings.Join(cfg.Servers, "\nnameserver ") +
+			"\n"
+	}
+	if len(cfg.Search) > 0 {
+		s += "search " + strings.Join(cfg.Search, " ") +
+			"\n"
+	}
+	return []byte(s)
+}

--- a/pkg/resolvconf/resolvconf_test.go
+++ b/pkg/resolvconf/resolvconf_test.go
@@ -1,0 +1,201 @@
+package resolvconf
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+func TestBuildResolvConf(t *testing.T) {
+	data := buildResolvConf(&dns.ClientConfig{
+		Servers: []string{"1.1.1.1", "8.8.8.8", "9.9.9.9"},
+		Search:  []string{"fire.local", "test.fire.local"},
+	})
+	expected := `# The following config was built by ignite:
+nameserver 1.1.1.1
+nameserver 8.8.8.8
+nameserver 9.9.9.9
+search fire.local test.fire.local
+`
+	if string(data) != string(expected) {
+		t.Errorf(
+			"\nexpected:\n%q\nactual:\n%q",
+			string(expected),
+			string(data),
+		)
+	}
+}
+
+func TestBuildResolvConfEmpty(t *testing.T) {
+	data := buildResolvConf(&dns.ClientConfig{})
+	expected := `# The following config was built by ignite:
+`
+	if string(data) != string(expected) {
+		t.Errorf(
+			"\nexpected:\n%q\nactual:\n%q",
+			string(expected),
+			string(data),
+		)
+	}
+}
+
+func TestIsSystemdResolved(t *testing.T) {
+	type tc struct {
+		cfg      dns.ClientConfig
+		expected bool
+	}
+	testCases := []tc{
+		{
+			cfg: dns.ClientConfig{
+				Servers: []string{"127.0.0.53"},
+			},
+			expected: true,
+		},
+		{
+			cfg: dns.ClientConfig{
+				Servers: []string{"::ffff:127.0.0.53"},
+			},
+			expected: true,
+		},
+		{
+			cfg: dns.ClientConfig{
+				Servers: []string{"::fFFf:127.0.0.53"},
+			},
+			expected: true,
+		},
+		{
+			cfg: dns.ClientConfig{
+				Servers: []string{"127.0.0.1", "::ffFF:127.0.0.53", "::ffff:127.0.0.53"},
+			},
+			expected: false,
+		},
+		{
+			cfg: dns.ClientConfig{
+				Servers: []string{"127.0.0.1", "::ffFF:127.0.0.53", "::ffff:127.0.0.53"},
+			},
+			expected: false,
+		},
+		{
+			cfg: dns.ClientConfig{
+				Servers: []string{"1.1.1.1"},
+			},
+			expected: false,
+		},
+		{
+			cfg: dns.ClientConfig{
+				Servers: []string{"127.0.0.1", "1.1.1.1"},
+			},
+			expected: false,
+		},
+		{
+			cfg: dns.ClientConfig{
+				Servers: []string{"127.0.0.53", "1.1.1.1", "8.8.8.8", "9.9.9.9"},
+			},
+			expected: false,
+		},
+		{
+			cfg: dns.ClientConfig{
+				Servers: []string{"127.0.0.1"},
+			},
+			expected: false,
+		},
+		{
+			cfg: dns.ClientConfig{
+				Servers: []string{"::1"},
+			},
+			expected: false,
+		},
+		{
+			cfg: dns.ClientConfig{
+				Servers: []string{"::53"},
+			},
+			expected: false,
+		},
+		{
+			cfg: dns.ClientConfig{
+				Servers: []string{},
+			},
+			expected: false,
+		},
+	}
+	for i, tc := range testCases {
+		res := isSystemdResolved(&tc.cfg)
+		if res != tc.expected {
+			t.Errorf("Case #%d expected %t, got %t: %q", i, tc.expected, res, tc.cfg.Servers)
+		}
+	}
+}
+
+func TestFilterLoopBack(t *testing.T) {
+	type tc struct {
+		cfg      dns.ClientConfig
+		expected []string
+	}
+	testCases := []tc{
+		{
+			cfg: dns.ClientConfig{
+				Servers: []string{},
+			},
+			expected: []string{},
+		},
+		{
+			cfg: dns.ClientConfig{
+				Servers: []string{"127.0.0.1", "1.1.1.1", "::ffFF:127.0.0.53", "::ffff:127.0.0.1"},
+			},
+			expected: []string{"1.1.1.1"},
+		},
+		{
+			cfg: dns.ClientConfig{
+				Servers: []string{"127.0.0.1", "::ffFF:127.0.0.53", "::ffff:127.0.0.53"},
+			},
+			expected: []string{},
+		},
+		{
+			cfg: dns.ClientConfig{
+				Servers: []string{"1.1.1.1"},
+			},
+			expected: []string{"1.1.1.1"},
+		},
+		{
+			cfg: dns.ClientConfig{
+				Servers: []string{"127.0.0.1", "1.1.1.1"},
+			},
+			expected: []string{"1.1.1.1"},
+		},
+		{
+			cfg: dns.ClientConfig{
+				Servers: []string{"127.0.0.53", "1.1.1.1", "8.8.8.8", "9.9.9.9"},
+			},
+			expected: []string{"1.1.1.1", "8.8.8.8", "9.9.9.9"},
+		},
+		{
+			cfg: dns.ClientConfig{
+				Servers: []string{"127.0.0.1"},
+			},
+			expected: []string{},
+		},
+		{
+			cfg: dns.ClientConfig{
+				Servers: []string{"::1"},
+			},
+			expected: []string{""},
+		},
+		{
+			cfg: dns.ClientConfig{
+				Servers: []string{"::53"},
+			},
+			expected: []string{"::53"},
+		},
+	}
+	for _, tc := range testCases {
+		filterLoopback(&tc.cfg)
+		if strings.Join(tc.cfg.Servers, ", ") != strings.Join(tc.expected, ", ") {
+			t.Errorf(
+				"\nexpected:\n%v\nactual:\n%v",
+				tc.expected,
+				tc.cfg.Servers,
+			)
+		}
+	}
+}

--- a/pkg/runtime/docker/client.go
+++ b/pkg/runtime/docker/client.go
@@ -130,7 +130,7 @@ func (dc *dockerClient) AttachContainer(container string) (err error) {
 	return
 }
 
-func (dc *dockerClient) RunContainer(image meta.OCIImageRef, config *runtime.ContainerConfig, name string) (string, error) {
+func (dc *dockerClient) RunContainer(image meta.OCIImageRef, config *runtime.ContainerConfig, name, id string) (string, error) {
 	binds := make([]string, 0, len(config.Binds))
 	for _, bind := range config.Binds {
 		binds = append(binds, fmt.Sprintf("%s:%s", bind.HostPath, bind.ContainerPath))

--- a/pkg/runtime/types.go
+++ b/pkg/runtime/types.go
@@ -56,7 +56,7 @@ type Interface interface {
 
 	InspectContainer(container string) (*ContainerInspectResult, error)
 	AttachContainer(container string) error
-	RunContainer(image meta.OCIImageRef, config *ContainerConfig, name string) (string, error)
+	RunContainer(image meta.OCIImageRef, config *ContainerConfig, name, id string) (string, error)
 	StopContainer(container string, timeout *time.Duration) error
 	KillContainer(container, signal string) error
 	RemoveContainer(container string) error


### PR DESCRIPTION
Fixes #437

Patches:
- Add heuristic resolv.conf builder supporting nameserver+search
- Fix containerd DHCP using resolvconf + Add id to runtime.RunContainer()

Having the user be able to setup custom DNS is great, but it would be better if it first worked well without any tweaking.

This resolv.conf library supports `/etc/resolv.conf`, systemd-resolved, and will even work with nothing at all.
All loopback nameservers are filtered, and in the event that there's still no usable DNS, it falls back to Google DNS servers. (other default suggestions are welcome)

The containerd runtime then uses this lib to populate the vmDir specfic to the ignite vm's id.
A modification to the runtime interface was needed to pass the id so this could be done.

It might be better to try and use the container's snapshot instead of the vmDir to accomplish this.
However, using the vmDir is a generic solution since adding mounts for the runtime container is simple.
We could use this mechanism to more uniformly configure DHCP /w docker while disabling the default resolver for ignite-spawn as mentioned in #438.

I'd also be fine not actually writing any file and just adding fields to the vm manifest for `dhcp.Nameservers` and `dhcp.Search`.
We can still use readDNSConfig() and its accompanying functions to calculate the proper values from the host.

The benefit of using `/etc/resolv.conf` is it's well integrated with docker networks which the vm will benefit from through it's DHCP config.
______________________
example behavior:
```shell
make build-all
~/Repos/ignite-scratch/ignite-clean.sh
~/Repos/ignite-scratch/iptables-clean-cni-ignite.sh

sudo bin/ignite vm run weaveworks/ignite-ubuntu --log-level debug --ssh --name test441
DEBU[0000] Ensuring image weaveworks/ignite-ubuntu:latest exists, or importing it... 
DEBU[0000] Found image with UID 35c47bfb397b922b        
DEBU[0000] Ensuring kernel weaveworks/ignite-kernel:4.19.47 exists, or importing it... 
DEBU[0000] Found kernel with UID 5dfb8abbb5d4c79a       
INFO[0000] Created VM with ID "030cd0a728543694" and name "test441" 
DEBU[0001] containerd: Inspecting image "weaveworks/ignite:v0.6.0-67-585d77f9804381" 
DEBU[0001] Writing "/var/lib/firecracker/vm/030cd0a728543694/runtime.containerd.resolv.conf" with new hash: "cca33446e2ce0f418633a6ea9ef9c54859cb8a755f90dcc74274200c31fa85e4", old hash: "" 
INFO[0001] Networking is handled by "cni"               
INFO[0001] Started Firecracker VM "030cd0a728543694" in a container with ID "ignite-030cd0a728543694" 

sudo bin/ignite exec test441 cat /etc/resolv.conf
#PROTO: DHCP
nameserver 1.0.0.1
bootserver 0.0.0.0

export vm_id="$(sudo bin/ignite ps | grep test441 | awk '{print $1}')"

ls -1 /var/lib/firecracker/vm/${vm_id}/*resolv.conf*
/var/lib/firecracker/vm/030cd0a728543694/runtime.containerd.resolv.conf
/var/lib/firecracker/vm/030cd0a728543694/runtime.containerd.resolv.conf.sha256

cat /var/lib/firecracker/vm/${vm_id}/*resolv.conf*
# The following config was built by ignite:
nameserver 1.0.0.1
search stealthybox.local
cca33446e2ce0f418633a6ea9ef9c54859cb8a755f90dcc74274200c31fa85e4

sudo ctr -n firecracker t exec --exec-id 0 "ignite-${vm_id}" cat /etc/resolv.conf
# The following config was built by ignite:
nameserver 1.0.0.1
search stealthybox.local

sudo bin/ignite vm stop test441 --log-level debug
INFO[0000] Removing the container with ID "ignite-030cd0a728543694" from the "cni" network 
INFO[0008] Stopped VM with name "test441" and ID "030cd0a728543694" 

sudo bin/ignite vm start test441 --log-level debug
DEBU[0000] containerd: Inspecting image "weaveworks/ignite:v0.6.0-67-585d77f9804381" 
DEBU[0000] "/var/lib/firecracker/vm/030cd0a728543694/runtime.containerd.resolv.conf" with hash "cca33446e2ce0f418633a6ea9ef9c54859cb8a755f90dcc74274200c31fa85e4" is unchanged 
INFO[0000] Networking is handled by "cni"               
INFO[0000] Started Firecracker VM "030cd0a728543694" in a container with ID "ignite-030cd0a728543694" 

sudo bin/ignite exec test441 cat /etc/resolv.conf
#PROTO: DHCP
nameserver 1.0.0.1
bootserver 0.0.0.0
```