### PR TITLE
Fix OCIString parsing of local docker images

### DIFF
--- a/pkg/apis/meta/v1alpha1/image_test.go
+++ b/pkg/apis/meta/v1alpha1/image_test.go
@@ -34,3 +34,48 @@ func TestNewOCIImageRef(t *testing.T) {
 		}
 	}
 }
+
+func TestParseOCIString(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		out  OCIContentID
+		err  bool
+	}{
+		{
+			name: "oci string with repo name",
+			in:   "oci://docker.io/library/hello-world@sha256:fce289e99eb9bca977dae136fbe2a82b6b7d4c372474c9235adc1741675f587e",
+			out: OCIContentID{
+				repoName: "docker.io/library/hello-world",
+				digest:   "sha256:fce289e99eb9bca977dae136fbe2a82b6b7d4c372474c9235adc1741675f587e",
+			},
+		},
+		{
+			name: "oci string local docker sha",
+			in:   "docker://sha256:fce289e99eb9bca977dae136fbe2a82b6b7d4c372474c9235adc1741675f587e",
+			out: OCIContentID{
+				digest: "sha256:fce289e99eb9bca977dae136fbe2a82b6b7d4c372474c9235adc1741675f587e",
+			},
+		},
+		{
+			name: "invalid oci string",
+			in:   "sha256:fce289e99eb9bca977dae136fbe2a82b6b7d4c372474c9235adc1741675f587e",
+			err:  true,
+		},
+	}
+
+	for _, rt := range tests {
+		t.Run(rt.name, func(t *testing.T) {
+			actual, err := parseOCIString(rt.in)
+			if (err != nil) != rt.err {
+				t.Errorf("expected error %t, actual: %v", rt.err, err)
+			}
+
+			if !rt.err {
+				if actual.String() != rt.out.String() {
+					t.Errorf("expected %q, actual: %q", rt.out.String(), actual.String())
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Local docker images don't have repo name in the OCI string.
Example: `docker://sha256:fce289e99eb9bca977dae136fbe2a82b6b7d4c372474c9235adc1741675f587e`

URL parsing OCI string of local docker image fails because of the
invalid url format.

I was working on local image import from a tar file and came across this issue when importing with runtime docker. Importing with containerd resulted in proper OCI string with repo name in it. When `/var/lib/firecracker/image` contains any image metadata with invalid OCI source ID, any ignite execution that reads images starts failing with errors like:
```
FATA[0000] v1alpha2.Image.Status: v1alpha2.ImageStatus.OCISource: v1alpha2.OCIImageSource.Size: ID: unmarshalerDecoder: parse docker://sha256:fce289e99eb9bca977dae136fbe2a82b6b7d4c372474c9235adc1741675f587e: invalid port ":fce289e99eb9bca977dae136fbe2a82b6b7d4c372474c9235adc1741675f587e" after host, error found in #10 byte of ...|1675f587e","size":"1|..., bigger context ...|977dae136fbe2a82b6b7d4c372474c9235adc1741675f587e","size":"1840B"}}}|... 
```

After debugging, the actual error was about the URL parse failure at `parseOCIString()`:
```
parse docker://sha256:fce289e99eb9bca977dae136fbe2a82b6b7d4c372474c9235adc1741675f587e: invalid port ":fce289e99eb9bca977dae136fbe2a82b6b7d4c372474c9235adc1741675f587e" after host
```
Adds tests to verify the fix.