### PR TITLE
Run link-checker periodically on `master` -- disable for PR's

### DIFF
--- a/.github/workflows/check-links.yaml
+++ b/.github/workflows/check-links.yaml
@@ -1,10 +1,10 @@
 name: docs
 
 on:
-  pull_request:
-  push:
-    branches:
-      - master
+  schedule:
+    # Scheduled workflows run on the latest commit on the default or base branch. 
+    # * is a special character in YAML so you have to quote this string
+    - cron:  '0 0 * * 3'
 
 jobs:
   markdown-link-checker:


### PR DESCRIPTION
The link checker regularly hits the rate limit,  but the logic is good so we want to still continue running it regularly so we can spot failed links in the docs, even if we are not changing them.

Related comments in #619

Future work to reenable the link check on PR's should use different logic that only check the diffs, but we'll still have this one checking the entire docs site weekly.