### PR TITLE
Add --require-name to create and run commands

### DIFF
--- a/cmd/ignite/cmd/vmcmd/create.go
+++ b/cmd/ignite/cmd/vmcmd/create.go
@@ -71,6 +71,7 @@ func addCreateFlags(fs *pflag.FlagSet, cf *run.CreateFlags) {
 	fs.Uint64Var(&cf.VM.Spec.CPUs, "cpus", cf.VM.Spec.CPUs, "VM vCPU count, 1 or even numbers between 1 and 32")
 	fs.StringVar(&cf.VM.Spec.Kernel.CmdLine, "kernel-args", cf.VM.Spec.Kernel.CmdLine, "Set the command line for the kernel")
 	fs.StringArrayVarP(&cf.Labels, "label", "l", cf.Labels, "Set a label (foo=bar)")
+	fs.BoolVar(&cf.RequireName, "require-name", cf.RequireName, "Require VM name to be passed, no name generation")
 
 	// Register more complex flags with their own flag types
 	cmdutil.SizeVar(fs, &cf.VM.Spec.Memory, "memory", "Amount of RAM to allocate for the VM")

--- a/cmd/ignite/run/create.go
+++ b/cmd/ignite/run/create.go
@@ -28,10 +28,11 @@ type CreateFlags struct {
 	// If it was set using flags, it will be copied over to
 	// the API type. TODO: When we later have internal types
 	// this can go away
-	SSH        api.SSH
-	ConfigFile string
-	VM         *api.VM
-	Labels     []string
+	SSH         api.SSH
+	ConfigFile  string
+	VM          *api.VM
+	Labels      []string
+	RequireName bool
 }
 
 type createOptions struct {
@@ -64,6 +65,11 @@ func (cf *CreateFlags) constructVMFromCLI(args []string) error {
 	// If the SSH flag was set, copy it over to the API type
 	if cf.SSH.Generate || cf.SSH.PublicKey != "" {
 		cf.VM.Spec.SSH = &cf.SSH
+	}
+
+	// If --require-name is true, VM name must be provided.
+	if cf.RequireName && len(cf.VM.Name) == 0 {
+		return fmt.Errorf("must pass a VM name, flag --require-name set")
 	}
 
 	return nil

--- a/cmd/ignite/run/create.go
+++ b/cmd/ignite/run/create.go
@@ -83,6 +83,10 @@ func (cf *CreateFlags) NewCreateOptions(args []string) (*createOptions, error) {
 		if err := scheme.Serializer.DecodeFileInto(cf.ConfigFile, cf.VM); err != nil {
 			return nil, err
 		}
+		// If --require-name is true, VM name must be provided.
+		if cf.RequireName && len(cf.VM.Name) == 0 {
+			return nil, fmt.Errorf("must set VM name, flag --require-name set")
+		}
 	} else {
 		if err := cf.constructVMFromCLI(args); err != nil {
 			return nil, err

--- a/cmd/ignite/run/create_test.go
+++ b/cmd/ignite/run/create_test.go
@@ -1,0 +1,168 @@
+package run
+
+import (
+	"net"
+	"reflect"
+	"testing"
+
+	"github.com/weaveworks/gitops-toolkit/pkg/runtime"
+	api "github.com/weaveworks/ignite/pkg/apis/ignite"
+	meta "github.com/weaveworks/ignite/pkg/apis/meta/v1alpha1"
+)
+
+func TestConstructVMFromCLI(t *testing.T) {
+	testImage := "weaveworks/ubuntu"
+	testOCIRef, err := meta.NewOCIImageRef(testImage)
+	if err != nil {
+		t.Fatalf("error parsing image: %v", err)
+	}
+
+	tests := []struct {
+		name            string
+		createFlag      *CreateFlags
+		args            []string
+		wantCopyFiles   []api.FileMapping
+		wantPortMapping meta.PortMappings
+		wantSSH         api.SSH
+		err             bool
+	}{
+		{
+			name: "with VM name and image arg",
+			createFlag: &CreateFlags{
+				VM: &api.VM{
+					ObjectMeta: runtime.ObjectMeta{
+						Name: "fooVM",
+					},
+				},
+			},
+			args: []string{testImage},
+		},
+		{
+			name: "with invalid image reference",
+			createFlag: &CreateFlags{
+				VM: &api.VM{},
+			},
+			args: []string{"foo:bar:baz"},
+			err:  true,
+		},
+		{
+			name: "valid copy files flag",
+			createFlag: &CreateFlags{
+				VM:        &api.VM{},
+				CopyFiles: []string{"/tmp/foo:/tmp/bar"},
+			},
+			args: []string{testImage},
+			wantCopyFiles: []api.FileMapping{
+				{
+					HostPath: "/tmp/foo",
+					VMPath:   "/tmp/bar",
+				},
+			},
+		},
+		{
+			name: "invalid copy files syntax",
+			createFlag: &CreateFlags{
+				VM:        &api.VM{},
+				CopyFiles: []string{"foo:bar:baz"},
+			},
+			args: []string{testImage},
+			err:  true,
+		},
+		{
+			name: "invalid copy files paths - not absolute paths",
+			createFlag: &CreateFlags{
+				VM:        &api.VM{},
+				CopyFiles: []string{"foo:bar"},
+			},
+			args: []string{testImage},
+			err:  true,
+		},
+		{
+			name: "valid port mapping",
+			createFlag: &CreateFlags{
+				VM:           &api.VM{},
+				PortMappings: []string{"80:80"},
+			},
+			args: []string{testImage},
+			wantPortMapping: meta.PortMappings{
+				meta.PortMapping{
+					BindAddress: net.IPv4(0, 0, 0, 0),
+					HostPort:    uint64(80),
+					VMPort:      uint64(80),
+					Protocol:    meta.ProtocolTCP,
+				},
+			},
+		},
+		{
+			name: "invalid port mapping",
+			createFlag: &CreateFlags{
+				VM:           &api.VM{},
+				PortMappings: []string{"1.1.1.1:foo:bar"},
+			},
+			args: []string{testImage},
+			err:  true,
+		},
+		{
+			name: "ssh public key set",
+			createFlag: &CreateFlags{
+				VM: &api.VM{},
+				SSH: api.SSH{
+					Generate:  true,
+					PublicKey: "some-pub-key",
+				},
+			},
+			args: []string{testImage},
+			wantSSH: api.SSH{
+				Generate:  true,
+				PublicKey: "some-pub-key",
+			},
+		},
+		{
+			name: "with no VM name and --require-name flag set",
+			createFlag: &CreateFlags{
+				VM:          &api.VM{},
+				RequireName: true,
+			},
+			args: []string{testImage},
+			err:  true,
+		},
+	}
+
+	for _, rt := range tests {
+		t.Run(rt.name, func(t *testing.T) {
+			err := rt.createFlag.constructVMFromCLI(rt.args)
+			if (err != nil) != rt.err {
+				t.Errorf("expected error %t, actual: %v", rt.err, err)
+			}
+
+			if !rt.err {
+				// Check if the VM image is set as expected.
+				if rt.createFlag.VM.Spec.Image.OCI != testOCIRef {
+					t.Errorf("expected VM.Spec.Image.OCI to be %q, actual: %q", testOCIRef.String(), rt.createFlag.VM.Spec.Image.OCI.String())
+				}
+
+				// Check if copy files are set as expected.
+				if len(rt.wantCopyFiles) > 0 {
+					if !reflect.DeepEqual(rt.createFlag.VM.Spec.CopyFiles, rt.wantCopyFiles) {
+						t.Errorf("expected VM.Spec.CopyFiles to be %v, actual: %v", rt.wantCopyFiles, rt.createFlag.VM.Spec.CopyFiles)
+					}
+				} else {
+					// If the copy files map is empty, compare their sizes.
+					if len(rt.wantCopyFiles) != len(rt.createFlag.VM.Spec.CopyFiles) {
+						t.Errorf("expected VM.Spec.CopyFiles to be %v, actual: %v", rt.wantCopyFiles, rt.createFlag.VM.Spec.CopyFiles)
+					}
+				}
+
+				// Check if port mappings are set as expected.
+				if reflect.DeepEqual(rt.createFlag.VM.Spec.Network.Ports, rt.wantPortMapping) {
+					t.Errorf("expected VM.Spec.Network.Ports to be %v, actual: %v", rt.wantPortMapping, rt.createFlag.VM.Spec.Network.Ports)
+				}
+
+				// Check if the SSH values are set as expected.
+				if reflect.DeepEqual(rt.createFlag.VM.Spec.SSH, rt.wantSSH) {
+					t.Errorf("expected VM.Spec.SSH to be %v, actual: %v", rt.wantSSH, rt.createFlag.VM.Spec.SSH)
+				}
+			}
+		})
+	}
+}

--- a/cmd/ignite/run/create_test.go
+++ b/cmd/ignite/run/create_test.go
@@ -1,7 +1,9 @@
 package run
 
 import (
+	"fmt"
 	"net"
+	"path/filepath"
 	"reflect"
 	"testing"
 
@@ -162,6 +164,40 @@ func TestConstructVMFromCLI(t *testing.T) {
 				if reflect.DeepEqual(rt.createFlag.VM.Spec.SSH, rt.wantSSH) {
 					t.Errorf("expected VM.Spec.SSH to be %v, actual: %v", rt.wantSSH, rt.createFlag.VM.Spec.SSH)
 				}
+			}
+		})
+	}
+}
+
+func TestNewCreateOptions(t *testing.T) {
+	tests := []struct {
+		name       string
+		createFlag *CreateFlags
+		err        bool
+	}{
+		{
+			name: "require-name with no name",
+			createFlag: &CreateFlags{
+				VM:          &api.VM{},
+				RequireName: true,
+			},
+			err: true,
+		},
+		{
+			name: "require-name with VM config",
+			createFlag: &CreateFlags{
+				ConfigFile:  fmt.Sprintf("testdata%c%s", filepath.Separator, "input/create-config-no-name.yaml"),
+				RequireName: true,
+			},
+			err: true,
+		},
+	}
+
+	for _, rt := range tests {
+		t.Run(rt.name, func(t *testing.T) {
+			_, err := rt.createFlag.NewCreateOptions([]string{})
+			if (err != nil) != rt.err {
+				t.Errorf("expected error %t, actual: %v", rt.err, err)
 			}
 		})
 	}

--- a/cmd/ignite/run/testdata/input/create-config-no-name.yaml
+++ b/cmd/ignite/run/testdata/input/create-config-no-name.yaml
@@ -1,0 +1,5 @@
+apiVersion: ignite.weave.works/v1alpha2
+kind: VM
+spec:
+  image:
+    oci: weaveworks/ignite-ubuntu

--- a/docs/cli/ignite/ignite_create.md
+++ b/docs/cli/ignite/ignite_create.md
@@ -44,6 +44,7 @@ ignite create <OCI image> [flags]
       --memory size              Amount of RAM to allocate for the VM (default 512.0 MB)
   -n, --name string              Specify the name
   -p, --ports strings            Map host ports to VM ports
+      --require-name             Require VM name to be passed, no name generation
   -s, --size size                VM filesystem size, for example 5GB or 2048MB (default 4.0 GB)
       --ssh[=<path>]             Enable SSH for the VM. If <path> is given, it will be imported as the public key. If just '--ssh' is specified, a new keypair will be generated. (default is unset, which disables SSH access to the VM)
   -v, --volumes volume           Expose block devices from the host inside the VM

--- a/docs/cli/ignite/ignite_run.md
+++ b/docs/cli/ignite/ignite_run.md
@@ -40,6 +40,7 @@ ignite run <OCI image> [flags]
       --memory size                       Amount of RAM to allocate for the VM (default 512.0 MB)
   -n, --name string                       Specify the name
   -p, --ports strings                     Map host ports to VM ports
+      --require-name                      Require VM name to be passed, no name generation
   -s, --size size                         VM filesystem size, for example 5GB or 2048MB (default 4.0 GB)
       --ssh[=<path>]                      Enable SSH for the VM. If <path> is given, it will be imported as the public key. If just '--ssh' is specified, a new keypair will be generated. (default is unset, which disables SSH access to the VM)
   -v, --volumes volume                    Expose block devices from the host inside the VM

--- a/docs/cli/ignite/ignite_vm_create.md
+++ b/docs/cli/ignite/ignite_vm_create.md
@@ -44,6 +44,7 @@ ignite vm create <OCI image> [flags]
       --memory size              Amount of RAM to allocate for the VM (default 512.0 MB)
   -n, --name string              Specify the name
   -p, --ports strings            Map host ports to VM ports
+      --require-name             Require VM name to be passed, no name generation
   -s, --size size                VM filesystem size, for example 5GB or 2048MB (default 4.0 GB)
       --ssh[=<path>]             Enable SSH for the VM. If <path> is given, it will be imported as the public key. If just '--ssh' is specified, a new keypair will be generated. (default is unset, which disables SSH access to the VM)
   -v, --volumes volume           Expose block devices from the host inside the VM

--- a/docs/cli/ignite/ignite_vm_run.md
+++ b/docs/cli/ignite/ignite_vm_run.md
@@ -40,6 +40,7 @@ ignite vm run <OCI image> [flags]
       --memory size                       Amount of RAM to allocate for the VM (default 512.0 MB)
   -n, --name string                       Specify the name
   -p, --ports strings                     Map host ports to VM ports
+      --require-name                      Require VM name to be passed, no name generation
   -s, --size size                         VM filesystem size, for example 5GB or 2048MB (default 4.0 GB)
       --ssh[=<path>]                      Enable SSH for the VM. If <path> is given, it will be imported as the public key. If just '--ssh' is specified, a new keypair will be generated. (default is unset, which disables SSH access to the VM)
   -v, --volumes volume                    Expose block devices from the host inside the VM


### PR DESCRIPTION
Adds `--require-name` flag to create and run commands to fail when a VM
name is not passed. This can be used along with config file to avoid
generating different resource from the same config file due to generated
name and UID.

Adds tests to verify the change.

Follow up of https://github.com/weaveworks/ignite/pull/525