### PR TITLE
backport: implement ssh wait for a VM

### DIFF
--- a/cmd/ignite/run/start.go
+++ b/cmd/ignite/run/start.go
@@ -2,6 +2,10 @@ package run
 
 import (
 	"fmt"
+	"net"
+	"time"
+
+	"github.com/weaveworks/ignite/pkg/apis/ignite"
 
 	"github.com/weaveworks/ignite/pkg/operations"
 )
@@ -38,9 +42,42 @@ func Start(so *startOptions) error {
 		return err
 	}
 
+	if err := waitForSSH(so.vm, 10); err != nil {
+		return err
+	}
+
 	// If starting interactively, attach after starting
 	if so.Interactive {
 		return Attach(so.attachOptions)
 	}
+	return nil
+}
+
+func waitForSSH(vm *ignite.VM, seconds int) error {
+	// When --ssh is enabled, wait until SSH service started on port 22 at most N seconds
+	ssh := vm.Spec.SSH
+	if ssh != nil && ssh.Generate && len(vm.Status.IPAddresses) > 0 {
+		addr := vm.Status.IPAddresses[0].String() + ":22"
+		perSecond := 10
+		delay := time.Second / time.Duration(perSecond)
+		var err error
+		for i := 0; i < seconds*perSecond; i++ {
+			conn, dialErr := net.DialTimeout("tcp", addr, delay)
+			if conn != nil {
+				defer conn.Close()
+				err = nil
+				break
+			}
+			err = dialErr
+			time.Sleep(delay)
+		}
+		if err != nil {
+			if err, ok := err.(*net.OpError); ok && err.Timeout() {
+				return fmt.Errorf("Tried connecting to SSH but timed out %s", err)
+			}
+			return err
+		}
+	}
+
 	return nil
 }


### PR DESCRIPTION
The bug fixed by commit 929acaf793 seems to affect a related project. It would be great to backport this fix to 0.5.x.

(cherry picked from commit 929acaf79392e5cb26fc2eb1f5c4fd482995904c)
Signed-off-by: Chanwit Kaewkasi <chanwit@gmail.com>