### PR TITLE
Workaround firecracker-go-sdk go.mod issue using new commit

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/docker/docker v0.0.0-00010101000000-000000000000
 	github.com/docker/go-connections v0.4.0
 	github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c // indirect
-	github.com/firecracker-microvm/firecracker-go-sdk v0.21.0
+	github.com/firecracker-microvm/firecracker-go-sdk v0.21.1-0.20200312220944-e6eaff81c885
 	github.com/freddierice/go-losetup v0.0.0-20170407175016-fc9adea44124
 	github.com/go-openapi/spec v0.19.7
 	github.com/gogo/googleapis v1.3.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -129,8 +129,8 @@ github.com/emicklei/go-restful v2.9.6+incompatible h1:tfrHha8zJ01ywiOEC1miGY8st1
 github.com/emicklei/go-restful v2.9.6+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/evanphx/json-patch v0.0.0-20190203023257-5858425f7550/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
-github.com/firecracker-microvm/firecracker-go-sdk v0.21.0 h1:kV/PDppT1p96RGB4AGeCL3+Xy0jEV4nC4ark71DMGek=
-github.com/firecracker-microvm/firecracker-go-sdk v0.21.0/go.mod h1:zyc9BrKGePpNLbQ5y2ZtdzXEfpMJeHPeFNVpyo0S1WQ=
+github.com/firecracker-microvm/firecracker-go-sdk v0.21.1-0.20200312220944-e6eaff81c885 h1:piIWgkcle94UuCHlrTTqPC66BgoFtaTvU+P9UfW9MQ4=
+github.com/firecracker-microvm/firecracker-go-sdk v0.21.1-0.20200312220944-e6eaff81c885/go.mod h1:zyc9BrKGePpNLbQ5y2ZtdzXEfpMJeHPeFNVpyo0S1WQ=
 github.com/freddierice/go-losetup v0.0.0-20170407175016-fc9adea44124 h1:TVfi5xMshZAXzVXozESk8bi0JSTPwHkx7qtLOkkcu/c=
 github.com/freddierice/go-losetup v0.0.0-20170407175016-fc9adea44124/go.mod h1:zAk7fcFx45euzK9Az14j6Hd9n8Cwhnjp/NBfhSIAmFg=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=

--- a/vendor/github.com/firecracker-microvm/firecracker-go-sdk/handlers.go
+++ b/vendor/github.com/firecracker-microvm/firecracker-go-sdk/handlers.go
@@ -169,11 +169,9 @@ var BootstrapLoggingHandler = Handler{
 	Name: BootstrapLoggingHandlerName,
 	Fn: func(ctx context.Context, m *Machine) error {
 		if err := m.setupLogging(ctx); err != nil {
-			m.logger.Warnf("setupLogging() returned %s. Continuing anyway.", err)
-		} else {
-			m.logger.Debugf("setup logging: success")
+			return err
 		}
-
+		m.logger.Debugf("setup logging: success")
 		return nil
 	},
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -176,7 +176,7 @@ github.com/docker/go-units
 # github.com/emicklei/go-restful v2.9.6+incompatible
 github.com/emicklei/go-restful
 github.com/emicklei/go-restful/log
-# github.com/firecracker-microvm/firecracker-go-sdk v0.21.0
+# github.com/firecracker-microvm/firecracker-go-sdk v0.21.1-0.20200312220944-e6eaff81c885
 ## explicit
 github.com/firecracker-microvm/firecracker-go-sdk
 github.com/firecracker-microvm/firecracker-go-sdk/client


### PR DESCRIPTION
Using `v0.21.0` with `go mod tidy` using go versions 1.14.2, 1.12.17, and 1.12
produce a vendored dependency from firecracker that contains `CHANGELOG.md`
and `version.go` from a commit with `v0.20.0` contents.

We have not yet determined which commit the incorrect source is coming from.
This should be opened up as an issue with github.com/golang/go with a
dedicated reproduction.

Problematic:
```shell
go mod edit -require github.com/firecracker-microvm/firecracker-go-sdk@v0.21.0
go mod tidy
```

Commands run to produce this workaround:
```shell
go mod edit -require github.com/firecracker-microvm/firecracker-go-sdk@e6eaff8
make tidy-in-docker
  # go mod tidy
  # go mod vendor
  # ... etc
```

cc @darkowlzz