### PR TITLE
Template formatted output for ps & inspect

### DIFF
--- a/cmd/ignite/cmd/inspect.go
+++ b/cmd/ignite/cmd/inspect.go
@@ -42,4 +42,5 @@ func NewCmdInspect(out io.Writer) *cobra.Command {
 
 func addInspectFlags(fs *pflag.FlagSet, i *run.InspectFlags) {
 	fs.StringVarP(&i.OutputFormat, "output", "o", "json", "Output the object in the specified format")
+	fs.StringVarP(&i.TemplateFormat, "template", "t", "", "Format the output using the given Go template")
 }

--- a/cmd/ignite/cmd/vmcmd/ps.go
+++ b/cmd/ignite/cmd/vmcmd/ps.go
@@ -69,4 +69,5 @@ func NewCmdPs(out io.Writer) *cobra.Command {
 func addPsFlags(fs *pflag.FlagSet, pf *run.PsFlags) {
 	fs.BoolVarP(&pf.All, "all", "a", false, "Show all VMs, not just running ones")
 	fs.StringVarP(&pf.Filter, "filter", "f", "", "Filter the VMs")
+	fs.StringVarP(&pf.TemplateFormat, "template", "t", "", "Format the output using the given Go template")
 }

--- a/cmd/ignite/run/inspect_test.go
+++ b/cmd/ignite/run/inspect_test.go
@@ -1,0 +1,101 @@
+package run
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/weaveworks/gitops-toolkit/pkg/runtime"
+)
+
+// Update the test output golden files with this flag.
+var update = flag.Bool("update", false, "update inspect output golden files")
+
+// Update the golden files with:
+//   go test -v github.com/weaveworks/ignite/cmd/ignite/run -run TestInspect -update
+func TestInspect(t *testing.T) {
+	cases := []struct {
+		name         string
+		inspectFlags *InspectFlags
+		golden       string
+		err          bool
+	}{
+		{
+			name:         "json output",
+			inspectFlags: &InspectFlags{OutputFormat: "json"},
+			golden:       "output/inspect-json.txt",
+		},
+		{
+			name:         "yaml output",
+			inspectFlags: &InspectFlags{OutputFormat: "yaml"},
+			golden:       "output/inspect-yaml.txt",
+		},
+		{
+			name:         "template formatted output",
+			inspectFlags: &InspectFlags{TemplateFormat: "{{.ObjectMeta.Name}} {{.Spec.Image.OCI}}"},
+			golden:       "output/inspect-template.txt",
+		},
+		{
+			name:         "unknown output - error",
+			inspectFlags: &InspectFlags{OutputFormat: "text"},
+			err:          true,
+		},
+	}
+
+	for _, rt := range cases {
+		t.Run(rt.name, func(t *testing.T) {
+			vm, err := createTestVM("someVM", "1699b6ba255cde7f")
+			if err != nil {
+				t.Fatalf("failed to create test vm: %v", err)
+			}
+
+			iop := &inspectOptions{InspectFlags: rt.inspectFlags, object: runtime.Object(vm)}
+
+			// Run inspect and capture stdout.
+			oldStdout := os.Stdout
+			r, w, _ := os.Pipe()
+			os.Stdout = w
+
+			err = Inspect(iop)
+
+			w.Close()
+			os.Stdout = oldStdout
+
+			var buf bytes.Buffer
+			io.Copy(&buf, r)
+
+			// Construct golden file path.
+			goldenFilePath := fmt.Sprintf("testdata%c%s", filepath.Separator, rt.golden)
+
+			// Update the golden file if needed.
+			if *update {
+				t.Log("update inspect golden files")
+				if err := ioutil.WriteFile(goldenFilePath, buf.Bytes(), 0644); err != nil {
+					t.Fatalf("failed to update inspect golden file: %s: %v", goldenFilePath, err)
+				}
+			}
+
+			// Check output only when no error is expected.
+			if !rt.err {
+				// Read golden file.
+				wantOutput, err := ioutil.ReadFile(goldenFilePath)
+				if err != nil {
+					t.Fatalf("failed to read inspect golden file: %s: %v", goldenFilePath, err)
+				}
+
+				if !bytes.Equal(buf.Bytes(), wantOutput) {
+					t.Errorf("expected output to be:\n%v\ngot output:\n%v", wantOutput, buf.Bytes())
+				}
+			}
+
+			if (err != nil) != rt.err {
+				t.Errorf("expected error %t, actual: %v", rt.err, err)
+			}
+		})
+	}
+}

--- a/cmd/ignite/run/ps_test.go
+++ b/cmd/ignite/run/ps_test.go
@@ -1,0 +1,154 @@
+package run
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/weaveworks/gitops-toolkit/pkg/runtime"
+	api "github.com/weaveworks/ignite/pkg/apis/ignite"
+	meta "github.com/weaveworks/ignite/pkg/apis/meta/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/weaveworks/ignite/pkg/util"
+)
+
+// createTestVM creates a VM object, given a name and ID (optional) with default
+// images.
+func createTestVM(name, id string) (*api.VM, error) {
+	vm := &api.VM{}
+	vm.SetName(name)
+
+	// Generate an ID if not provided.
+	if id == "" {
+		uid, err := util.NewUID()
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate new UID: %v", err)
+		}
+		id = uid
+	}
+	vm.SetUID(runtime.UID(id))
+
+	// Set a fixed time for deterministic results.
+	createdTime := time.Date(2000, time.January, 1, 1, 0, 0, 0, time.UTC)
+	vm.SetCreated(runtime.Time{Time: metav1.Time{Time: createdTime}})
+
+	// Set VM image.
+	ociRef, err := meta.NewOCIImageRef("foo/bar:latest")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create new image reference: %v", err)
+	}
+	img := &api.Image{
+		Spec: api.ImageSpec{
+			OCI: ociRef,
+		},
+	}
+	vm.SetImage(img)
+
+	// Set Kernel image.
+	ociRefKernel, err := meta.NewOCIImageRef("foo/bar:latest")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create new image reference: %v", err)
+	}
+	kernel := &api.Kernel{
+		Spec: api.KernelSpec{
+			OCI: ociRefKernel,
+		},
+	}
+	vm.SetKernel(kernel)
+
+	return vm, nil
+}
+
+// Update the golden files with:
+//   go test -v github.com/weaveworks/ignite/cmd/ignite/run -run TestPs -update
+func TestPs(t *testing.T) {
+	// Existing VMs with ID for deterministic results.
+	existingVMs := map[string]string{
+		"vm1": "cddc37ba657766e3",
+		"vm2": "20e1d566ce318ada",
+		"vm3": "bfc80c948b1e2419",
+	}
+
+	cases := []struct {
+		name    string
+		psFlags *PsFlags
+		golden  string
+	}{
+		{
+			name:    "list in table format",
+			psFlags: &PsFlags{},
+			golden:  "output/ps-table.txt",
+		},
+		{
+			name:    "filtered list in table format",
+			psFlags: &PsFlags{Filter: "{{.ObjectMeta.Name}}=vm2"},
+			golden:  "output/ps-filtered-table.txt",
+		},
+		{
+			name:    "formatted filtered list",
+			psFlags: &PsFlags{Filter: "{{.ObjectMeta.Name}}!=vm2", TemplateFormat: "Name: {{.ObjectMeta.Name}} Image: {{.Spec.Image.OCI}}"},
+			golden:  "output/ps-formatted-table.txt",
+		},
+	}
+
+	for _, rt := range cases {
+		t.Run(rt.name, func(t *testing.T) {
+			vms := []*api.VM{}
+
+			// Create VMs.
+			for name, id := range existingVMs {
+				vm, err := createTestVM(name, id)
+				if err != nil {
+					t.Errorf("failed to create VM: %v", err)
+				}
+				vms = append(vms, vm)
+			}
+
+			psop := &psOptions{PsFlags: rt.psFlags, allVMs: vms}
+
+			// Run vm list and capture stdout.
+			oldStdout := os.Stdout
+			r, w, _ := os.Pipe()
+			os.Stdout = w
+
+			if err := Ps(psop); err != nil {
+				t.Errorf("unexpected error while listing VMs: %v", err)
+			}
+
+			w.Close()
+			os.Stdout = oldStdout
+
+			var buf bytes.Buffer
+			io.Copy(&buf, r)
+
+			// Construct golden file path.
+			goldenFilePath := fmt.Sprintf("testdata%c%s", filepath.Separator, rt.golden)
+
+			// Update the golden file if needed.
+			if *update {
+				t.Log("update ps golden files")
+				if err := ioutil.WriteFile(goldenFilePath, buf.Bytes(), 0644); err != nil {
+					t.Fatalf("failed to update ps golden file: %s: %v", goldenFilePath, err)
+				}
+			}
+
+			// Read golden file.
+			wantOutput, err := ioutil.ReadFile(goldenFilePath)
+			if err != nil {
+				t.Fatalf("failed to read ps golden file: %s: %v", goldenFilePath, err)
+			}
+
+			// Check if the output contains expected result.
+			if !bytes.Equal(buf.Bytes(), wantOutput) {
+				t.Errorf("expected output to be:\n%v\ngot output:\n%v", wantOutput, buf.Bytes())
+			}
+		})
+	}
+
+}

--- a/cmd/ignite/run/ps_test.go
+++ b/cmd/ignite/run/ps_test.go
@@ -68,11 +68,13 @@ func createTestVM(name, id string) (*api.VM, error) {
 // Update the golden files with:
 //   go test -v github.com/weaveworks/ignite/cmd/ignite/run -run TestPs -update
 func TestPs(t *testing.T) {
-	// Existing VMs with ID for deterministic results.
-	existingVMs := map[string]string{
-		"vm1": "cddc37ba657766e3",
-		"vm2": "20e1d566ce318ada",
-		"vm3": "bfc80c948b1e2419",
+	// Existing VMs with UID for deterministic results.
+	// A sorted list of VMs. The VM list returned by the VM filter is sorted by
+	// VM UID.
+	existingVMs := []runtime.ObjectMeta{
+		{Name: "vm1", UID: "20e1d566ce318ada"},
+		{Name: "vm2", UID: "bfc80c948b1e2419"},
+		{Name: "vm3", UID: "cddc37ba657766e3"},
 	}
 
 	cases := []struct {
@@ -102,8 +104,8 @@ func TestPs(t *testing.T) {
 			vms := []*api.VM{}
 
 			// Create VMs.
-			for name, id := range existingVMs {
-				vm, err := createTestVM(name, id)
+			for _, eVM := range existingVMs {
+				vm, err := createTestVM(eVM.Name, eVM.UID.String())
 				if err != nil {
 					t.Errorf("failed to create VM: %v", err)
 				}
@@ -146,7 +148,7 @@ func TestPs(t *testing.T) {
 
 			// Check if the output contains expected result.
 			if !bytes.Equal(buf.Bytes(), wantOutput) {
-				t.Errorf("expected output to be:\n%v\ngot output:\n%v", wantOutput, buf.Bytes())
+				t.Errorf("expected output to be:\n%v\ngot output:\n%v", string(wantOutput), string(buf.Bytes()))
 			}
 		})
 	}

--- a/cmd/ignite/run/testdata/output/inspect-json.txt
+++ b/cmd/ignite/run/testdata/output/inspect-json.txt
@@ -1,0 +1,37 @@
+{
+  "kind": "VM",
+  "apiVersion": "ignite.weave.works/v1alpha2",
+  "metadata": {
+    "name": "someVM",
+    "uid": "1699b6ba255cde7f",
+    "created": "2000-01-01T01:00:00Z"
+  },
+  "spec": {
+    "image": {
+      "oci": "foo/bar:latest"
+    },
+    "kernel": {
+      "oci": "foo/bar:latest"
+    },
+    "cpus": 0,
+    "memory": "0B",
+    "diskSize": "0B",
+    "network": {
+      
+    },
+    "storage": {
+      
+    }
+  },
+  "status": {
+    "running": false,
+    "image": {
+      "id": null,
+      "size": "0B"
+    },
+    "kernel": {
+      "id": null,
+      "size": "0B"
+    }
+  }
+}

--- a/cmd/ignite/run/testdata/output/inspect-template.txt
+++ b/cmd/ignite/run/testdata/output/inspect-template.txt
@@ -1,0 +1,1 @@
+someVM foo/bar:latest

--- a/cmd/ignite/run/testdata/output/inspect-yaml.txt
+++ b/cmd/ignite/run/testdata/output/inspect-yaml.txt
@@ -1,0 +1,24 @@
+apiVersion: ignite.weave.works/v1alpha2
+kind: VM
+metadata:
+  created: "2000-01-01T01:00:00Z"
+  name: someVM
+  uid: 1699b6ba255cde7f
+spec:
+  cpus: 0
+  diskSize: 0B
+  image:
+    oci: foo/bar:latest
+  kernel:
+    oci: foo/bar:latest
+  memory: 0B
+  network: {}
+  storage: {}
+status:
+  image:
+    id: null
+    size: 0B
+  kernel:
+    id: null
+    size: 0B
+  running: false

--- a/cmd/ignite/run/testdata/output/ps-filtered-table.txt
+++ b/cmd/ignite/run/testdata/output/ps-filtered-table.txt
@@ -1,2 +1,2 @@
 VM ID			IMAGE		KERNEL		SIZE	CPUS	MEMORY	CREATED	STATUS	IPS	PORTS	NAME
-20e1d566ce318ada	foo/bar:latest	foo/bar:latest	0 B	0	0 B	20y ago	Stopped			vm2
+bfc80c948b1e2419	foo/bar:latest	foo/bar:latest	0 B	0	0 B	20y ago	Stopped			vm2

--- a/cmd/ignite/run/testdata/output/ps-filtered-table.txt
+++ b/cmd/ignite/run/testdata/output/ps-filtered-table.txt
@@ -1,0 +1,2 @@
+VM ID			IMAGE		KERNEL		SIZE	CPUS	MEMORY	CREATED	STATUS	IPS	PORTS	NAME
+20e1d566ce318ada	foo/bar:latest	foo/bar:latest	0 B	0	0 B	20y ago	Stopped			vm2

--- a/cmd/ignite/run/testdata/output/ps-formatted-table.txt
+++ b/cmd/ignite/run/testdata/output/ps-formatted-table.txt
@@ -1,0 +1,2 @@
+Name: vm1 Image: foo/bar:latest
+Name: vm3 Image: foo/bar:latest

--- a/cmd/ignite/run/testdata/output/ps-table.txt
+++ b/cmd/ignite/run/testdata/output/ps-table.txt
@@ -1,4 +1,4 @@
 VM ID			IMAGE		KERNEL		SIZE	CPUS	MEMORY	CREATED	STATUS	IPS	PORTS	NAME
-cddc37ba657766e3	foo/bar:latest	foo/bar:latest	0 B	0	0 B	20y ago	Stopped			vm1
-20e1d566ce318ada	foo/bar:latest	foo/bar:latest	0 B	0	0 B	20y ago	Stopped			vm2
-bfc80c948b1e2419	foo/bar:latest	foo/bar:latest	0 B	0	0 B	20y ago	Stopped			vm3
+20e1d566ce318ada	foo/bar:latest	foo/bar:latest	0 B	0	0 B	20y ago	Stopped			vm1
+bfc80c948b1e2419	foo/bar:latest	foo/bar:latest	0 B	0	0 B	20y ago	Stopped			vm2
+cddc37ba657766e3	foo/bar:latest	foo/bar:latest	0 B	0	0 B	20y ago	Stopped			vm3

--- a/cmd/ignite/run/testdata/output/ps-table.txt
+++ b/cmd/ignite/run/testdata/output/ps-table.txt
@@ -1,0 +1,4 @@
+VM ID			IMAGE		KERNEL		SIZE	CPUS	MEMORY	CREATED	STATUS	IPS	PORTS	NAME
+cddc37ba657766e3	foo/bar:latest	foo/bar:latest	0 B	0	0 B	20y ago	Stopped			vm1
+20e1d566ce318ada	foo/bar:latest	foo/bar:latest	0 B	0	0 B	20y ago	Stopped			vm2
+bfc80c948b1e2419	foo/bar:latest	foo/bar:latest	0 B	0	0 B	20y ago	Stopped			vm3

--- a/docs/cli/ignite/ignite_inspect.md
+++ b/docs/cli/ignite/ignite_inspect.md
@@ -18,8 +18,9 @@ ignite inspect <kind> <object> [flags]
 ### Options
 
 ```
-  -h, --help            help for inspect
-  -o, --output string   Output the object in the specified format (default "json")
+  -h, --help              help for inspect
+  -o, --output string     Output the object in the specified format (default "json")
+  -t, --template string   Format the output using the given Go template
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli/ignite/ignite_ps.md
+++ b/docs/cli/ignite/ignite_ps.md
@@ -38,9 +38,10 @@ ignite ps [flags]
 ### Options
 
 ```
-  -a, --all             Show all VMs, not just running ones
-  -f, --filter string   Filter the VMs
-  -h, --help            help for ps
+  -a, --all               Show all VMs, not just running ones
+  -f, --filter string     Filter the VMs
+  -h, --help              help for ps
+  -t, --template string   Format the output using the given Go template
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli/ignite/ignite_vm_ps.md
+++ b/docs/cli/ignite/ignite_vm_ps.md
@@ -38,9 +38,10 @@ ignite vm ps [flags]
 ### Options
 
 ```
-  -a, --all             Show all VMs, not just running ones
-  -f, --filter string   Filter the VMs
-  -h, --help            help for ps
+  -a, --all               Show all VMs, not just running ones
+  -f, --filter string     Filter the VMs
+  -h, --help              help for ps
+  -t, --template string   Format the output using the given Go template
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
Adds new flag `--template` (`-t`) for Go template formatted output in `inspect` and `ps` subcommands.
Since `ps` command already has a `-f` flag for `--filter`, this uses `-t` for template formatted output.

Adds golden files based tests for Inspect() and Ps() to verify the results.