### PR TITLE
Configure dmsetup to fallback to managing device nodes without udevd

### DIFF
--- a/pkg/dmlegacy/cleanup/deactivate.go
+++ b/pkg/dmlegacy/cleanup/deactivate.go
@@ -9,6 +9,7 @@ import (
 func DeactivateSnapshot(vm *api.VM) error {
 	dmArgs := []string{
 		"remove",
+		"--verifyudev", // if udevd is not running, dmsetup will manage the device node in /dev/mapper
 		util.NewPrefixer().Prefix(vm.GetUID()),
 	}
 

--- a/pkg/dmlegacy/cleanup/deactivate.go
+++ b/pkg/dmlegacy/cleanup/deactivate.go
@@ -9,7 +9,7 @@ import (
 func DeactivateSnapshot(vm *api.VM) error {
 	dmArgs := []string{
 		"remove",
-		vm.SnapshotDev(),
+		util.NewPrefixer().Prefix(vm.GetUID()),
 	}
 
 	// If the base device is visible in "dmsetup", we should remove it

--- a/pkg/dmlegacy/loopdev.go
+++ b/pkg/dmlegacy/loopdev.go
@@ -36,7 +36,11 @@ func (ld *loopDevice) Size512K() (uint64, error) {
 
 // dmsetup uses stdin to read multiline tables, this is a helper function for that
 func runDMSetup(name string, table []byte) error {
-	cmd := exec.Command("dmsetup", "create", name)
+	cmd := exec.Command(
+		"dmsetup", "create",
+		"--verifyudev", // if udevd is not running, dmsetup will manage the device node in /dev/mapper
+		name,
+	)
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
 		return err
@@ -52,7 +56,7 @@ func runDMSetup(name string, table []byte) error {
 
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("command %q exited with %q: %v", cmd.Args, out, err)
+		return fmt.Errorf("command %q exited with %q: %w", cmd.Args, out, err)
 	}
 
 	return nil

--- a/pkg/dmlegacy/vm.go
+++ b/pkg/dmlegacy/vm.go
@@ -83,7 +83,7 @@ func AllocateAndPopulateOverlay(vm *api.VM) error {
 }
 
 func copyToOverlay(vm *api.VM) (err error) {
-	err = ActivateSnapshot(vm)
+	_, err = ActivateSnapshot(vm)
 	if err != nil {
 		return
 	}

--- a/pkg/operations/remove.go
+++ b/pkg/operations/remove.go
@@ -48,7 +48,7 @@ func CleanupVM(vm *api.VM) error {
 	// TODO should this function return a proper error?
 	RemoveVMContainer(inspectResult)
 
-	// After remove the VM container, and the SnapshotDev still there
+	// After removing the VM container, if the Snapshot Device is still there, clean up
 	if _, err := os.Stat(vm.SnapshotDev()); err == nil {
 		// try remove it again with DeactivateSnapshot
 		if err := cleanup.DeactivateSnapshot(vm); err != nil {

--- a/pkg/operations/start.go
+++ b/pkg/operations/start.go
@@ -25,7 +25,8 @@ func StartVM(vm *api.VM, debug bool) error {
 	RemoveVMContainer(inspectResult)
 
 	// Setup the snapshot overlay filesystem
-	if err := dmlegacy.ActivateSnapshot(vm); err != nil {
+	snapshotDevPath, err := dmlegacy.ActivateSnapshot(vm)
+	if err != nil {
 		return err
 	}
 
@@ -70,7 +71,7 @@ func StartVM(vm *api.VM, debug bool) error {
 			runtime.BindBoth("/dev/mapper/control"), // This enables containerized Ignite to remove its own dm snapshot
 			runtime.BindBoth("/dev/net/tun"),        // Needed for creating TAP adapters
 			runtime.BindBoth("/dev/kvm"),            // Pass through virtualization support
-			runtime.BindBoth(vm.SnapshotDev()),      // The block device to boot from
+			runtime.BindBoth(snapshotDevPath),       // The block device to boot from
 		},
 		StopTimeout:  constants.STOP_TIMEOUT + constants.IGNITE_TIMEOUT,
 		PortBindings: vm.Spec.Network.Ports, // Add the port mappings to Docker


### PR DESCRIPTION
This patch frees up dependent interactions with udev for device node creation.
Ignite can now create boot devices in absence of a working udevd equivalent.
This makes ignite easier to run in docker containers and WSL2.

I wrote a similar implementation ([no_udev_sync](https://github.com/stealthybox/ignite/commit/e550f32b3ae)) which completely bypassed udev sync even when present.
It execs `dmsetup info` to retrieve block device paths and manages its own symlinks, but I found this implementation gets sort of coupled to `/dev` in the root mount namespace because `dmsetup info` will return the canonical device-path of `/dev/dm-$i`.
It's simple and possible to call `mknod /dev/dm-$i -m600 253 $i` and ensure the device node exists with `no_udev_sync`.

I decided to try using the built-in udev fallback from `dmsetup` which is what is implemented in this PR.

Note it's possible to actually get working behavior with older builds of ignite by setting `DM_DISABLE_UDEV=1`, but this requires the user to know about udev and potentially passthrough their env to sudo.

I found in `dmsetup`'s changelog that the `--verifyudev` fallback actually used to be the default behavior.
I didn't look further, but I assume this was disabled, because it could be potentially harmful if you created devices during boot before udevd started up.
I figure that silently having udev rules not apply is fairly low-risk for ignite boot devices -- if people are using ignite during boot, they should be configuring their units at the proper run-level, but it is a consideration.
The trade-off is that if we accept this bit of informal fallback behavior, users don't have to configure `dmsetup`, and ignite can use dmsetup in containers without mounting `/dev:/dev`*.

Note: `losetup` does not seem to currently have any device node management.
In order for `losetup` to work in a container without mounting `/dev:/dev` you need to pre-create some loop device nodes in the container like so:
```
for i in {0..20}; do mknod /dev/loop$i -m600 b 7 $i; done
```

Other Changes:
- Fix DeactivateSnapshot bug which would cause cleanup failures
- Refactor ActivateSnapshot to return snapshotDevPath so it is just calculated once