### PR TITLE
Filter loopback IPs from VM metadata to prevent SSH related test flakes

### DIFF
--- a/pkg/operations/start.go
+++ b/pkg/operations/start.go
@@ -132,9 +132,11 @@ func StartVM(vm *api.VM, debug bool) error {
 	startTime := apiruntime.Timestamp()
 	vm.Status.StartTime = &startTime
 
-	// Append the runtime IP address of the VM to its state
+	// Append non-loopback runtime IP addresses of the VM to its state
 	for _, addr := range result.Addresses {
-		vm.Status.IPAddresses = append(vm.Status.IPAddresses, addr.IP)
+		if !addr.IP.IsLoopback() {
+			vm.Status.IPAddresses = append(vm.Status.IPAddresses, addr.IP)
+		}
 	}
 
 	// Set the VM's status to running


### PR DESCRIPTION
(also, this just makes sense)
discussed with @darkowlzz
we see no use-case for reporting that VMs have loopback IPs at an API level
