### PR TITLE
Always set keep_bootcon on ARM64, and update default kernel params

### DIFF
--- a/docs/cli/ignite/ignite_create.md
+++ b/docs/cli/ignite/ignite_create.md
@@ -38,7 +38,7 @@ ignite create <OCI image> [flags]
   -f, --copy-files strings       Copy files/directories from the host to the created VM
       --cpus uint                VM vCPU count, 1 or even numbers between 1 and 32 (default 1)
   -h, --help                     help for create
-      --kernel-args string       Set the command line for the kernel (default "console=ttyS0 reboot=k panic=1 pci=off ip=dhcp")
+      --kernel-args string       Set the command line for the kernel (default "console=ttyS0 reboot=k panic=1 pci=off ip=dhcp i8042.noaux i8042.nomux i8042.nopnp i8042.dumbkbd")
   -k, --kernel-image oci-image   Specify an OCI image containing the kernel at /boot/vmlinux and optionally, modules (default weaveworks/ignite-kernel:4.19.47)
       --memory size              Amount of RAM to allocate for the VM (default 512.0 MB)
   -n, --name string              Specify the name

--- a/docs/cli/ignite/ignite_run.md
+++ b/docs/cli/ignite/ignite_run.md
@@ -33,7 +33,7 @@ ignite run <OCI image> [flags]
   -d, --debug                    Debug mode, keep container after VM shutdown
   -h, --help                     help for run
   -i, --interactive              Attach to the VM after starting
-      --kernel-args string       Set the command line for the kernel (default "console=ttyS0 reboot=k panic=1 pci=off ip=dhcp")
+      --kernel-args string       Set the command line for the kernel (default "console=ttyS0 reboot=k panic=1 pci=off ip=dhcp i8042.noaux i8042.nomux i8042.nopnp i8042.dumbkbd")
   -k, --kernel-image oci-image   Specify an OCI image containing the kernel at /boot/vmlinux and optionally, modules (default weaveworks/ignite-kernel:4.19.47)
       --memory size              Amount of RAM to allocate for the VM (default 512.0 MB)
   -n, --name string              Specify the name

--- a/docs/cli/ignite/ignite_vm_create.md
+++ b/docs/cli/ignite/ignite_vm_create.md
@@ -38,7 +38,7 @@ ignite vm create <OCI image> [flags]
   -f, --copy-files strings       Copy files/directories from the host to the created VM
       --cpus uint                VM vCPU count, 1 or even numbers between 1 and 32 (default 1)
   -h, --help                     help for create
-      --kernel-args string       Set the command line for the kernel (default "console=ttyS0 reboot=k panic=1 pci=off ip=dhcp")
+      --kernel-args string       Set the command line for the kernel (default "console=ttyS0 reboot=k panic=1 pci=off ip=dhcp i8042.noaux i8042.nomux i8042.nopnp i8042.dumbkbd")
   -k, --kernel-image oci-image   Specify an OCI image containing the kernel at /boot/vmlinux and optionally, modules (default weaveworks/ignite-kernel:4.19.47)
       --memory size              Amount of RAM to allocate for the VM (default 512.0 MB)
   -n, --name string              Specify the name

--- a/docs/cli/ignite/ignite_vm_run.md
+++ b/docs/cli/ignite/ignite_vm_run.md
@@ -33,7 +33,7 @@ ignite vm run <OCI image> [flags]
   -d, --debug                    Debug mode, keep container after VM shutdown
   -h, --help                     help for run
   -i, --interactive              Attach to the VM after starting
-      --kernel-args string       Set the command line for the kernel (default "console=ttyS0 reboot=k panic=1 pci=off ip=dhcp")
+      --kernel-args string       Set the command line for the kernel (default "console=ttyS0 reboot=k panic=1 pci=off ip=dhcp i8042.noaux i8042.nomux i8042.nopnp i8042.dumbkbd")
   -k, --kernel-image oci-image   Specify an OCI image containing the kernel at /boot/vmlinux and optionally, modules (default weaveworks/ignite-kernel:4.19.47)
       --memory size              Amount of RAM to allocate for the VM (default 512.0 MB)
   -n, --name string              Specify the name

--- a/pkg/constants/vm.go
+++ b/pkg/constants/vm.go
@@ -8,10 +8,13 @@ const (
 	MANIFEST_DIR = "/etc/firecracker/manifests"
 
 	// Default values for VM options
-	VM_DEFAULT_CPUS        = 1
-	VM_DEFAULT_MEMORY      = 512 * MB
-	VM_DEFAULT_SIZE        = 4 * GB
-	VM_DEFAULT_KERNEL_ARGS = "console=ttyS0 reboot=k panic=1 pci=off ip=dhcp"
+	VM_DEFAULT_CPUS   = 1
+	VM_DEFAULT_MEMORY = 512 * MB
+	VM_DEFAULT_SIZE   = 4 * GB
+	// Refer to https://github.com/firecracker-microvm/firecracker/blob/master/src/vmm/src/vmm_config/boot_source.rs
+	// TODO: The Firecracker team don't use console=ttyS0 anymore, but 8250.nr_uarts=0 instead
+	// See https://github.com/firecracker-microvm/firecracker/pull/313 for more info
+	VM_DEFAULT_KERNEL_ARGS = "console=ttyS0 reboot=k panic=1 pci=off ip=dhcp i8042.noaux i8042.nomux i8042.nopnp i8042.dumbkbd"
 
 	// SSH key template for VMs
 	VM_SSH_KEY_TEMPLATE = "id_%s"

--- a/pkg/container/firecracker.go
+++ b/pkg/container/firecracker.go
@@ -6,7 +6,9 @@ import (
 	"os"
 	"os/signal"
 	"path"
+	"runtime"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -38,6 +40,12 @@ func ExecuteFirecracker(vm *api.VM, dhcpIfaces []DHCPInterface) error {
 	if len(cmdLine) == 0 {
 		// if for some reason cmdline would be unpopulated, set it to the default
 		cmdLine = constants.VM_DEFAULT_KERNEL_ARGS
+	}
+
+	// On ARM64, keep_bootcon needs to be applied to the kernel arguments
+	if runtime.GOARCH == "arm64" && !strings.Contains(cmdLine, "keep_bootcon") {
+		// Prepend keep_bootcon as per https://github.com/firecracker-microvm/firecracker/blob/master/docs/getting-started.md
+		cmdLine = fmt.Sprintf("keep_bootcon %s", cmdLine)
 	}
 
 	// Convert the logrus error level to a Firecracker compatible error level.


### PR DESCRIPTION
This PR makes sure `keep_bootcon` is given to the kernel args on ARM64.
It also updates the default kernel params to the new recommendations.

cc @chanwit @stealthybox 