### PR TITLE
Chain firewall plugin to fix routing for default CNI bridge

### DIFF
--- a/pkg/network/cni/cni.go
+++ b/pkg/network/cni/cni.go
@@ -59,6 +59,9 @@ var igniteCNIConf = fmt.Sprintf(`{
 			"capabilities": {
 				"portMappings": true
 			}
+		},
+		{
+			"type": "firewall"
 		}
 	]
 }


### PR DESCRIPTION
Alternative to #427 using the `firewall` CNI plugin in our conflist
Fixes #401
Fixes #418

This works on my machine with the normal quirks that we've run into switching subnets.
Please test.
____________

Output with containerd+cni working twice and docker+cni working once:
```shell
# ~/Repos/ignite-scratch/ignite-clean.sh; ~/Repos/ignite-scratch/iptables-clean-cni-ignite.sh

# make build-all

export suffix="" # use build
export ignite="sudo $( ls ~/Repos/ignite/bin/amd64/ignite${suffix} )"
test-vm() {
  r=$1 ; n=$2 ; echo $r $n
    name=${3:-t_${r}_${n}_}
    $=ignite vm run weaveworks/ignite-ubuntu --runtime $r --network-plugin $n --ssh --name $name  &&  sleep 2; sudo iptables -L -t nat | grep ignite
    $=ignite exec $name -- ping -c2 -i.1 8.8.4.4
};
#test-vm docker docker-bridge
test-vm containerd cni ctrd${suffix}_1
test-vm containerd cni ctrd${suffix}_2
test-vm docker cni

containerd cni
INFO[0000] Created VM with ID "87126a6fa47f08f3" and name "ctrd_1" 
INFO[0001] Networking is handled by "cni"               
INFO[0001] Started Firecracker VM "87126a6fa47f08f3" in a container with ID "ignite-87126a6fa47f08f3" 
CNI-00de49e45305e5d1fd4153c6  all  --  172.18.0.234         anywhere             /* name: "ignite-containerd-bridge" id: "ignite-87126a6fa47f08f3" */
ACCEPT     all  --  anywhere             172.18.0.0/16        /* name: "ignite-containerd-bridge" id: "ignite-87126a6fa47f08f3" */
MASQUERADE  all  --  anywhere            !base-address.mcast.net/4  /* name: "ignite-containerd-bridge" id: "ignite-87126a6fa47f08f3" */
PING 8.8.4.4 (8.8.4.4) 56(84) bytes of data.
64 bytes from 8.8.4.4: icmp_seq=1 ttl=53 time=14.7 ms
64 bytes from 8.8.4.4: icmp_seq=2 ttl=53 time=16.5 ms

--- 8.8.4.4 ping statistics ---
2 packets transmitted, 2 received, 0% packet loss, time 100ms
rtt min/avg/max/mdev = 14.705/15.613/16.522/0.917 ms
containerd cni
INFO[0000] Created VM with ID "117328942cdb4496" and name "ctrd_2" 
INFO[0001] Networking is handled by "cni"               
INFO[0001] Started Firecracker VM "117328942cdb4496" in a container with ID "ignite-117328942cdb4496" 
CNI-00de49e45305e5d1fd4153c6  all  --  172.18.0.234         anywhere             /* name: "ignite-containerd-bridge" id: "ignite-87126a6fa47f08f3" */
CNI-412ef007d5c6d81acafb143a  all  --  172.18.0.235         anywhere             /* name: "ignite-containerd-bridge" id: "ignite-117328942cdb4496" */
ACCEPT     all  --  anywhere             172.18.0.0/16        /* name: "ignite-containerd-bridge" id: "ignite-87126a6fa47f08f3" */
MASQUERADE  all  --  anywhere            !base-address.mcast.net/4  /* name: "ignite-containerd-bridge" id: "ignite-87126a6fa47f08f3" */
ACCEPT     all  --  anywhere             172.18.0.0/16        /* name: "ignite-containerd-bridge" id: "ignite-117328942cdb4496" */
MASQUERADE  all  --  anywhere            !base-address.mcast.net/4  /* name: "ignite-containerd-bridge" id: "ignite-117328942cdb4496" */
PING 8.8.4.4 (8.8.4.4) 56(84) bytes of data.
64 bytes from 8.8.4.4: icmp_seq=1 ttl=53 time=17.8 ms
64 bytes from 8.8.4.4: icmp_seq=2 ttl=53 time=11.7 ms

--- 8.8.4.4 ping statistics ---
2 packets transmitted, 2 received, 0% packet loss, time 100ms
rtt min/avg/max/mdev = 11.774/14.812/17.850/3.038 ms
docker cni
INFO[0000] Created VM with ID "5bec20b7a6927eed" and name "t_docker_cni_" 
INFO[0001] Networking is handled by "cni"               
INFO[0001] Started Firecracker VM "5bec20b7a6927eed" in a container with ID "9f7522163fd27605d8b790775584b22f826f7d3b98bcb4469a5bbf70f0c0de52" 
CNI-00de49e45305e5d1fd4153c6  all  --  172.18.0.234         anywhere             /* name: "ignite-containerd-bridge" id: "ignite-87126a6fa47f08f3" */
CNI-412ef007d5c6d81acafb143a  all  --  172.18.0.235         anywhere             /* name: "ignite-containerd-bridge" id: "ignite-117328942cdb4496" */
CNI-0428dc85ddf50abc1e01631a  all  --  172.18.0.239         anywhere             /* name: "ignite-containerd-bridge" id: "9f7522163fd27605d8b790775584b22f826f7d3b98bcb4469a5bbf70f0c0de52" */
ACCEPT     all  --  anywhere             172.18.0.0/16        /* name: "ignite-containerd-bridge" id: "ignite-87126a6fa47f08f3" */
MASQUERADE  all  --  anywhere            !base-address.mcast.net/4  /* name: "ignite-containerd-bridge" id: "ignite-87126a6fa47f08f3" */
ACCEPT     all  --  anywhere             172.18.0.0/16        /* name: "ignite-containerd-bridge" id: "9f7522163fd27605d8b790775584b22f826f7d3b98bcb4469a5bbf70f0c0de52" */
MASQUERADE  all  --  anywhere            !base-address.mcast.net/4  /* name: "ignite-containerd-bridge" id: "9f7522163fd27605d8b790775584b22f826f7d3b98bcb4469a5bbf70f0c0de52" */
ACCEPT     all  --  anywhere             172.18.0.0/16        /* name: "ignite-containerd-bridge" id: "ignite-117328942cdb4496" */
MASQUERADE  all  --  anywhere            !base-address.mcast.net/4  /* name: "ignite-containerd-bridge" id: "ignite-117328942cdb4496" */
PING 8.8.4.4 (8.8.4.4) 56(84) bytes of data.
64 bytes from 8.8.4.4: icmp_seq=1 ttl=53 time=16.2 ms
64 bytes from 8.8.4.4: icmp_seq=2 ttl=53 time=13.7 ms

--- 8.8.4.4 ping statistics ---
2 packets transmitted, 2 received, 0% packet loss, time 101ms
rtt min/avg/max/mdev = 13.793/15.024/16.255/1.231 ms


# notice there are FORWARD rules per vm
sudo iptables -S | grep CNI
-N CNI-ADMIN
-N CNI-FORWARD
-A FORWARD -m comment --comment "CNI firewall plugin rules" -j CNI-FORWARD
-A CNI-FORWARD -m comment --comment "CNI firewall plugin rules" -j CNI-ADMIN
-A CNI-FORWARD -d 172.18.0.234/32 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
-A CNI-FORWARD -s 172.18.0.234/32 -j ACCEPT
-A CNI-FORWARD -d 172.18.0.235/32 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
-A CNI-FORWARD -s 172.18.0.235/32 -j ACCEPT
-A CNI-FORWARD -d 172.18.0.239/32 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
-A CNI-FORWARD -s 172.18.0.239/32 -j ACCEPT

```