### PR TITLE
Allow provider override when using config file

### DIFF
--- a/cmd/ignite/cmd/root.go
+++ b/cmd/ignite/cmd/root.go
@@ -17,9 +17,11 @@ import (
 	"github.com/weaveworks/ignite/pkg/constants"
 	"github.com/weaveworks/ignite/pkg/logs"
 	logflag "github.com/weaveworks/ignite/pkg/logs/flag"
+	"github.com/weaveworks/ignite/pkg/network"
 	networkflag "github.com/weaveworks/ignite/pkg/network/flag"
 	"github.com/weaveworks/ignite/pkg/providers"
 	"github.com/weaveworks/ignite/pkg/providers/ignite"
+	"github.com/weaveworks/ignite/pkg/runtime"
 	runtimeflag "github.com/weaveworks/ignite/pkg/runtime/flag"
 	"github.com/weaveworks/ignite/pkg/util"
 	versioncmd "github.com/weaveworks/ignite/pkg/version/cmd"
@@ -80,15 +82,25 @@ func NewIgniteCommand(in io.Reader, out, err io.Writer) *cobra.Command {
 					log.Fatal(err)
 				}
 
-				// Set providers runtime and network plugin if found in config.
-				if providers.ComponentConfig.Spec.Runtime != "" {
+				// Set providers runtime and network plugin if found in config
+				// and not set explicitly via flags.
+				if providers.ComponentConfig.Spec.Runtime != "" && providers.RuntimeName == "" {
 					providers.RuntimeName = providers.ComponentConfig.Spec.Runtime
 				}
-				if providers.ComponentConfig.Spec.NetworkPlugin != "" {
+				if providers.ComponentConfig.Spec.NetworkPlugin != "" && providers.NetworkPluginName == "" {
 					providers.NetworkPluginName = providers.ComponentConfig.Spec.NetworkPlugin
 				}
 			} else {
 				log.Debugln("Using ignite default configurations")
+			}
+
+			// Set the default runtime and network-plugin if it's not set by
+			// now.
+			if providers.RuntimeName == "" {
+				providers.RuntimeName = runtime.RuntimeContainerd
+			}
+			if providers.NetworkPluginName == "" {
+				providers.NetworkPluginName = network.PluginCNI
 			}
 
 			// Populate the providers after flags have been parsed

--- a/pkg/network/flag/networkflag.go
+++ b/pkg/network/flag/networkflag.go
@@ -37,5 +37,5 @@ func (nf *NetworkPluginFlag) Type() string {
 var _ pflag.Value = &NetworkPluginFlag{}
 
 func NetworkPluginVar(fs *pflag.FlagSet, ptr *network.PluginName) {
-	fs.Var(&NetworkPluginFlag{value: ptr}, "network-plugin", fmt.Sprintf("Network plugin to use. Available options are: %v", plugins))
+	fs.Var(&NetworkPluginFlag{value: ptr}, "network-plugin", fmt.Sprintf("Network plugin to use. Available options are: %v (default %v)", plugins, network.PluginCNI))
 }

--- a/pkg/providers/providers.go
+++ b/pkg/providers/providers.go
@@ -11,7 +11,7 @@ import (
 
 // NetworkPluginName binds to the global flag to select the network plugin
 // The default network plugin is "cni"
-var NetworkPluginName = network.PluginCNI
+var NetworkPluginName network.PluginName
 
 // NetworkPlugin provides the chosen network plugin that should be used
 // This should be set after parsing user input on what network plugin to use
@@ -19,7 +19,7 @@ var NetworkPlugin network.Plugin
 
 // RuntimeName binds to the global flag to select the container runtime
 // The default runtime is "containerd"
-var RuntimeName = runtime.RuntimeContainerd
+var RuntimeName runtime.Name
 
 // Runtime provides the chosen container runtime for retrieving OCI images and running VM containers
 // This should be set after parsing user input on what runtime to use

--- a/pkg/runtime/flag/runtimeflag.go
+++ b/pkg/runtime/flag/runtimeflag.go
@@ -39,5 +39,5 @@ func (nf *RuntimeFlag) Type() string {
 var _ pflag.Value = &RuntimeFlag{}
 
 func RuntimeVar(fs *pflag.FlagSet, ptr *runtime.Name) {
-	fs.Var(&RuntimeFlag{value: ptr}, "runtime", fmt.Sprintf("Container runtime to use. Available options are: %v", runtimes))
+	fs.Var(&RuntimeFlag{value: ptr}, "runtime", fmt.Sprintf("Container runtime to use. Available options are: %v (default %v)", runtimes, runtime.RuntimeContainerd))
 }


### PR DESCRIPTION
When using ignite configuration file, the global flags `--runtime` and
`--network-plugin` were ignored. This change enables the overrides to work.

The default runtime and network-plugin name assignment is moved from
providers into `NewIgniteCommand` and the defaults are set only when the
values are empty after applying config files and flag overrides.