### PR TITLE
Add VM Status defaulter

### DIFF
--- a/cmd/ignite/run/testdata/output/apply-vm-config-empty.json
+++ b/cmd/ignite/run/testdata/output/apply-vm-config-empty.json
@@ -28,6 +28,14 @@
   },
   "status": {
     "running": false,
+    "runtime": {
+      "id": "",
+      "name": ""
+    },
+    "network": {
+      "plugin": "",
+      "ipAddresses": null
+    },
     "image": {
       "id": null,
       "size": "0B"

--- a/cmd/ignite/run/testdata/output/apply-vm-config-json.json
+++ b/cmd/ignite/run/testdata/output/apply-vm-config-json.json
@@ -29,6 +29,14 @@
   },
   "status": {
     "running": false,
+    "runtime": {
+      "id": "",
+      "name": ""
+    },
+    "network": {
+      "plugin": "",
+      "ipAddresses": null
+    },
     "image": {
       "id": null,
       "size": "0B"

--- a/cmd/ignite/run/testdata/output/apply-vm-config-yaml.json
+++ b/cmd/ignite/run/testdata/output/apply-vm-config-yaml.json
@@ -29,6 +29,14 @@
   },
   "status": {
     "running": false,
+    "runtime": {
+      "id": "",
+      "name": ""
+    },
+    "network": {
+      "plugin": "",
+      "ipAddresses": null
+    },
     "image": {
       "id": null,
       "size": "0B"

--- a/docs/api/ignite_v1alpha3.md
+++ b/docs/api/ignite_v1alpha3.md
@@ -23,6 +23,7 @@
   - [func SetDefaults\_VMSandboxSpec(obj
     \*VMSandboxSpec)](#SetDefaults_VMSandboxSpec)
   - [func SetDefaults\_VMSpec(obj \*VMSpec)](#SetDefaults_VMSpec)
+  - [func SetDefaults\_VMStatus(obj \*VMStatus)](#SetDefaults_VMStatus)
   - [type BlockDeviceVolume](#BlockDeviceVolume)
   - [type Configuration](#Configuration)
   - [type ConfigurationSpec](#ConfigurationSpec)
@@ -133,6 +134,12 @@ func SetDefaults_VMSandboxSpec(obj *VMSandboxSpec)
 
 ``` go
 func SetDefaults_VMSpec(obj *VMSpec)
+```
+
+## <a name="SetDefaults_VMStatus">func</a> [SetDefaults\_VMStatus](https://github.com/weaveworks/ignite/tree/master/pkg/apis/ignite/v1alpha3/defaults.go?s=2390:2430#L89)
+
+``` go
+func SetDefaults_VMStatus(obj *VMStatus)
 ```
 
 ## <a name="BlockDeviceVolume">type</a> [BlockDeviceVolume](https://github.com/weaveworks/ignite/tree/master/pkg/apis/ignite/v1alpha3/types.go?s=7717:7777#L203)

--- a/pkg/apis/ignite/v1alpha3/defaults.go
+++ b/pkg/apis/ignite/v1alpha3/defaults.go
@@ -85,3 +85,12 @@ func calcMetadataDevSize(obj *PoolSpec) meta.Size {
 
 	return meta.NewSizeFromBytes(48 * obj.DataSize.Bytes() / obj.AllocationSize.Bytes()).Min(maxSize).Max(minSize)
 }
+
+func SetDefaults_VMStatus(obj *VMStatus) {
+	if obj.Runtime == nil {
+		obj.Runtime = &Runtime{}
+	}
+	if obj.Network == nil {
+		obj.Network = &Network{}
+	}
+}

--- a/pkg/apis/ignite/v1alpha3/zz_generated.defaults.go
+++ b/pkg/apis/ignite/v1alpha3/zz_generated.defaults.go
@@ -33,4 +33,5 @@ func SetObjectDefaults_VM(in *VM) {
 	SetDefaults_VMSpec(&in.Spec)
 	SetDefaults_VMSandboxSpec(&in.Spec.Sandbox)
 	SetDefaults_VMKernelSpec(&in.Spec.Kernel)
+	SetDefaults_VMStatus(&in.Status)
 }

--- a/pkg/dmlegacy/vm.go
+++ b/pkg/dmlegacy/vm.go
@@ -134,7 +134,7 @@ func copyToOverlay(vm *api.VM) (err error) {
 	}
 
 	ip := net.IP{127, 0, 0, 1}
-	if vm.Status.Network != nil && len(vm.Status.Network.IPAddresses) > 0 {
+	if len(vm.Status.Network.IPAddresses) > 0 {
 		ip = vm.Status.Network.IPAddresses[0]
 	}
 

--- a/pkg/operations/start.go
+++ b/pkg/operations/start.go
@@ -124,20 +124,14 @@ func StartVM(vm *api.VM, debug bool) error {
 	}
 
 	// Set the container ID for the VM
-	vm.Status.Runtime = &api.Runtime{
-		ID:   containerID,
-		Name: providers.RuntimeName,
-	}
+	vm.Status.Runtime.ID = containerID
+	vm.Status.Runtime.Name = providers.RuntimeName
 
 	// Set the start time for the VM
 	startTime := apiruntime.Timestamp()
 	vm.Status.StartTime = &startTime
+	vm.Status.Network.Plugin = providers.NetworkPluginName
 
-	if vm.Status.Network == nil {
-		vm.Status.Network = &api.Network{
-			Plugin: providers.NetworkPluginName,
-		}
-	}
 	// Append non-loopback runtime IP addresses of the VM to its state
 	for _, addr := range result.Addresses {
 		if !addr.IP.IsLoopback() {


### PR DESCRIPTION
VM `Status.Network` & `Status.Runtime` are nil by default. Initialize it
to avoid panics when attempting to set their attributes.

Remove extra nil checks added previously in https://github.com/weaveworks/ignite/pull/651
and any runtime initializations.