### PR TITLE
[POC] Import images from tar file

### DIFF
--- a/cmd/ignite/cmd/imgcmd/image.go
+++ b/cmd/ignite/cmd/imgcmd/image.go
@@ -33,6 +33,7 @@ func NewCmdImage(out io.Writer) *cobra.Command {
 	}
 
 	cmd.AddCommand(NewCmdImport(out))
+	cmd.AddCommand(NewCmdTarImport(out))
 	cmd.AddCommand(NewCmdLs(out))
 	cmd.AddCommand(NewCmdRm(out))
 	return cmd

--- a/cmd/ignite/cmd/imgcmd/tar_import.go
+++ b/cmd/ignite/cmd/imgcmd/tar_import.go
@@ -1,0 +1,29 @@
+package imgcmd
+
+import (
+	"io"
+
+	"github.com/lithammer/dedent"
+	"github.com/spf13/cobra"
+	"github.com/weaveworks/ignite/cmd/ignite/cmd/cmdutil"
+	"github.com/weaveworks/ignite/cmd/ignite/run"
+)
+
+// NewCmdImport imports new VM images from a tar source.
+func NewCmdTarImport(out io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "tarimport <OCI image>",
+		Short: "Import new base images for VMs from a tar file",
+		Long: dedent.Dedent(`
+			Import OCI images as a base images for VMs from a tar file, takes in a file path to
+			a tar file.
+		`),
+		Args: cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.CheckErr(func() error {
+				return run.ImportTarFile(args[0])
+			}())
+		},
+	}
+	return cmd
+}

--- a/cmd/ignite/run/import.go
+++ b/cmd/ignite/run/import.go
@@ -8,6 +8,11 @@ import (
 	"github.com/weaveworks/ignite/pkg/providers"
 )
 
+// ImportTarFile imports an image from a tar file.
+func ImportTarFile(tarPath string) error {
+	return operations.ImportImageFromTar(providers.Client, tarPath)
+}
+
 func ImportImage(source string) (*api.Image, error) {
 	ociRef, err := meta.NewOCIImageRef(source)
 	if err != nil {

--- a/pkg/apis/meta/v1alpha1/image.go
+++ b/pkg/apis/meta/v1alpha1/image.go
@@ -111,6 +111,13 @@ var _ json.Marshaler = &OCIContentID{}
 var _ json.Unmarshaler = &OCIContentID{}
 
 func parseOCIString(s string) (*OCIContentID, error) {
+	// Check the OCI string ID prefix to determine if it's a local image without
+	// any repo name. Parsing local images that don't have repo name with
+	// url.Parse fails because there's no host in the string.
+	if strings.HasPrefix(s, ociSchemeLocal) {
+		return ParseOCIContentID(strings.TrimPrefix(s, ociSchemeLocal))
+	}
+
 	u, err := url.Parse(s)
 	if err != nil {
 		return nil, err

--- a/pkg/runtime/types.go
+++ b/pkg/runtime/types.go
@@ -51,6 +51,7 @@ type ContainerConfig struct {
 
 type Interface interface {
 	PullImage(image meta.OCIImageRef) error
+	ImportImage(imageFilePath string) ([]meta.OCIImageRef, error)
 	InspectImage(image meta.OCIImageRef) (*ImageInspectResult, error)
 	ExportImage(image meta.OCIImageRef) (io.ReadCloser, func() error, error)
 

--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -12,8 +12,14 @@ type Source interface {
 	// Ref returns the reference of the source
 	Ref() meta.OCIImageRef
 
+	// SetRef allows setting reference of the source.
+	SetRef(meta.OCIImageRef)
+
 	// Parse verifies the ImageSource, fills in any missing fields and prepares the reader
 	Parse(src meta.OCIImageRef) (*api.OCIImageSource, error)
+
+	// Import  an image from a file source and prepares the reader.
+	Import(path string) (map[meta.OCIImageRef]*api.OCIImageSource, error)
 
 	// Reader provides a tar stream reader
 	Reader() (io.ReadCloser, error)


### PR DESCRIPTION
Implements importing local container images from tar file. Uses a new
subcommand `tarimport` for now, since `import` command is already used
for pulling the image from image repository.
Adds a new function `ImportImage()` in the runtime interface and
implements them for docker and containerd runtimes. The images are first
imported into the runtime's image store and then copied to ignite's
backend store as ignite VM images.

Usage:
```
ignite image tarimport hello-world.tar
```

`tarimport` is a placeholder subcommand for now. It'll be changed to something better after some feedback about the implementation.