### PR TITLE
docs/installation: set VM status.running to true

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -150,6 +150,8 @@ spec:
   cpus: 2
   diskSize: 3GB
   memory: 800MB
+status:
+  running: true
 EOF
 ```
 


### PR DESCRIPTION
When the VM doesn't start, it confuses the users. Set it to true to
run the VM automatically.