### PR TITLE
Fix image import with runtime docker

### DIFF
--- a/e2e/image_test.go
+++ b/e2e/image_test.go
@@ -31,3 +31,33 @@ func TestImportTinyImage(t *testing.T) {
 	importImgOut, importImgErr := importImgCmd.CombinedOutput()
 	assert.Check(t, importImgErr, fmt.Sprintf("image import: \n%q\n%s", importImgCmd.Args, importImgOut))
 }
+
+func TestDockerImportImage(t *testing.T) {
+	assert.Assert(t, e2eHome != "", "IGNITE_E2E_HOME should be set")
+
+	testImage := "hello-world:latest"
+	// Remove if the image already exists.
+	rmvImgCmd := exec.Command(
+		igniteBin,
+		"image", "rm", testImage,
+	)
+	// Ignore error if the image doesn't exists.
+	_, _ = rmvImgCmd.CombinedOutput()
+
+	// Remove image from docker image store if already exists.
+	rmvDockerImgCmd := exec.Command(
+		"docker",
+		"rmi", testImage,
+	)
+	// Ignore error if the image doesn't exists.
+	_, _ = rmvDockerImgCmd.CombinedOutput()
+
+	// Import the image.
+	importImgCmd := exec.Command(
+		igniteBin,
+		"--runtime=docker",
+		"image", "import", testImage,
+	)
+	importImgOut, importImgErr := importImgCmd.CombinedOutput()
+	assert.Check(t, importImgErr, fmt.Sprintf("image import: \n%q\n%s", importImgCmd.Args, importImgOut))
+}

--- a/pkg/runtime/docker/client.go
+++ b/pkg/runtime/docker/client.go
@@ -47,7 +47,7 @@ func (dc *dockerClient) PullImage(image meta.OCIImageRef) (err error) {
 	var rc io.ReadCloser
 	if rc, err = dc.client.ImagePull(context.Background(), image.Normalized(), types.ImagePullOptions{}); err == nil {
 		// Don't output the pull command
-		util.DeferErr(&err, rc.Close)
+		defer util.DeferErr(&err, rc.Close)
 		_, err = io.Copy(ioutil.Discard, rc)
 	}
 


### PR DESCRIPTION
Importing image with runtime docker fails because the ReadCloser is
closed too early.

```
# ignite image import hello-world:latest --runtime=docker
INFO[0000] docker image "hello-world:latest" not found locally, pulling...
FATA[0006] http: read on closed response body
```

Defer DeferErr to avoid closing the ReadCloser early.

Adds an e2e test to ensure image import works with docker runtime.