### PR TITLE
Add interactive vm exec support

### DIFF
--- a/cmd/ignite/cmd/vmcmd/exec.go
+++ b/cmd/ignite/cmd/vmcmd/exec.go
@@ -42,5 +42,6 @@ func NewCmdExec(out io.Writer, err io.Writer, in io.Reader) *cobra.Command {
 
 func addExecFlags(fs *pflag.FlagSet, ef *run.ExecFlags) {
 	fs.StringVarP(&ef.IdentityFile, "identity", "i", "", "Override the vm's default identity file")
-	fs.Uint32VarP(&ef.Timeout, "timeout", "t", 10, "Timeout waiting for connection in seconds")
+	fs.Uint32Var(&ef.Timeout, "timeout", 10, "Timeout waiting for connection in seconds")
+	fs.BoolVarP(&ef.Tty, "tty", "t", false, "Allocate a pseudo-TTY")
 }

--- a/docs/cli/ignite/ignite_exec.md
+++ b/docs/cli/ignite/ignite_exec.md
@@ -20,7 +20,8 @@ ignite exec <vm> <command...> [flags]
 ```
   -h, --help              help for exec
   -i, --identity string   Override the vm's default identity file
-  -t, --timeout uint32    Timeout waiting for connection in seconds (default 10)
+      --timeout uint32    Timeout waiting for connection in seconds (default 10)
+  -t, --tty               Allocate a pseudo-TTY
 ```
 
 ### Options inherited from parent commands

--- a/e2e/vm_exec_test.go
+++ b/e2e/vm_exec_test.go
@@ -1,0 +1,60 @@
+package e2e
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"gotest.tools/assert"
+)
+
+func TestVMExecInteractive(t *testing.T) {
+	assert.Assert(t, e2eHome != "", "IGNITE_E2E_HOME should be set")
+
+	vmName := "e2e_test_ignite_exec_interactive"
+
+	runCmd := exec.Command(
+		igniteBin,
+		"run", "--name="+vmName,
+		"--ssh",
+		"weaveworks/ignite-ubuntu",
+	)
+	runOut, runErr := runCmd.CombinedOutput()
+
+	defer func() {
+		rmvCmd := exec.Command(
+			igniteBin,
+			"rm", "-f", vmName,
+		)
+		rmvOut, rmvErr := rmvCmd.CombinedOutput()
+		assert.Check(t, rmvErr, fmt.Sprintf("vm removal: \n%q\n%s", rmvCmd.Args, rmvOut))
+	}()
+
+	assert.Check(t, runErr, fmt.Sprintf("vm run: \n%q\n%s", runCmd.Args, runOut))
+
+	// Pass input data from host and write to a file inside the VM.
+	remoteFileName := "afile.txt"
+	inputContent := "foooo..."
+	input := strings.NewReader(inputContent)
+
+	execCmd := exec.Command(
+		igniteBin,
+		"exec", vmName,
+		"tee", remoteFileName,
+	)
+	execCmd.Stdin = input
+
+	execOut, execErr := execCmd.CombinedOutput()
+	assert.Check(t, execErr, fmt.Sprintf("exec: \n%q\n%s", execCmd.Args, execOut))
+
+	// Check the file content inside the VM.
+	catCmd := exec.Command(
+		igniteBin,
+		"exec", vmName,
+		"cat", remoteFileName,
+	)
+	catOut, catErr := catCmd.CombinedOutput()
+	assert.Check(t, catErr, fmt.Sprintf("cat: \n%q\n%s", catCmd.Args, catOut))
+	assert.Equal(t, string(catOut), inputContent, fmt.Sprintf("unexpected file content on host:\n\t(WNT): %q\n\t(GOT): %q", inputContent, string(catOut)))
+} 


### PR DESCRIPTION
Breaking change: Moves -t, exec short flag, from timeout to tty.

This change makes the VM exec command interactive by default. This
enables the ability to pipe host input to VM commands using exec.
TTY is disabled by default. It can be enabled by using -t exec flag.

Adds e2e test to verify the feature.

Fixes #558 