### PR TITLE
Add OCI tool choice

### DIFF
--- a/images/kernel/Makefile
+++ b/images/kernel/Makefile
@@ -1,4 +1,5 @@
 # Check https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/refs/ for updates
+OCI_TOOL?=docker
 REGISTRY?=weaveworks
 IMAGE_NAME?=${REGISTRY}/ignite-kernel
 KERNEL_VERSIONS ?= 4.14.166 4.19.97 5.4.13
@@ -28,7 +29,7 @@ upgrade-%:
 
 build: $(addprefix build-,$(KERNEL_VERSIONS))
 build-%:
-	docker build -t $(IMAGE_NAME):$*-${GOARCH} \
+	$(OCI_TOOL) build -t $(IMAGE_NAME):$*-${GOARCH} \
 		--build-arg KERNEL_VERSION=$* \
 		--build-arg ARCH=${KERNEL_ARCH} \
 		--build-arg GOARCH=${GOARCH} \

--- a/images/kernel/upgrade-config.sh
+++ b/images/kernel/upgrade-config.sh
@@ -21,7 +21,13 @@ if [[ ${FROM} != ${TO} ]]; then
     cp ${FROM} ${TO}
 fi
 
-docker run -it \
+if ! [ -x "$(command -v podman)" ]; then
+  oci_tool=podman
+else
+  oci_tool=docker
+fi
+
+${oci_tool} run -it \
     ${ARCH_PARAMETER} \
 	-v $(pwd)/${TO}:/tmp/.config \
     ${KERNEL_BUILDER_IMAGE} /bin/bash -c "\


### PR DESCRIPTION
Only alters kernel build scripts.
Preserves existing behavior.
Defaults to `docker` when `podman` is not available.

Tested as working via `make`

Signed-off-by: Begley Brothers Inc <begleybrothers@gmail.com>