### PR TITLE
Tiny image import fix

### DIFF
--- a/e2e/image_test.go
+++ b/e2e/image_test.go
@@ -1,0 +1,33 @@
+package e2e
+
+import (
+	"fmt"
+	"os/exec"
+	"testing"
+
+	"gotest.tools/assert"
+)
+
+func TestImportTinyImage(t *testing.T) {
+	assert.Assert(t, e2eHome != "", "IGNITE_E2E_HOME should be set")
+
+	// NOTE: Along with tiny image, this also tests the image import failure
+	// when there's no /etc directory in the image filesystem.
+
+	testImage := "hello-world:latest"
+	// Remove if the image already exists.
+	rmvImgCmd := exec.Command(
+		igniteBin,
+		"image", "rm", testImage,
+	)
+	// Ignore error if the image doesn't exists.
+	_, _ = rmvImgCmd.CombinedOutput()
+
+	// Import the image.
+	importImgCmd := exec.Command(
+		igniteBin,
+		"image", "import", testImage,
+	)
+	importImgOut, importImgErr := importImgCmd.CombinedOutput()
+	assert.Check(t, importImgErr, fmt.Sprintf("image import: \n%q\n%s", importImgCmd.Args, importImgOut))
+}


### PR DESCRIPTION
When an image is very small, filesystem creation using mkfs fails due to
not enough space. This adds a minimum base image size that's used when
the image is too small.

Also, fixes the /etc/resolv.conf symlink error when there's no /etc
directory in the image filesystem. /etc dir is created as part of the
import step if it doesn't exists.

Adds an e2e test for this fix using hello-world docker container image
which is tiny and lacks /etc dir.

Fixes #402 