### PR TITLE
Run e2e in Travis CI /w nested virt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+language: minimal # git checkout will not be in a GOPATH
+dist: bionic # Ubuntu 18.04 required for nested-virt
+
+services:
+- docker
+
+env:
+- GIMME_GO_VERSION=1.12.17
+
+install:
+- eval "$(curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | bash)" # install specific go version
+- |
+  # https://ignite.readthedocs.io/en/latest/installation.html
+  sudo apt-get install -y cpu-checker
+  sudo apt-get install -y --no-install-recommends dmsetup openssh-client git binutils
+  sudo which containerd || sudo apt-get install -y --no-install-recommends containerd
+      # Install containerd if it's not present -- prevents breaking docker-ce installations
+- kvm-ok
+- |
+  export CNI_VERSION=v0.8.5
+  export ARCH=$([ $(uname -m) = "x86_64" ] && echo amd64 || echo arm64)
+  sudo mkdir -p /opt/cni/bin
+  curl -sSL https://github.com/containernetworking/plugins/releases/download/${CNI_VERSION}/cni-plugins-linux-${ARCH}-${CNI_VERSION}.tgz | sudo tar -xz -C /opt/cni/bin
+
+before_script:
+- make ignite ignite-spawn bin/amd64/Dockerfile GO_MAKE_TARGET=local GIT_VERSION=v0.0-${TRAVIS_COMMIT}-e2e  # bypass hack/ldflags.sh -- no tag info in shallow clone
+
+script:
+- make e2e-nobuild  # this depends on Travis CI's support for nested virtualization

--- a/Makefile
+++ b/Makefile
@@ -203,9 +203,9 @@ api-doc:
 			bin/tmp/${GROUP_VERSION}.md > docs/api/${GROUP_VERSION}.md
 
 autogen: api-docs
-	$(MAKE) go-make TARGETS="dockerized-autogen"
+	$(MAKE) go-make TARGETS="go-autogen"
 
-dockerized-autogen: /go/bin/deepcopy-gen /go/bin/defaulter-gen /go/bin/conversion-gen /go/bin/openapi-gen
+go-autogen: /go/bin/deepcopy-gen /go/bin/defaulter-gen /go/bin/conversion-gen /go/bin/openapi-gen
 	# Let the boilerplate be empty
 	touch /tmp/boilerplate
 	/go/bin/deepcopy-gen \

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ DOCKER_USER?=weaveworks
 IMAGE=$(DOCKER_USER)/ignite
 GIT_VERSION:=$(shell hack/ldflags.sh --version-only)
 IMAGE_DEV_TAG=dev
-IMAGE_TAG:=$(shell hack/ldflags.sh --image-tag-only)
+IMAGE_TAG:=$(shell IGNITE_GIT_VERSION=$(GIT_VERSION) hack/ldflags.sh --image-tag-only)
 # IS_DIRTY is 1 if the tree state is dirty, otherwise 0
 IS_DIRTY:=$(shell echo ${GIT_VERSION} | grep -o dirty | wc -l)
 PROJECT = github.com/weaveworks/ignite
@@ -107,7 +107,7 @@ go-in-docker: # Do not use directly -- use $(GO_MAKE_TARGET)
 # Make make execute this target although the file already exists.
 .PHONY: bin/$(GOARCH)/ignite bin/$(GOARCH)/ignite-spawn bin/$(GOARCH)/ignited
 bin/$(GOARCH)/ignite bin/$(GOARCH)/ignited bin/$(GOARCH)/ignite-spawn: bin/$(GOARCH)/%:
-	CGO_ENABLED=0 GOARCH=$(GOARCH) go build -mod=vendor -ldflags "$(shell ./hack/ldflags.sh)" -o bin/$(GOARCH)/$* ./cmd/$*
+	CGO_ENABLED=0 GOARCH=$(GOARCH) go build -mod=vendor -ldflags "$(shell IGNITE_GIT_VERSION=$(GIT_VERSION) ./hack/ldflags.sh)" -o bin/$(GOARCH)/$* ./cmd/$*
 ifeq ($(GOARCH),$(GOHOSTARCH))
 	ln -sf ./$(GOARCH)/$* bin/$*
 endif

--- a/hack/ldflags.sh
+++ b/hack/ldflags.sh
@@ -9,8 +9,12 @@ get_version_vars() {
   else
     IGNITE_GIT_TREE_STATE="dirty"
   fi
-  # Use git describe to find the version based on tags.
-  IGNITE_GIT_VERSION=$(git describe --tags --abbrev=14 "${IGNITE_GIT_COMMIT}^{commit}" 2>/dev/null)
+
+  # allow env override for IGNITE_GIT_VERSION
+  if [ -z "${IGNITE_GIT_VERSION}" ]; then
+    # Use git describe to find the version based on tags.
+    IGNITE_GIT_VERSION=$(git describe --tags --abbrev=14 "${IGNITE_GIT_COMMIT}^{commit}" 2>/dev/null)
+  fi
 
   # This translates the "git describe" to an actual semver.org
   # compatible semantic version that looks something like this:


### PR DESCRIPTION
`kvm-ok` works on ubuntu 18.04 (bionic) in Travis CI.
We can use this to add valuable E2E signal in addition to CircleCI.

The only feature I don't see Travis supporting is provider hosted artifacts.
Travis supports artifacts but requires you to bring your own S3 bucket.
CircleCI is currently hosting artifacts for our existing pipelines.

Related #392