### PR TITLE
Don't fail preflight when only `docker-containerd` is available

### DIFF
--- a/cmd/ignite/cmd/vmcmd/start.go
+++ b/cmd/ignite/cmd/vmcmd/start.go
@@ -42,4 +42,5 @@ func NewCmdStart(out io.Writer) *cobra.Command {
 func addStartFlags(fs *pflag.FlagSet, sf *run.StartFlags) {
 	cmdutil.AddInteractiveFlag(fs, &sf.Interactive)
 	fs.BoolVarP(&sf.Debug, "debug", "d", false, "Debug mode, keep container after VM shutdown")
+	fs.StringSliceVar(&sf.IgnoredPreflightErrors, "ignore-preflight-checks", []string{}, "A list of checks whose errors will be shown as warnings. Example: 'BinaryInPath,Port,ExistingFile'. Value 'all' ignores errors from all checks.")
 }

--- a/docs/cli/ignite/ignite_run.md
+++ b/docs/cli/ignite/ignite_run.md
@@ -27,20 +27,21 @@ ignite run <OCI image> [flags]
 ### Options
 
 ```
-      --config string            Specify a path to a file with the API resources you want to pass
-  -f, --copy-files strings       Copy files/directories from the host to the created VM
-      --cpus uint                VM vCPU count, 1 or even numbers between 1 and 32 (default 1)
-  -d, --debug                    Debug mode, keep container after VM shutdown
-  -h, --help                     help for run
-  -i, --interactive              Attach to the VM after starting
-      --kernel-args string       Set the command line for the kernel (default "console=ttyS0 reboot=k panic=1 pci=off ip=dhcp")
-  -k, --kernel-image oci-image   Specify an OCI image containing the kernel at /boot/vmlinux and optionally, modules (default weaveworks/ignite-kernel:4.19.47)
-      --memory size              Amount of RAM to allocate for the VM (default 512.0 MB)
-  -n, --name string              Specify the name
-  -p, --ports strings            Map host ports to VM ports
-  -s, --size size                VM filesystem size, for example 5GB or 2048MB (default 4.0 GB)
-      --ssh[=<path>]             Enable SSH for the VM. If <path> is given, it will be imported as the public key. If just '--ssh' is specified, a new keypair will be generated. (default is unset, which disables SSH access to the VM)
-  -v, --volumes volume           Expose block devices from the host inside the VM
+      --config string                     Specify a path to a file with the API resources you want to pass
+  -f, --copy-files strings                Copy files/directories from the host to the created VM
+      --cpus uint                         VM vCPU count, 1 or even numbers between 1 and 32 (default 1)
+  -d, --debug                             Debug mode, keep container after VM shutdown
+  -h, --help                              help for run
+      --ignore-preflight-checks strings   A list of checks whose errors will be shown as warnings. Example: 'BinaryInPath,Port,ExistingFile'. Value 'all' ignores errors from all checks.
+  -i, --interactive                       Attach to the VM after starting
+      --kernel-args string                Set the command line for the kernel (default "console=ttyS0 reboot=k panic=1 pci=off ip=dhcp")
+  -k, --kernel-image oci-image            Specify an OCI image containing the kernel at /boot/vmlinux and optionally, modules (default weaveworks/ignite-kernel:4.19.47)
+      --memory size                       Amount of RAM to allocate for the VM (default 512.0 MB)
+  -n, --name string                       Specify the name
+  -p, --ports strings                     Map host ports to VM ports
+  -s, --size size                         VM filesystem size, for example 5GB or 2048MB (default 4.0 GB)
+      --ssh[=<path>]                      Enable SSH for the VM. If <path> is given, it will be imported as the public key. If just '--ssh' is specified, a new keypair will be generated. (default is unset, which disables SSH access to the VM)
+  -v, --volumes volume                    Expose block devices from the host inside the VM
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli/ignite/ignite_start.md
+++ b/docs/cli/ignite/ignite_start.md
@@ -17,9 +17,10 @@ ignite start <vm> [flags]
 ### Options
 
 ```
-  -d, --debug         Debug mode, keep container after VM shutdown
-  -h, --help          help for start
-  -i, --interactive   Attach to the VM after starting
+  -d, --debug                             Debug mode, keep container after VM shutdown
+  -h, --help                              help for start
+      --ignore-preflight-checks strings   A list of checks whose errors will be shown as warnings. Example: 'BinaryInPath,Port,ExistingFile'. Value 'all' ignores errors from all checks.
+  -i, --interactive                       Attach to the VM after starting
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli/ignite/ignite_vm_run.md
+++ b/docs/cli/ignite/ignite_vm_run.md
@@ -27,20 +27,21 @@ ignite vm run <OCI image> [flags]
 ### Options
 
 ```
-      --config string            Specify a path to a file with the API resources you want to pass
-  -f, --copy-files strings       Copy files/directories from the host to the created VM
-      --cpus uint                VM vCPU count, 1 or even numbers between 1 and 32 (default 1)
-  -d, --debug                    Debug mode, keep container after VM shutdown
-  -h, --help                     help for run
-  -i, --interactive              Attach to the VM after starting
-      --kernel-args string       Set the command line for the kernel (default "console=ttyS0 reboot=k panic=1 pci=off ip=dhcp")
-  -k, --kernel-image oci-image   Specify an OCI image containing the kernel at /boot/vmlinux and optionally, modules (default weaveworks/ignite-kernel:4.19.47)
-      --memory size              Amount of RAM to allocate for the VM (default 512.0 MB)
-  -n, --name string              Specify the name
-  -p, --ports strings            Map host ports to VM ports
-  -s, --size size                VM filesystem size, for example 5GB or 2048MB (default 4.0 GB)
-      --ssh[=<path>]             Enable SSH for the VM. If <path> is given, it will be imported as the public key. If just '--ssh' is specified, a new keypair will be generated. (default is unset, which disables SSH access to the VM)
-  -v, --volumes volume           Expose block devices from the host inside the VM
+      --config string                     Specify a path to a file with the API resources you want to pass
+  -f, --copy-files strings                Copy files/directories from the host to the created VM
+      --cpus uint                         VM vCPU count, 1 or even numbers between 1 and 32 (default 1)
+  -d, --debug                             Debug mode, keep container after VM shutdown
+  -h, --help                              help for run
+      --ignore-preflight-checks strings   A list of checks whose errors will be shown as warnings. Example: 'BinaryInPath,Port,ExistingFile'. Value 'all' ignores errors from all checks.
+  -i, --interactive                       Attach to the VM after starting
+      --kernel-args string                Set the command line for the kernel (default "console=ttyS0 reboot=k panic=1 pci=off ip=dhcp")
+  -k, --kernel-image oci-image            Specify an OCI image containing the kernel at /boot/vmlinux and optionally, modules (default weaveworks/ignite-kernel:4.19.47)
+      --memory size                       Amount of RAM to allocate for the VM (default 512.0 MB)
+  -n, --name string                       Specify the name
+  -p, --ports strings                     Map host ports to VM ports
+  -s, --size size                         VM filesystem size, for example 5GB or 2048MB (default 4.0 GB)
+      --ssh[=<path>]                      Enable SSH for the VM. If <path> is given, it will be imported as the public key. If just '--ssh' is specified, a new keypair will be generated. (default is unset, which disables SSH access to the VM)
+  -v, --volumes volume                    Expose block devices from the host inside the VM
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli/ignite/ignite_vm_start.md
+++ b/docs/cli/ignite/ignite_vm_start.md
@@ -17,9 +17,10 @@ ignite vm start <vm> [flags]
 ### Options
 
 ```
-  -d, --debug         Debug mode, keep container after VM shutdown
-  -h, --help          help for start
-  -i, --interactive   Attach to the VM after starting
+  -d, --debug                             Debug mode, keep container after VM shutdown
+  -h, --help                              help for start
+      --ignore-preflight-checks strings   A list of checks whose errors will be shown as warnings. Example: 'BinaryInPath,Port,ExistingFile'. Value 'all' ignores errors from all checks.
+  -i, --interactive                       Attach to the VM after starting
 ```
 
 ### Options inherited from parent commands

--- a/pkg/runtime/containerd/client.go
+++ b/pkg/runtime/containerd/client.go
@@ -101,6 +101,12 @@ func getNewestAvailableContainerdRuntime() (string, error) {
 		return plugin.RuntimeLinuxV1, nil
 	}
 
+	// legacy fallback needs hard-coded binary name -- it's not exported by containerd/runtime/v1/shim
+	// this is for debian's packaging of docker.io
+	if _, err := exec.LookPath("docker-containerd-shim"); err == nil {
+		return plugin.RuntimeLinuxV1, nil
+	}
+
 	// default to the legacy runtime and return an error so the caller can decide what to do
 	return plugin.RuntimeLinuxV1, fmt.Errorf("a containerd-shim could not be found for runtimes %v, %s", v2ShimRuntimes, plugin.RuntimeLinuxV1)
 }


### PR DESCRIPTION
In the `docker.io` package in Debian 10, the containerd binary is shipped as `docker-containerd`
At the moment, Ignite fails the preflight checks for this. This PR fixes this false negative.
Similarly, if `docker-containerd` is available (only), then we should fall back to `RuntimeLinuxV1` without issuing the extra warning (not needed, it works well).

This PR also propagates through the ignore-preflight-checks flag to the user, and fixes minor bugs related to this.

@stealthybox @chanwit Please review