### PR TITLE
ignited: catch signals and cleanup socket file

### DIFF
--- a/cmd/ignited/ignited.go
+++ b/cmd/ignited/ignited.go
@@ -2,16 +2,43 @@ package main
 
 import (
 	"os"
+	"os/signal"
+	"path"
+	"syscall"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/weaveworks/ignite/cmd/ignited/cmd"
+	"github.com/weaveworks/ignite/pkg/constants"
 	"github.com/weaveworks/ignite/pkg/providers"
 	"github.com/weaveworks/ignite/pkg/providers/ignited"
 	"github.com/weaveworks/ignite/pkg/util"
 )
 
 func main() {
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		s := <-sigChan
+		log.Debugf("Signal %q caught", s)
+		cleanup()
+
+		log.Debug("Program terminated normally")
+		os.Exit(0)
+	}()
+
 	if err := Run(); err != nil {
+		log.Debugf("Termination with error: %v", err)
 		os.Exit(1)
+	}
+}
+
+func cleanup() {
+
+	var daemonSocket = path.Join(constants.DATA_DIR, constants.DAEMON_SOCKET)
+
+	err := os.Remove(daemonSocket)
+	if err == nil {
+		log.Debugf("Socket %q removed successfully", daemonSocket)
 	}
 }
 


### PR DESCRIPTION
This PR catches signals and cleans the left over socket file up.
Fixes #485 

**Result:**
```
DEBU[0000] FileWatcher: Monitoring thread started       
DEBU[0000] SyncStorage: Monitoring thread started       
DEBU[0000] FileWatcher: Dispatch thread started         
DEBU[0000] GenericWatchStorage: Monitoring thread started 
INFO[0000] Starting GitOps loop for repo at "git@github.com:chanwit/ignited-demo" 
INFO[0000] Whenever changes are pushed to the master branch, Ignite will apply the desired state locally 
DEBU[0000] Starting the commit loop...                  
DEBU[0000] Starting the repo sync...                    
DEBU[0000] Starting the checkout loop...                
INFO[0000] Initializing the Git repo...                 
INFO[0026] Git initialized: A bare clone of repo "git@github.com:chanwit/ignited-demo" has been made 
INFO[0026] New commit observed on branch "master": a57fca1f35fd9c42598e2d97824900b0e2cd2115. User initiated: true 
INFO[0026] Initial clone done, entering the checkout loop... 
DEBU[0030] FileWatcher: Dispatch thread started         
DEBU[0030] FileWatcher: Monitoring thread started       
DEBU[0030] GenericWatchStorage: Monitoring thread started 
DEBU[0030] SyncStorage: Monitoring thread started       
DEBU[0030] GenericMappedRawStorage: AddMapping: "vm/022b373de5d34c80" -> "/tmp/flux-working982449342/myvm.yaml" 
DEBU[0030] SyncStorage: Received update {{MODIFY &TypeMeta{Kind:VM,APIVersion:ignite.weave.works/v1alpha2,}} 0xc000370240} true 
DEBU[0030] SyncStorage: Sent update: {MODIFY &TypeMeta{Kind:VM,APIVersion:ignite.weave.works/v1alpha2,}} 
DEBU[0030] FileWatcher: Skipping suspended event MODIFY for path: "/tmp/flux-working982449342/myvm.yaml" 
^CDEBU[0066] Signal SIGTERM caught                        
DEBU[0066] Socket "/var/lib/firecracker/daemon.sock" removed successfully 
DEBU[0066] Program normally terminated     
```