### PR TITLE
e2e test: Run the tests with vendored deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -279,6 +279,6 @@ e2e: build-all e2e-nobuild
 e2e-nobuild:
 	sudo IGNITE_E2E_HOME=$(shell pwd) \
 		$(shell which go) test \
-		./e2e/. -v \
+		./e2e/. -v -mod=vendor \
 		-count $(E2E_COUNT) \
 		-run $(E2E_REGEX)


### PR DESCRIPTION
Since the dependencies are checked into the repo, use vendored
dependencies while running e2e tests.