### PR TITLE
Ignite wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ bin
 images/kubeadm/run
 images/alpine/alpine.*
 docs/_build
+ignitew

--- a/Dockerfile.ignitew
+++ b/Dockerfile.ignitew
@@ -1,0 +1,23 @@
+FROM ubuntu:bionic
+
+RUN apt-get update && apt-get install -y curl
+
+ENV CNI_VERSION v0.8.2
+ENV ARCH amd64
+
+# Install wrap packer
+ADD  https://github.com/dgiagio/warp/releases/download/v0.3.0/linux-x64.warp-packer /usr/bin/linux-x64.warp-packer
+RUN  chmod +x /usr/bin/linux-x64.warp-packer
+
+RUN  mkdir /bundle
+WORKDIR /bundle
+
+COPY bin/amd64/ignite /bundle/ignite
+
+RUN mkdir -p  opt/cni/bin
+RUN curl -sSL https://github.com/containernetworking/plugins/releases/download/${CNI_VERSION}/cni-plugins-linux-${ARCH}-${CNI_VERSION}.tgz | tar -xz -C opt/cni/bin
+
+# Create wrapper
+RUN  mkdir /output
+WORKDIR /output
+RUN  linux-x64.warp-packer --arch linux-x64 --input_dir /bundle --exec ignite --output ignitew

--- a/Makefile
+++ b/Makefile
@@ -265,6 +265,12 @@ serve-docs: build-docs
 	@echo Stating docs website on http://localhost:${DOCS_PORT}/_build/html/index.html
 	@$(DOCKER) run -i --rm -p ${DOCS_PORT}:8000 -e USER_ID=$$UID ignite-docs
 
+build-ignitew: build-all
+	$(DOCKER) build --no-cache -t ignitew-builder -f Dockerfile.ignitew .
+	$(DOCKER) create --name=ignitew-builder ignitew-builder
+	$(DOCKER) cp ignitew-builder:/output/ignitew .
+	$(DOCKER) rm -f ignitew-builder
+
 e2e: build-all e2e-nobuild
 
 e2e-nobuild:

--- a/pkg/preflight/checkers/checks.go
+++ b/pkg/preflight/checkers/checks.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	api "github.com/weaveworks/ignite/pkg/apis/ignite"
@@ -99,9 +100,20 @@ func StartCmdChecks(vm *api.VM, ignoredPreflightErrors sets.String) error {
 	for _, dependency := range constants.PathDependencies {
 		checks = append(checks, ExistingFileChecker{filePath: dependency})
 	}
+	// This should be warning only, in case users prefer other network plugins
 	if providers.NetworkPluginName == network.PluginCNI {
-		for _, dependency := range constants.CNIDependencies {
-			checks = append(checks, ExistingFileChecker{filePath: dependency})
+		// In case of using ignitew, we put CNI plugin binaries relatively to the executable
+		exeDir := filepath.Dir(os.Args[0])
+		if _, err := os.Stat(exeDir); err == nil {
+			for _, dependency := range constants.CNIDependencies {
+				releativeCNIPath := filepath.Join(exeDir, dependency)
+				checks = append(checks, ExistingFileChecker{filePath: releativeCNIPath})
+			}
+		} else {
+			// Otherwise in the normal case, we check usually path
+			for _, dependency := range constants.CNIDependencies {
+				checks = append(checks, ExistingFileChecker{filePath: dependency})
+			}
 		}
 	}
 	checks = append(checks, providers.Runtime.PreflightChecker())


### PR DESCRIPTION
This PR introduce `ignitew`, a self-contained binary bundling `ignite` and CNI plugin binaries together.

`ignitew` can be used as a drop-in replacement of `ignite` OOTB without user manually installing CNI plugins.

It uses the excellent `warp-packer` https://github.com/dgiagio/warp to create the self contained binary. It uses no sandbox, so that the behaviour could be expected to be similar to the normal `ignite`.

**Example:**
```
$ sudo ls -al /opt/cni/bin/bridge
ls: cannot access '/opt/cni/bin/bridge': No such file or directory
$ sudo ls -al /opt/cni/bin/loopback
ls: cannot access '/opt/cni/bin/loopback': No such file or directory
$ ./ignitew version
Ignite version: version.Info{Major:"0", Minor:"6+", GitVersion:"v0.6.0-108+472f5f5d9ca49f", GitCommit:"472f5f5d9ca49f63d55bf2433d
e7eeafc946787b", GitTreeState:"clean", BuildDate:"2019-10-16T12:19:41Z", GoVersion:"go1.12.10", Compiler:"gc", Platform:"linux/am
d64"}
Firecracker version: v0.18.0
Runtime: containerd
$ sudo ./ignitew run weaveworks/ignite-ubuntu --ssh
INFO[0001] Created VM with ID "eee36d65bf8d132c" and name "little-forest" 
INFO[0001] Networking is handled by "cni"               
INFO[0001] Started Firecracker VM "eee36d65bf8d132c" in a container with ID "ignite-eee36d65bf8d132c" 
$ sudo ./ignitew exec little-forest -- uname -a
Linux localhost.localdomain 4.19.47 #1 SMP Tue Jul 16 18:57:23 UTC 2019 x86_64 x86_64 x86_64 GNU/Linux
$ sudo ./ignitew rm -f little-forest
INFO[0000] Removing the container with ID "ignite-eee36d65bf8d132c" from the "cni" network 
INFO[0000] Removed VM with name "little-forest" and ID "eee36d65bf8d132c" 
```