### PR TITLE
Bump QEMU version to v4.2, Alpine to 3.11 and fix a bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,16 +53,16 @@ undefine GOFLAGS
 GOHOSTARCH := $(shell GOARCH= go env GOARCH 2>/dev/null || echo "amd64")
 GOARCH ?= amd64
 GOARCH_LIST = amd64 arm64
-QEMUVERSION=v2.9.1
+QEMUVERSION=v4.2.0-6
 
 ifeq ($(GOARCH),amd64)
 QEMUARCH=amd64
-BASEIMAGE=alpine:3.9
+BASEIMAGE=alpine:3.11
 FIRECRACKER_ARCH_SUFFIX=-x86_64
 endif
 ifeq ($(GOARCH),arm64)
 QEMUARCH=aarch64
-BASEIMAGE=arm64v8/alpine:3.9
+BASEIMAGE=arm64v8/alpine:3.11
 FIRECRACKER_ARCH_SUFFIX=-aarch64
 endif
 

--- a/images/Makefile
+++ b/images/Makefile
@@ -36,7 +36,7 @@ endif
 	@ls ${WHAT} >/dev/null
 
 ifeq ($(IS_MANIFEST_LIST),0)
-	docker build --build-arg RELEASE -t $(FULL_IMAGE_NAME) ${WHAT}
+	sed "s|DOCKERARCH|$(DOCKERARCH)|g;/QEMUARCH/d" ${WHAT}/Dockerfile | docker build --build-arg RELEASE -f - -t $(FULL_IMAGE_NAME) ${WHAT}
 else
 	# Register /usr/bin/qemu-ARCH-static as the handler for non-x86 binaries in the kernel
 	docker run --rm --privileged multiarch/qemu-user-static:register --reset


### PR DESCRIPTION
Bump stuff we depend on, QEMU gets us better arm64 emulation for our image builds.
Use a new version of Alpine to take advantage of updated and (hopefully) more secure packages in the ignite-spawn image.
Also fix a bug when building non-multiarch OS images.