### PR TITLE
Shadow the bogus /etc/resolv.conf of centos:8 to fix `wksctl`

### DIFF
--- a/images/centos/Dockerfile
+++ b/images/centos/Dockerfile
@@ -2,6 +2,9 @@ ARG RELEASE
 
 FROM centos:${RELEASE}
 
+# Shadow the bogus /etc/resolv.conf of centos:8 by copying a blank file over it
+COPY resolv.conf /etc/
+
 # Install common utilities
 RUN yum -y install \
         iproute \


### PR DESCRIPTION
The `centos:8` image currently used as the base for `weaveworks/ignite-centos:latest` includes a bogus `/etc/resolv.conf` file (that normally gets shadowed by Docker):
```
$ docker save centos:8 | tar -xf - -O cbab9bd72bc8f39dfc72b687ab56cd464589268d2a468ea8104fee89e4ca8b84/layer.tar | tar xO etc/resolv.conf
# Generated by NetworkManager
nameserver 192.168.122.1
```
This gets picked up by Ignite as a custom resolver configuration, so it won't be replaced with the symlink to the in-kernel DHCP at `/proc/net/pnp`. Subsequently, this then breaks `wksctl` integration as the Footloose-managed VMs don't have proper resolving configured resulting in no internet access (this probably affects Firekube as well).

Fix this by copying a blank file over `/etc/resolv.conf` during build.