### PR TITLE
Added stream contents of FIFO files to logs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,6 +47,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/pkg/sftp v1.11.0
 	github.com/prometheus/client_golang v1.5.1
+	github.com/rjeczalik/notify v0.9.2
 	github.com/sirupsen/logrus v1.5.0
 	github.com/spf13/cobra v0.0.7
 	github.com/spf13/pflag v1.0.5
@@ -58,6 +59,6 @@ require (
 	golang.org/x/sys v0.0.0-20200409092240-59c9f1ba88fa
 	gotest.tools v2.2.0+incompatible
 	k8s.io/apimachinery v0.18.1
-	k8s.io/kube-openapi v0.0.0-20200403204345-e1beb1bd0f35
+	k8s.io/kube-openapi v0.0.0-20200413232311-afe0b5e9f729
 	sigs.k8s.io/yaml v1.2.0
 )

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -41,9 +41,18 @@ const (
 	// In-container file name for the firecracker metrics FIFO
 	METRICS_FIFO = "firecracker_metrics.fifo"
 
+	// Persistent file to stream to from firecracker log FIFO
+	LOG_FIFO_PERSISTENT = "firecracker_log.log"
+
+	// Persistent file to stream to from firecracker metrics FIFO
+	METRICS_FIFO_PERSISTENT = "firecracker_metrics.log"
+
 	// Socket with a web server (with metrics for now) for the daemon
 	DAEMON_SOCKET = "daemon.sock"
 
 	// How many characters Ignite UIDs should have
 	IGNITE_UID_LENGTH = 16
+
+	// Max concurrent writers to LOG_FIFO and METRICS_FIFO
+	MAX_CONCURRENT_WRITERS = 5
 )

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/rand"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"strings"
@@ -11,8 +12,11 @@ import (
 	"time"
 
 	"github.com/goombaio/namegenerator"
+	"github.com/rjeczalik/notify"
 	log "github.com/sirupsen/logrus"
 	"github.com/weaveworks/ignite/pkg/constants"
+	//"github.com/containerd/fifo"
+	//"golang.org/x/net/context"
 )
 
 // GenericCheckErr is used by the commands to check if the action failed
@@ -169,4 +173,72 @@ func (p *Prefixer) Prefix(input ...interface{}) string {
 	}
 
 	return p.prefix
+}
+
+// Watch the fifo (named-pipe) file at pipePath and copy any
+// writes to the fifo buffer to a persitent file at filePath
+// Credit: https://stackoverflow.com/questions/45443414/read-continuously-from-a-named-pipe
+func NamedPipeWatcher(pipePath string, filePath string) {
+	var p, f *os.File
+	var err error
+	var e notify.EventInfo
+
+	syscall.Mkfifo(pipePath, 0666)
+
+	if p, err = os.Open(pipePath); os.IsNotExist(err) {
+		log.Fatalf("Named pipe '%s' does not exist", pipePath)
+	} else if os.IsPermission(err) {
+		log.Fatalf("Insufficient permissions to read named pipe '%s': %s", pipePath, err)
+	} else if err != nil {
+		log.Fatalf("Error while opening named pipe '%s': %s", pipePath, err)
+	}
+
+	defer p.Close()
+
+	// Do the same for the output file
+	if f, err = os.OpenFile(filePath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0666); os.IsNotExist(err) {
+		log.Fatalf("File '%s' does not exist", filePath)
+		return
+	} else if os.IsPermission(err) {
+		log.Fatalf("Insufficient permissions to open/create file '%s' for appending: %s", filePath, err)
+		return
+	} else if err != nil {
+		log.Fatalf("Error while opening file '%s' for writing: %err", filePath, err)
+		return
+	}
+
+	defer f.Close()
+
+	// Here is where it happens. We create a buffered channel for events which might happen
+	// on the file. The reason why we make it buffered to the number of expected concurrent writers
+	// is that if all writers would (theoretically) write at once or at least pretty close
+	// to each other, it might happen that we loose event. This is due to the underlying implementations
+	// not because of go.
+	c := make(chan notify.EventInfo, constants.MAX_CONCURRENT_WRITERS)
+
+	// Here we tell notify to watch out named pipe for events, Write and Remove events
+	// specifically. We watch for remove events, too, as this removes the file handle we
+	// read from, making reads impossible
+	notify.Watch(pipePath, c, notify.Write|notify.Remove)
+
+loop:
+	for {
+		// ...waiting for an event to be passed.
+		e = <-c
+
+		switch e.Event() {
+		case notify.Write:
+			// If it a a write event, we copy the content of the named pipe to
+			// our output file and wait for the next event to happen.
+			// Note that this is idempotent: Even if we have huge writes by multiple
+			// writers on the named pipe, the first call to Copy will copy the contents.
+			// The time to copy that data may well be longer than it takes to generate the events.
+			// However, subsequent calls may copy nothing, but that does not do any harm.
+			io.Copy(f, p)
+		case notify.Remove:
+			// Some user or process has removed the named pipe,
+			// so we have nothing left to read from.
+			break loop
+		}
+	}
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -333,6 +333,7 @@ github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
 # github.com/rjeczalik/notify v0.9.2
+## explicit
 github.com/rjeczalik/notify
 # github.com/russross/blackfriday/v2 v2.0.1
 github.com/russross/blackfriday/v2
@@ -517,7 +518,7 @@ k8s.io/apimachinery/third_party/forked/golang/json
 k8s.io/apimachinery/third_party/forked/golang/reflect
 # k8s.io/klog v1.0.0
 k8s.io/klog
-# k8s.io/kube-openapi v0.0.0-20200403204345-e1beb1bd0f35 => k8s.io/kube-openapi v0.0.0-20200121204235-bf4fb3bd569c
+# k8s.io/kube-openapi v0.0.0-20200413232311-afe0b5e9f729 => k8s.io/kube-openapi v0.0.0-20200121204235-bf4fb3bd569c
 ## explicit
 k8s.io/kube-openapi/pkg/common
 k8s.io/kube-openapi/pkg/util/proto


### PR DESCRIPTION
This PR adds goroutines launched in `ExecuteFirecracker()` which watch the FIFO files emitted by Firecracker and streams them to a persistent file with the same name but ending in `.log`.

We add the function `NamedPipeWatcher(pipePath string, filePath string)` in ` pkg/util/util.go` which handles streaming the contents from the FIFO at `pipePath` to a file at `filePath`.

If there is a more appropriate place for this function we can move it.

Fixes #88