### PR TITLE
Ignore docker source cleanup err when resource not found

### DIFF
--- a/pkg/dmlegacy/image_format.go
+++ b/pkg/dmlegacy/image_format.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"unicode"
 
+	containerderr "github.com/containerd/containerd/errdefs"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	api "github.com/weaveworks/ignite/pkg/apis/ignite"
@@ -99,7 +100,10 @@ func addFiles(img *api.Image, src source.Source) error {
 	}
 
 	if err := src.Cleanup(); err != nil {
-		return err
+		// Ignore the cleanup error if the resource no longer exists.
+		if !errors.Is(err, containerderr.ErrNotFound) {
+			return err
+		}
 	}
 
 	return setupResolvConf(tempDir)

--- a/pkg/operations/import.go
+++ b/pkg/operations/import.go
@@ -1,12 +1,14 @@
 package operations
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
 
+	containerderr "github.com/containerd/containerd/errdefs"
 	log "github.com/sirupsen/logrus"
 	"github.com/weaveworks/gitops-toolkit/pkg/filter"
 	"github.com/weaveworks/gitops-toolkit/pkg/storage/filterer"
@@ -156,7 +158,10 @@ func importKernel(c *client.Client, ociRef meta.OCIImageRef) (*api.Kernel, error
 
 		// Remove the temporary container
 		if err := dockerSource.Cleanup(); err != nil {
-			return nil, err
+			// Ignore the cleanup error if the resource no longer exists.
+			if !errors.Is(err, containerderr.ErrNotFound) {
+				return nil, err
+			}
 		}
 
 		// Locate the kernel file in the temporary directory


### PR DESCRIPTION
Fixes the snapshot not found error seen in the CI when importing VM,
kernel images and running a VM for the first time. The issue was due to
a missing containerd snapshot key which was attempted to be cleaned up.
Since the snapshot key didn't exist, the cleanup returned `snapshot <key>
does not exist: not found` error.
The fix checks if the error is a containerd "not found" error and
ignores it. Any other error during the cleanup is returned as before.

containerd cleanup function: https://github.com/weaveworks/ignite/blob/fd8cd298126ffc5e14ed7e45b258e5176600b16c/pkg/runtime/containerd/client.go#L260-L266
In case of docker, the cleanup removes a container.

Link to a CI build with debug logs: https://travis-ci.com/github/darkowlzz/ignite/builds/160924846#L529

It's possible that we are seeing this due to the containerd dependency update from [1.3.0](https://github.com/weaveworks/ignite/blob/v0.6.3/go.mod#L12) to 1.3.3, or maybe this issue always existed.