### PR TITLE
Fix image platform for arm image

### DIFF
--- a/hack/push-manifest-list.sh
+++ b/hack/push-manifest-list.sh
@@ -25,3 +25,11 @@ for arch in ${ARCHES}; do
     ${DOCKER} manifest annotate --arch=${arch} ${IMAGE} ${IMAGE}-${arch}
 done
 ${DOCKER} manifest push --purge ${IMAGE}
+
+for arch in ${ARCHES}; do
+    CURR_IMAGE=${IMAGE}-${arch}
+    ${DOCKER} manifest create --amend ${CURR_IMAGE} ${CURR_IMAGE}
+    ${DOCKER} manifest annotate --arch=${arch} ${CURR_IMAGE} ${CURR_IMAGE}
+    ${DOCKER} manifest push --purge ${CURR_IMAGE}
+done
+


### PR DESCRIPTION
Fix: #345 

Fixing the multi-arch container image build by properly annotate the image manifest for each architectures (arm64 and amd64). So that the image platform is correct. 

**Testing**
Built test image and pushed to my personal dockerhub registry:

```
docker manifest inspect chengpan/ignite:v0.7.0-25-9c998301147a44-arm64
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
   "manifests": [
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 529,
         "digest": "sha256:81d44b341961ca83f74fcaad5b88f6750413f4de96b20df561566cf3af8ec5ce",
         "platform": {
            "architecture": "arm64",
            "os": "linux"
         }
      }
   ]
}
```