### PR TITLE
Add labels to VMs

### DIFF
--- a/cmd/ignite/cmd/vmcmd/create.go
+++ b/cmd/ignite/cmd/vmcmd/create.go
@@ -70,6 +70,7 @@ func addCreateFlags(fs *pflag.FlagSet, cf *run.CreateFlags) {
 	// Register flags for simple types (int, string, etc.)
 	fs.Uint64Var(&cf.VM.Spec.CPUs, "cpus", cf.VM.Spec.CPUs, "VM vCPU count, 1 or even numbers between 1 and 32")
 	fs.StringVar(&cf.VM.Spec.Kernel.CmdLine, "kernel-args", cf.VM.Spec.Kernel.CmdLine, "Set the command line for the kernel")
+	fs.StringArrayVarP(&cf.Labels, "label", "l", cf.Labels, "Set a label (foo=bar)")
 
 	// Register more complex flags with their own flag types
 	cmdutil.SizeVar(fs, &cf.VM.Spec.Memory, "memory", "Amount of RAM to allocate for the VM")

--- a/cmd/ignite/run/create.go
+++ b/cmd/ignite/run/create.go
@@ -31,6 +31,7 @@ type CreateFlags struct {
 	SSH        api.SSH
 	ConfigFile string
 	VM         *api.VM
+	Labels     []string
 }
 
 type createOptions struct {
@@ -113,6 +114,10 @@ func (cf *CreateFlags) NewCreateOptions(args []string) (*createOptions, error) {
 func Create(co *createOptions) error {
 	// Generate a random UID and Name
 	if err := metadata.SetNameAndUID(co.VM, providers.Client); err != nil {
+		return err
+	}
+	// Set VM labels.
+	if err := metadata.SetLabels(co.VM, co.Labels); err != nil {
 		return err
 	}
 	defer metadata.Cleanup(co.VM, false) // TODO: Handle silent

--- a/docs/cli/ignite/ignite_create.md
+++ b/docs/cli/ignite/ignite_create.md
@@ -40,6 +40,7 @@ ignite create <OCI image> [flags]
   -h, --help                     help for create
       --kernel-args string       Set the command line for the kernel (default "console=ttyS0 reboot=k panic=1 pci=off ip=dhcp")
   -k, --kernel-image oci-image   Specify an OCI image containing the kernel at /boot/vmlinux and optionally, modules (default weaveworks/ignite-kernel:4.19.47)
+  -l, --label stringArray        Set a label (foo=bar)
       --memory size              Amount of RAM to allocate for the VM (default 512.0 MB)
   -n, --name string              Specify the name
   -p, --ports strings            Map host ports to VM ports

--- a/docs/cli/ignite/ignite_run.md
+++ b/docs/cli/ignite/ignite_run.md
@@ -36,6 +36,7 @@ ignite run <OCI image> [flags]
   -i, --interactive                       Attach to the VM after starting
       --kernel-args string                Set the command line for the kernel (default "console=ttyS0 reboot=k panic=1 pci=off ip=dhcp")
   -k, --kernel-image oci-image            Specify an OCI image containing the kernel at /boot/vmlinux and optionally, modules (default weaveworks/ignite-kernel:4.19.47)
+  -l, --label stringArray                 Set a label (foo=bar)
       --memory size                       Amount of RAM to allocate for the VM (default 512.0 MB)
   -n, --name string                       Specify the name
   -p, --ports strings                     Map host ports to VM ports

--- a/docs/cli/ignite/ignite_vm_create.md
+++ b/docs/cli/ignite/ignite_vm_create.md
@@ -40,6 +40,7 @@ ignite vm create <OCI image> [flags]
   -h, --help                     help for create
       --kernel-args string       Set the command line for the kernel (default "console=ttyS0 reboot=k panic=1 pci=off ip=dhcp")
   -k, --kernel-image oci-image   Specify an OCI image containing the kernel at /boot/vmlinux and optionally, modules (default weaveworks/ignite-kernel:4.19.47)
+  -l, --label stringArray        Set a label (foo=bar)
       --memory size              Amount of RAM to allocate for the VM (default 512.0 MB)
   -n, --name string              Specify the name
   -p, --ports strings            Map host ports to VM ports

--- a/docs/cli/ignite/ignite_vm_run.md
+++ b/docs/cli/ignite/ignite_vm_run.md
@@ -36,6 +36,7 @@ ignite vm run <OCI image> [flags]
   -i, --interactive                       Attach to the VM after starting
       --kernel-args string                Set the command line for the kernel (default "console=ttyS0 reboot=k panic=1 pci=off ip=dhcp")
   -k, --kernel-image oci-image            Specify an OCI image containing the kernel at /boot/vmlinux and optionally, modules (default weaveworks/ignite-kernel:4.19.47)
+  -l, --label stringArray                 Set a label (foo=bar)
       --memory size                       Amount of RAM to allocate for the VM (default 512.0 MB)
   -n, --name string                       Specify the name
   -p, --ports strings                     Map host ports to VM ports

--- a/pkg/metadata/metadata.go
+++ b/pkg/metadata/metadata.go
@@ -1,10 +1,12 @@
 package metadata
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path"
 	"regexp"
+	"strings"
 
 	"github.com/weaveworks/gitops-toolkit/pkg/filter"
 	"github.com/weaveworks/gitops-toolkit/pkg/runtime"
@@ -21,6 +23,9 @@ var (
 	uidRegex  = regexp.MustCompile(`^[a-z0-9]{16}$`)
 )
 
+// ErrNilObject is returned when the runtime object being initialized is nil.
+var ErrNilObject = errors.New("object cannot be nil when initializing runtime data")
+
 type Metadata interface {
 	runtime.Object
 }
@@ -28,7 +33,7 @@ type Metadata interface {
 // SetNameAndUID sets the name and UID for an object if that isn't set automatically
 func SetNameAndUID(obj runtime.Object, c *client.Client) error {
 	if obj == nil {
-		return fmt.Errorf("object cannot be nil when initializing runtime data")
+		return ErrNilObject
 	}
 
 	if c == nil {
@@ -42,6 +47,27 @@ func SetNameAndUID(obj runtime.Object, c *client.Client) error {
 
 	// Generate or validate the given name, if any
 	return processName(obj, c)
+}
+
+// SetLabels metadata labels for a given object.
+func SetLabels(obj runtime.Object, labels []string) error {
+	if obj == nil {
+		return ErrNilObject
+	}
+
+	for _, label := range labels {
+		kv := strings.SplitN(label, "=", 2)
+		// Check the length of key/val. Must be exactly 2.
+		if len(kv) != 2 {
+			return fmt.Errorf("invalid label value %q: supported syntax: --label <key>=<value>", label)
+		}
+		// Label name must not be empty.
+		if kv[0] == "" {
+			return fmt.Errorf("invalid label %q, name empty", label)
+		}
+		obj.SetLabel(kv[0], kv[1])
+	}
+	return nil
 }
 
 // processUID a new 8-byte ID and handles directory creation/deletion

--- a/pkg/metadata/metadata_test.go
+++ b/pkg/metadata/metadata_test.go
@@ -1,0 +1,68 @@
+package metadata
+
+import (
+	"testing"
+
+	"github.com/weaveworks/gitops-toolkit/pkg/runtime"
+	api "github.com/weaveworks/ignite/pkg/apis/ignite"
+)
+
+func TestSetLabels(t *testing.T) {
+	cases := []struct {
+		name       string
+		obj        runtime.Object
+		labels     []string
+		wantLabels map[string]string
+		err        bool
+	}{
+		{
+			name: "nil runtime object",
+			obj:  nil,
+			err:  true,
+		},
+		{
+			name: "valid labels",
+			obj:  &api.VM{},
+			labels: []string{
+				"label1=value1",
+				"label2=value2",
+				"label3=",
+				"label4=value4,label5=value5",
+			},
+			wantLabels: map[string]string{
+				"label1": "value1",
+				"label2": "value2",
+				"label3": "",
+				"label4": "value4,label5=value5",
+			},
+		},
+		{
+			name:   "invalid label - key without value",
+			obj:    &api.VM{},
+			labels: []string{"key1"},
+			err:    true,
+		},
+		{
+			name:   "invalid label - empty name",
+			obj:    &api.VM{},
+			labels: []string{"="},
+			err:    true,
+		},
+	}
+
+	for _, rt := range cases {
+		t.Run(rt.name, func(t *testing.T) {
+			err := SetLabels(rt.obj, rt.labels)
+			if (err != nil) != rt.err {
+				t.Errorf("expected error %t, actual: %v", rt.err, err)
+			}
+
+			// Check the values of all the labels.
+			for k, v := range rt.wantLabels {
+				if rt.obj.GetLabel(k) != v {
+					t.Errorf("expected label key %q to have value %q, actual: %q", k, v, rt.obj.GetLabel(k))
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds a new flag `--label` to VM create command for setting label on the VM
object. The flag is of StringArray type and can be used multiple times
to set more than one label.

```
# ignite create weaveworks/ignite-ubuntu --name my-vm1 -l label1=val1 -l label2=val2
```
vm inspect result:
```
# ignite inspect vm my-vm1
{
  "kind": "VM",
  "apiVersion": "ignite.weave.works/v1alpha2",
  "metadata": {
    "name": "my-vm1",
    "uid": "70d265ddaaa92462",
    "created": "2020-02-02T12:37:21Z",
    "labels": {
      "label1": "val1",
      "label2": "val2"
    }
...
```