### PR TITLE
Followup to #526 Ubuntu 19+ tar symlink fix

### DIFF
--- a/pkg/dmlegacy/vm.go
+++ b/pkg/dmlegacy/vm.go
@@ -165,7 +165,9 @@ func copyKernelToOverlay(vm *api.VM, mountPoint string) error {
 	}
 	// It is important to not replace existing symlinks to directories when extracting because
 	// /lib might be a symlink (usually to usr/lib)
-	_, err = util.ExecuteCommand("tar", "--keep-directory-symlink", "-xf", kernelTarPath, "-C", mountPoint)
+	// WARNING: `-h` is only available on GNU and Busybox tar.  It is not present on BSD's bsdtar
+	//          It means "Follow symlinks"
+	_, err = util.ExecuteCommand("tar", "-h", "-xf", kernelTarPath, "-C", mountPoint)
 	return err
 }
 

--- a/pkg/operations/import.go
+++ b/pkg/operations/import.go
@@ -144,7 +144,7 @@ func importKernel(c *client.Client, ociRef meta.OCIImageRef) (*api.Kernel, error
 		defer reader.Close()
 
 		// Extract only the /boot and /lib directories of the tar stream into the tempDir
-		tarCmd := exec.Command("tar", "-x", "-C", tempDir, "boot", "lib")
+		tarCmd := exec.Command("tar", "-x", "-C", tempDir, "boot", "lib/modules")
 		tarCmd.Stdin = reader
 		if err := tarCmd.Start(); err != nil {
 			return nil, err


### PR DESCRIPTION
Changes:
-  Use more portable flag "tar -h" to follow symlinks for GNU and Busybox tar.
   `-h` is not avialable on BSD tar
-  Restrict kernel image imports to /boot and /lib/modules