### PR TITLE
Make runtime and network-plugin VM create flags

### DIFF
--- a/cmd/ignite-spawn/ignite-spawn.go
+++ b/cmd/ignite-spawn/ignite-spawn.go
@@ -93,6 +93,6 @@ func patchStopped(vm *api.VM) error {
 		vm.status.startTime = nil
 	*/
 
-	patch := []byte(`{"status":{"running":false,"ipAddresses":null,"runtime":null,"startTime":null}}`)
+	patch := []byte(`{"status":{"running":false,"network":null,"runtime":null,"startTime":null}}`)
 	return patchutil.NewPatcher(scheme.Serializer).ApplyOnFile(constants.IGNITE_SPAWN_VM_FILE_PATH, patch, vm.GroupVersionKind())
 }

--- a/cmd/ignite/cmd/imgcmd/import.go
+++ b/cmd/ignite/cmd/imgcmd/import.go
@@ -5,8 +5,12 @@ import (
 
 	"github.com/lithammer/dedent"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
 	"github.com/weaveworks/ignite/cmd/ignite/cmd/cmdutil"
 	"github.com/weaveworks/ignite/cmd/ignite/run"
+	"github.com/weaveworks/ignite/pkg/providers"
+	runtimeflag "github.com/weaveworks/ignite/pkg/runtime/flag"
 )
 
 // NewCmdImport imports a new VM image
@@ -27,5 +31,11 @@ func NewCmdImport(out io.Writer) *cobra.Command {
 			}())
 		},
 	}
+
+	addImportFlags(cmd.Flags())
 	return cmd
+}
+
+func addImportFlags(fs *pflag.FlagSet) {
+	runtimeflag.RuntimeVar(fs, &providers.RuntimeName)
 }

--- a/cmd/ignite/cmd/kerncmd/import.go
+++ b/cmd/ignite/cmd/kerncmd/import.go
@@ -5,8 +5,12 @@ import (
 
 	"github.com/lithammer/dedent"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
 	"github.com/weaveworks/ignite/cmd/ignite/cmd/cmdutil"
 	"github.com/weaveworks/ignite/cmd/ignite/run"
+	"github.com/weaveworks/ignite/pkg/providers"
+	runtimeflag "github.com/weaveworks/ignite/pkg/runtime/flag"
 )
 
 // NewCmdImport imports a new kernel image
@@ -27,5 +31,11 @@ func NewCmdImport(out io.Writer) *cobra.Command {
 			}())
 		},
 	}
+
+	addImportFlags(cmd.Flags())
 	return cmd
+}
+
+func addImportFlags(fs *pflag.FlagSet) {
+	runtimeflag.RuntimeVar(fs, &providers.RuntimeName)
 }

--- a/cmd/ignite/cmd/root.go
+++ b/cmd/ignite/cmd/root.go
@@ -15,10 +15,8 @@ import (
 	"github.com/weaveworks/ignite/pkg/config"
 	"github.com/weaveworks/ignite/pkg/logs"
 	logflag "github.com/weaveworks/ignite/pkg/logs/flag"
-	networkflag "github.com/weaveworks/ignite/pkg/network/flag"
 	"github.com/weaveworks/ignite/pkg/providers"
 	"github.com/weaveworks/ignite/pkg/providers/ignite"
-	runtimeflag "github.com/weaveworks/ignite/pkg/runtime/flag"
 	"github.com/weaveworks/ignite/pkg/util"
 	versioncmd "github.com/weaveworks/ignite/pkg/version/cmd"
 )
@@ -133,8 +131,6 @@ func isNonRootCommand(cmd string, parentCmd string) bool {
 func addGlobalFlags(fs *pflag.FlagSet) {
 	AddQuietFlag(fs)
 	logflag.LogLevelFlagVar(fs, &logLevel)
-	runtimeflag.RuntimeVar(fs, &providers.RuntimeName)
-	networkflag.NetworkPluginVar(fs, &providers.NetworkPluginName)
 	fs.StringVar(&configPath, "ignite-config", "", "Ignite configuration path; refer to the 'Ignite Configuration' docs for more details")
 }
 

--- a/cmd/ignite/cmd/vmcmd/create.go
+++ b/cmd/ignite/cmd/vmcmd/create.go
@@ -7,8 +7,12 @@ import (
 	"github.com/lithammer/dedent"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+
 	"github.com/weaveworks/ignite/cmd/ignite/cmd/cmdutil"
 	"github.com/weaveworks/ignite/cmd/ignite/run"
+	networkflag "github.com/weaveworks/ignite/pkg/network/flag"
+	"github.com/weaveworks/ignite/pkg/providers"
+	runtimeflag "github.com/weaveworks/ignite/pkg/runtime/flag"
 	"github.com/weaveworks/ignite/pkg/version"
 )
 
@@ -80,4 +84,7 @@ func addCreateFlags(fs *pflag.FlagSet, cf *run.CreateFlags) {
 	cmdutil.OCIImageRefVar(fs, &cf.VM.Spec.Sandbox.OCI, "sandbox-image", "Specify an OCI image for the VM sandbox")
 	cmdutil.SSHVar(fs, &cf.SSH)
 	cmdutil.VolumeVarP(fs, &cf.VM.Spec.Storage, "volumes", "v", "Expose block devices from the host inside the VM")
+
+	runtimeflag.RuntimeVar(fs, &providers.RuntimeName)
+	networkflag.NetworkPluginVar(fs, &providers.NetworkPluginName)
 }

--- a/cmd/ignite/cmd/vmcmd/start.go
+++ b/cmd/ignite/cmd/vmcmd/start.go
@@ -8,6 +8,9 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/weaveworks/ignite/cmd/ignite/cmd/cmdutil"
 	"github.com/weaveworks/ignite/cmd/ignite/run"
+	networkflag "github.com/weaveworks/ignite/pkg/network/flag"
+	"github.com/weaveworks/ignite/pkg/providers"
+	runtimeflag "github.com/weaveworks/ignite/pkg/runtime/flag"
 )
 
 // NewCmdStart starts a VM
@@ -36,6 +39,13 @@ func NewCmdStart(out io.Writer) *cobra.Command {
 	}
 
 	addStartFlags(cmd.Flags(), sf)
+
+	// NOTE: Since the run command combines the create and start command flags,
+	// to avoid redefining runtime and network flag in run command, they are
+	// defined separately here.
+	runtimeflag.RuntimeVar(cmd.Flags(), &providers.RuntimeName)
+	networkflag.NetworkPluginVar(cmd.Flags(), &providers.NetworkPluginName)
+
 	return cmd
 }
 

--- a/cmd/ignite/run/attach.go
+++ b/cmd/ignite/run/attach.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	api "github.com/weaveworks/ignite/pkg/apis/ignite"
+	"github.com/weaveworks/ignite/pkg/config"
 	"github.com/weaveworks/ignite/pkg/providers"
 	"github.com/weaveworks/ignite/pkg/util"
 )
@@ -25,6 +26,11 @@ func Attach(ao *attachOptions) error {
 	// Check if the VM is running
 	if ao.checkRunning && !ao.vm.Running() {
 		return fmt.Errorf("VM %q is not running", ao.vm.GetUID())
+	}
+
+	// Set the runtime and network-plugin providers from the VM status.
+	if err := config.SetAndPopulateProviders(ao.vm.Status.Runtime.Name, ao.vm.Status.Network.Plugin); err != nil {
+		return err
 	}
 
 	// Print the ID before attaching

--- a/cmd/ignite/run/create.go
+++ b/cmd/ignite/run/create.go
@@ -10,6 +10,7 @@ import (
 	"github.com/weaveworks/ignite/pkg/apis/ignite/scheme"
 	"github.com/weaveworks/ignite/pkg/apis/ignite/validation"
 	meta "github.com/weaveworks/ignite/pkg/apis/meta/v1alpha1"
+	"github.com/weaveworks/ignite/pkg/config"
 	"github.com/weaveworks/ignite/pkg/dmlegacy"
 	"github.com/weaveworks/ignite/pkg/metadata"
 	"github.com/weaveworks/ignite/pkg/operations"
@@ -55,6 +56,15 @@ func (cf *CreateFlags) NewCreateOptions(args []string, fs *flag.FlagSet) (*creat
 	// If component config is in use, set the VMDefaults on the base VM.
 	if providers.ComponentConfig != nil {
 		baseVM.Spec = providers.ComponentConfig.Spec.VMDefaults
+	}
+
+	// Set the runtime and network-plugin on the VM. This overrides the global
+	// config.
+	baseVM.Status.Runtime.Name = providers.RuntimeName
+	baseVM.Status.Network.Plugin = providers.NetworkPluginName
+	// Populate the runtime and network-plugin providers.
+	if err := config.SetAndPopulateProviders(providers.RuntimeName, providers.NetworkPluginName); err != nil {
+		return nil, err
 	}
 
 	// Set the passed image argument on the new VM spec.

--- a/cmd/ignite/run/import.go
+++ b/cmd/ignite/run/import.go
@@ -3,6 +3,7 @@ package run
 import (
 	api "github.com/weaveworks/ignite/pkg/apis/ignite"
 	meta "github.com/weaveworks/ignite/pkg/apis/meta/v1alpha1"
+	"github.com/weaveworks/ignite/pkg/config"
 	"github.com/weaveworks/ignite/pkg/metadata"
 	"github.com/weaveworks/ignite/pkg/operations"
 	"github.com/weaveworks/ignite/pkg/providers"
@@ -10,6 +11,11 @@ import (
 )
 
 func ImportImage(source string) (image *api.Image, err error) {
+	// Populate the runtime provider.
+	if err := config.SetAndPopulateProviders(providers.RuntimeName, providers.NetworkPluginName); err != nil {
+		return nil, err
+	}
+
 	ociRef, err := meta.NewOCIImageRef(source)
 	if err != nil {
 		return
@@ -27,6 +33,11 @@ func ImportImage(source string) (image *api.Image, err error) {
 }
 
 func ImportKernel(source string) (kernel *api.Kernel, err error) {
+	// Populate the runtime provider.
+	if err := config.SetAndPopulateProviders(providers.RuntimeName, providers.NetworkPluginName); err != nil {
+		return nil, err
+	}
+
 	ociRef, err := meta.NewOCIImageRef(source)
 	if err != nil {
 		return

--- a/cmd/ignite/run/logs.go
+++ b/cmd/ignite/run/logs.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 
 	api "github.com/weaveworks/ignite/pkg/apis/ignite"
+	"github.com/weaveworks/ignite/pkg/config"
 	"github.com/weaveworks/ignite/pkg/providers"
 	"github.com/weaveworks/ignite/pkg/util"
 )
@@ -23,6 +24,11 @@ func Logs(lo *logsOptions) error {
 	// Check if the VM is running
 	if !lo.vm.Running() {
 		return fmt.Errorf("VM %q is not running", lo.vm.GetUID())
+	}
+
+	// Set the runtime and network-plugin providers from the VM status.
+	if err := config.SetAndPopulateProviders(lo.vm.Status.Runtime.Name, lo.vm.Status.Network.Plugin); err != nil {
+		return err
 	}
 
 	// Fetch the VM logs

--- a/cmd/ignite/run/rm.go
+++ b/cmd/ignite/run/rm.go
@@ -5,6 +5,7 @@ import (
 
 	api "github.com/weaveworks/ignite/pkg/apis/ignite"
 	"github.com/weaveworks/ignite/pkg/apis/ignite/scheme"
+	"github.com/weaveworks/ignite/pkg/config"
 	"github.com/weaveworks/ignite/pkg/operations"
 	"github.com/weaveworks/ignite/pkg/providers"
 )
@@ -58,6 +59,11 @@ func Rm(ro *rmOptions) error {
 		// If the VM is running, but we haven't enabled force-mode, return an error
 		if vm.Running() && !ro.Force {
 			return fmt.Errorf("%s is running", vm.GetUID())
+		}
+
+		// Set the runtime and network-plugin providers from the VM status.
+		if err := config.SetAndPopulateProviders(vm.Status.Runtime.Name, vm.Status.Network.Plugin); err != nil {
+			return err
 		}
 
 		// This will first kill the VM container, and then remove it

--- a/cmd/ignite/run/rm.go
+++ b/cmd/ignite/run/rm.go
@@ -61,9 +61,12 @@ func Rm(ro *rmOptions) error {
 			return fmt.Errorf("%s is running", vm.GetUID())
 		}
 
-		// Set the runtime and network-plugin providers from the VM status.
-		if err := config.SetAndPopulateProviders(vm.Status.Runtime.Name, vm.Status.Network.Plugin); err != nil {
-			return err
+		// Runtime and network info are present only when the VM is running.
+		if vm.Running() {
+			// Set the runtime and network-plugin providers from the VM status.
+			if err := config.SetAndPopulateProviders(vm.Status.Runtime.Name, vm.Status.Network.Plugin); err != nil {
+				return err
+			}
 		}
 
 		// This will first kill the VM container, and then remove it

--- a/cmd/ignite/run/start.go
+++ b/cmd/ignite/run/start.go
@@ -12,6 +12,7 @@ import (
 	"github.com/weaveworks/ignite/pkg/constants"
 	"github.com/weaveworks/ignite/pkg/operations"
 	"github.com/weaveworks/ignite/pkg/preflight/checkers"
+	"github.com/weaveworks/ignite/pkg/providers"
 	"github.com/weaveworks/ignite/pkg/util"
 	"golang.org/x/crypto/ssh"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -45,6 +46,12 @@ func Start(so *startOptions) error {
 	if so.vm.Running() {
 		return fmt.Errorf("VM %q is already running", so.vm.GetUID())
 	}
+
+	// In case the runtime and network-plugin is specified explicitly at start,
+	// set the runtime and network-plugin on the VM. This overrides the global
+	// config and config on the VM object, if any.
+	so.vm.Status.Runtime.Name = providers.RuntimeName
+	so.vm.Status.Network.Plugin = providers.NetworkPluginName
 
 	// Set the runtime and network-plugin providers from the VM status.
 	if err := config.SetAndPopulateProviders(so.vm.Status.Runtime.Name, so.vm.Status.Network.Plugin); err != nil {

--- a/cmd/ignite/run/start.go
+++ b/cmd/ignite/run/start.go
@@ -8,6 +8,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/weaveworks/ignite/pkg/apis/ignite"
+	"github.com/weaveworks/ignite/pkg/config"
 	"github.com/weaveworks/ignite/pkg/constants"
 	"github.com/weaveworks/ignite/pkg/operations"
 	"github.com/weaveworks/ignite/pkg/preflight/checkers"
@@ -43,6 +44,11 @@ func Start(so *startOptions) error {
 	// Check if the given VM is already running
 	if so.vm.Running() {
 		return fmt.Errorf("VM %q is already running", so.vm.GetUID())
+	}
+
+	// Set the runtime and network-plugin providers from the VM status.
+	if err := config.SetAndPopulateProviders(so.vm.Status.Runtime.Name, so.vm.Status.Network.Plugin); err != nil {
+		return err
 	}
 
 	ignoredPreflightErrors := sets.NewString(util.ToLower(so.StartFlags.IgnoredPreflightErrors)...)

--- a/cmd/ignite/run/stop.go
+++ b/cmd/ignite/run/stop.go
@@ -2,6 +2,7 @@ package run
 
 import (
 	api "github.com/weaveworks/ignite/pkg/apis/ignite"
+	"github.com/weaveworks/ignite/pkg/config"
 	"github.com/weaveworks/ignite/pkg/operations"
 )
 
@@ -22,6 +23,11 @@ func (sf *StopFlags) NewStopOptions(vmMatches []string) (so *stopOptions, err er
 
 func Stop(so *stopOptions) error {
 	for _, vm := range so.vms {
+		// Set the runtime and network-plugin providers from the VM status.
+		if err := config.SetAndPopulateProviders(vm.Status.Runtime.Name, vm.Status.Network.Plugin); err != nil {
+			return err
+		}
+
 		// Stop the VM, and optionally kill it
 		if err := operations.StopVM(vm, so.Kill, false); err != nil {
 			return err

--- a/docs/cli/ignite/ignite.md
+++ b/docs/cli/ignite/ignite.md
@@ -33,12 +33,10 @@ Example usage:
 ### Options
 
 ```
-  -h, --help                    help for ignite
-      --ignite-config string    Ignite configuration path; refer to the 'Ignite Configuration' docs for more details
-      --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
-  -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
+  -h, --help                   help for ignite
+      --ignite-config string   Ignite configuration path; refer to the 'Ignite Configuration' docs for more details
+      --log-level loglevel     Specify the loglevel for the program (default info)
+  -q, --quiet                  The quiet mode allows for machine-parsable output by printing only IDs
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_attach.md
+++ b/docs/cli/ignite/ignite_attach.md
@@ -23,11 +23,9 @@ ignite attach <vm> [flags]
 ### Options inherited from parent commands
 
 ```
-      --ignite-config string    Ignite configuration path; refer to the 'Ignite Configuration' docs for more details
-      --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
-  -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
+      --ignite-config string   Ignite configuration path; refer to the 'Ignite Configuration' docs for more details
+      --log-level loglevel     Specify the loglevel for the program (default info)
+  -q, --quiet                  The quiet mode allows for machine-parsable output by printing only IDs
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_completion.md
+++ b/docs/cli/ignite/ignite_completion.md
@@ -27,11 +27,9 @@ ignite completion [flags]
 ### Options inherited from parent commands
 
 ```
-      --ignite-config string    Ignite configuration path; refer to the 'Ignite Configuration' docs for more details
-      --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
-  -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
+      --ignite-config string   Ignite configuration path; refer to the 'Ignite Configuration' docs for more details
+      --log-level loglevel     Specify the loglevel for the program (default info)
+  -q, --quiet                  The quiet mode allows for machine-parsable output by printing only IDs
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_cp.md
+++ b/docs/cli/ignite/ignite_cp.md
@@ -31,11 +31,9 @@ ignite cp <source> <dest> [flags]
 ### Options inherited from parent commands
 
 ```
-      --ignite-config string    Ignite configuration path; refer to the 'Ignite Configuration' docs for more details
-      --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
-  -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
+      --ignite-config string   Ignite configuration path; refer to the 'Ignite Configuration' docs for more details
+      --log-level loglevel     Specify the loglevel for the program (default info)
+  -q, --quiet                  The quiet mode allows for machine-parsable output by printing only IDs
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_create.md
+++ b/docs/cli/ignite/ignite_create.md
@@ -43,8 +43,10 @@ ignite create <OCI image> [flags]
   -l, --label stringArray         Set a label (foo=bar)
       --memory size               Amount of RAM to allocate for the VM (default 512.0 MB)
   -n, --name string               Specify the name
+      --network-plugin plugin     Network plugin to use. Available options are: [cni docker-bridge] (default cni)
   -p, --ports strings             Map host ports to VM ports
       --require-name              Require VM name to be passed, no name generation
+      --runtime runtime           Container runtime to use. Available options are: [docker containerd] (default containerd)
       --sandbox-image oci-image   Specify an OCI image for the VM sandbox (default weaveworks/ignite:dev)
   -s, --size size                 VM filesystem size, for example 5GB or 2048MB (default 4.0 GB)
       --ssh[=<path>]              Enable SSH for the VM. If <path> is given, it will be imported as the public key. If just '--ssh' is specified, a new keypair will be generated. (default is unset, which disables SSH access to the VM)
@@ -54,11 +56,9 @@ ignite create <OCI image> [flags]
 ### Options inherited from parent commands
 
 ```
-      --ignite-config string    Ignite configuration path; refer to the 'Ignite Configuration' docs for more details
-      --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
-  -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
+      --ignite-config string   Ignite configuration path; refer to the 'Ignite Configuration' docs for more details
+      --log-level loglevel     Specify the loglevel for the program (default info)
+  -q, --quiet                  The quiet mode allows for machine-parsable output by printing only IDs
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_exec.md
+++ b/docs/cli/ignite/ignite_exec.md
@@ -27,11 +27,9 @@ ignite exec <vm> <command...> [flags]
 ### Options inherited from parent commands
 
 ```
-      --ignite-config string    Ignite configuration path; refer to the 'Ignite Configuration' docs for more details
-      --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
-  -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
+      --ignite-config string   Ignite configuration path; refer to the 'Ignite Configuration' docs for more details
+      --log-level loglevel     Specify the loglevel for the program (default info)
+  -q, --quiet                  The quiet mode allows for machine-parsable output by printing only IDs
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_image.md
+++ b/docs/cli/ignite/ignite_image.md
@@ -22,11 +22,9 @@ ignite image [flags]
 ### Options inherited from parent commands
 
 ```
-      --ignite-config string    Ignite configuration path; refer to the 'Ignite Configuration' docs for more details
-      --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
-  -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
+      --ignite-config string   Ignite configuration path; refer to the 'Ignite Configuration' docs for more details
+      --log-level loglevel     Specify the loglevel for the program (default info)
+  -q, --quiet                  The quiet mode allows for machine-parsable output by printing only IDs
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_image_import.md
+++ b/docs/cli/ignite/ignite_image_import.md
@@ -17,17 +17,16 @@ ignite image import <OCI image> [flags]
 ### Options
 
 ```
-  -h, --help   help for import
+  -h, --help              help for import
+      --runtime runtime   Container runtime to use. Available options are: [docker containerd] (default containerd)
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --ignite-config string    Ignite configuration path; refer to the 'Ignite Configuration' docs for more details
-      --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
-  -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
+      --ignite-config string   Ignite configuration path; refer to the 'Ignite Configuration' docs for more details
+      --log-level loglevel     Specify the loglevel for the program (default info)
+  -q, --quiet                  The quiet mode allows for machine-parsable output by printing only IDs
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_image_ls.md
+++ b/docs/cli/ignite/ignite_image_ls.md
@@ -21,11 +21,9 @@ ignite image ls [flags]
 ### Options inherited from parent commands
 
 ```
-      --ignite-config string    Ignite configuration path; refer to the 'Ignite Configuration' docs for more details
-      --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
-  -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
+      --ignite-config string   Ignite configuration path; refer to the 'Ignite Configuration' docs for more details
+      --log-level loglevel     Specify the loglevel for the program (default info)
+  -q, --quiet                  The quiet mode allows for machine-parsable output by printing only IDs
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_image_rm.md
+++ b/docs/cli/ignite/ignite_image_rm.md
@@ -24,11 +24,9 @@ ignite image rm <image>... [flags]
 ### Options inherited from parent commands
 
 ```
-      --ignite-config string    Ignite configuration path; refer to the 'Ignite Configuration' docs for more details
-      --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
-  -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
+      --ignite-config string   Ignite configuration path; refer to the 'Ignite Configuration' docs for more details
+      --log-level loglevel     Specify the loglevel for the program (default info)
+  -q, --quiet                  The quiet mode allows for machine-parsable output by printing only IDs
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_inspect.md
+++ b/docs/cli/ignite/ignite_inspect.md
@@ -35,11 +35,9 @@ ignite inspect <kind> <object> [flags]
 ### Options inherited from parent commands
 
 ```
-      --ignite-config string    Ignite configuration path; refer to the 'Ignite Configuration' docs for more details
-      --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
-  -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
+      --ignite-config string   Ignite configuration path; refer to the 'Ignite Configuration' docs for more details
+      --log-level loglevel     Specify the loglevel for the program (default info)
+  -q, --quiet                  The quiet mode allows for machine-parsable output by printing only IDs
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_kernel.md
+++ b/docs/cli/ignite/ignite_kernel.md
@@ -22,11 +22,9 @@ ignite kernel [flags]
 ### Options inherited from parent commands
 
 ```
-      --ignite-config string    Ignite configuration path; refer to the 'Ignite Configuration' docs for more details
-      --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
-  -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
+      --ignite-config string   Ignite configuration path; refer to the 'Ignite Configuration' docs for more details
+      --log-level loglevel     Specify the loglevel for the program (default info)
+  -q, --quiet                  The quiet mode allows for machine-parsable output by printing only IDs
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_kernel_import.md
+++ b/docs/cli/ignite/ignite_kernel_import.md
@@ -17,17 +17,16 @@ ignite kernel import <OCI image> [flags]
 ### Options
 
 ```
-  -h, --help   help for import
+  -h, --help              help for import
+      --runtime runtime   Container runtime to use. Available options are: [docker containerd] (default containerd)
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --ignite-config string    Ignite configuration path; refer to the 'Ignite Configuration' docs for more details
-      --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
-  -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
+      --ignite-config string   Ignite configuration path; refer to the 'Ignite Configuration' docs for more details
+      --log-level loglevel     Specify the loglevel for the program (default info)
+  -q, --quiet                  The quiet mode allows for machine-parsable output by printing only IDs
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_kernel_ls.md
+++ b/docs/cli/ignite/ignite_kernel_ls.md
@@ -21,11 +21,9 @@ ignite kernel ls [flags]
 ### Options inherited from parent commands
 
 ```
-      --ignite-config string    Ignite configuration path; refer to the 'Ignite Configuration' docs for more details
-      --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
-  -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
+      --ignite-config string   Ignite configuration path; refer to the 'Ignite Configuration' docs for more details
+      --log-level loglevel     Specify the loglevel for the program (default info)
+  -q, --quiet                  The quiet mode allows for machine-parsable output by printing only IDs
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_kernel_rm.md
+++ b/docs/cli/ignite/ignite_kernel_rm.md
@@ -24,11 +24,9 @@ ignite kernel rm <kernel>... [flags]
 ### Options inherited from parent commands
 
 ```
-      --ignite-config string    Ignite configuration path; refer to the 'Ignite Configuration' docs for more details
-      --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
-  -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
+      --ignite-config string   Ignite configuration path; refer to the 'Ignite Configuration' docs for more details
+      --log-level loglevel     Specify the loglevel for the program (default info)
+  -q, --quiet                  The quiet mode allows for machine-parsable output by printing only IDs
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_kill.md
+++ b/docs/cli/ignite/ignite_kill.md
@@ -23,11 +23,9 @@ ignite kill <vm>... [flags]
 ### Options inherited from parent commands
 
 ```
-      --ignite-config string    Ignite configuration path; refer to the 'Ignite Configuration' docs for more details
-      --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
-  -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
+      --ignite-config string   Ignite configuration path; refer to the 'Ignite Configuration' docs for more details
+      --log-level loglevel     Specify the loglevel for the program (default info)
+  -q, --quiet                  The quiet mode allows for machine-parsable output by printing only IDs
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_logs.md
+++ b/docs/cli/ignite/ignite_logs.md
@@ -22,11 +22,9 @@ ignite logs <vm> [flags]
 ### Options inherited from parent commands
 
 ```
-      --ignite-config string    Ignite configuration path; refer to the 'Ignite Configuration' docs for more details
-      --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
-  -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
+      --ignite-config string   Ignite configuration path; refer to the 'Ignite Configuration' docs for more details
+      --log-level loglevel     Specify the loglevel for the program (default info)
+  -q, --quiet                  The quiet mode allows for machine-parsable output by printing only IDs
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_ps.md
+++ b/docs/cli/ignite/ignite_ps.md
@@ -47,11 +47,9 @@ ignite ps [flags]
 ### Options inherited from parent commands
 
 ```
-      --ignite-config string    Ignite configuration path; refer to the 'Ignite Configuration' docs for more details
-      --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
-  -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
+      --ignite-config string   Ignite configuration path; refer to the 'Ignite Configuration' docs for more details
+      --log-level loglevel     Specify the loglevel for the program (default info)
+  -q, --quiet                  The quiet mode allows for machine-parsable output by printing only IDs
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_rm.md
+++ b/docs/cli/ignite/ignite_rm.md
@@ -26,11 +26,9 @@ ignite rm <vm>... [flags]
 ### Options inherited from parent commands
 
 ```
-      --ignite-config string    Ignite configuration path; refer to the 'Ignite Configuration' docs for more details
-      --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
-  -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
+      --ignite-config string   Ignite configuration path; refer to the 'Ignite Configuration' docs for more details
+      --log-level loglevel     Specify the loglevel for the program (default info)
+  -q, --quiet                  The quiet mode allows for machine-parsable output by printing only IDs
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_rmi.md
+++ b/docs/cli/ignite/ignite_rmi.md
@@ -24,11 +24,9 @@ ignite rmi <image> [flags]
 ### Options inherited from parent commands
 
 ```
-      --ignite-config string    Ignite configuration path; refer to the 'Ignite Configuration' docs for more details
-      --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
-  -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
+      --ignite-config string   Ignite configuration path; refer to the 'Ignite Configuration' docs for more details
+      --log-level loglevel     Specify the loglevel for the program (default info)
+  -q, --quiet                  The quiet mode allows for machine-parsable output by printing only IDs
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_rmk.md
+++ b/docs/cli/ignite/ignite_rmk.md
@@ -24,11 +24,9 @@ ignite rmk <kernel> [flags]
 ### Options inherited from parent commands
 
 ```
-      --ignite-config string    Ignite configuration path; refer to the 'Ignite Configuration' docs for more details
-      --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
-  -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
+      --ignite-config string   Ignite configuration path; refer to the 'Ignite Configuration' docs for more details
+      --log-level loglevel     Specify the loglevel for the program (default info)
+  -q, --quiet                  The quiet mode allows for machine-parsable output by printing only IDs
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_run.md
+++ b/docs/cli/ignite/ignite_run.md
@@ -39,8 +39,10 @@ ignite run <OCI image> [flags]
   -l, --label stringArray                 Set a label (foo=bar)
       --memory size                       Amount of RAM to allocate for the VM (default 512.0 MB)
   -n, --name string                       Specify the name
+      --network-plugin plugin             Network plugin to use. Available options are: [cni docker-bridge] (default cni)
   -p, --ports strings                     Map host ports to VM ports
       --require-name                      Require VM name to be passed, no name generation
+      --runtime runtime                   Container runtime to use. Available options are: [docker containerd] (default containerd)
       --sandbox-image oci-image           Specify an OCI image for the VM sandbox (default weaveworks/ignite:dev)
   -s, --size size                         VM filesystem size, for example 5GB or 2048MB (default 4.0 GB)
       --ssh[=<path>]                      Enable SSH for the VM. If <path> is given, it will be imported as the public key. If just '--ssh' is specified, a new keypair will be generated. (default is unset, which disables SSH access to the VM)
@@ -50,11 +52,9 @@ ignite run <OCI image> [flags]
 ### Options inherited from parent commands
 
 ```
-      --ignite-config string    Ignite configuration path; refer to the 'Ignite Configuration' docs for more details
-      --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
-  -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
+      --ignite-config string   Ignite configuration path; refer to the 'Ignite Configuration' docs for more details
+      --log-level loglevel     Specify the loglevel for the program (default info)
+  -q, --quiet                  The quiet mode allows for machine-parsable output by printing only IDs
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_ssh.md
+++ b/docs/cli/ignite/ignite_ssh.md
@@ -27,11 +27,9 @@ ignite ssh <vm> [flags]
 ### Options inherited from parent commands
 
 ```
-      --ignite-config string    Ignite configuration path; refer to the 'Ignite Configuration' docs for more details
-      --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
-  -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
+      --ignite-config string   Ignite configuration path; refer to the 'Ignite Configuration' docs for more details
+      --log-level loglevel     Specify the loglevel for the program (default info)
+  -q, --quiet                  The quiet mode allows for machine-parsable output by printing only IDs
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_start.md
+++ b/docs/cli/ignite/ignite_start.md
@@ -21,6 +21,8 @@ ignite start <vm> [flags]
   -h, --help                              help for start
       --ignore-preflight-checks strings   A list of checks whose errors will be shown as warnings. Example: 'BinaryInPath,Port,ExistingFile'. Value 'all' ignores errors from all checks.
   -i, --interactive                       Attach to the VM after starting
+      --network-plugin plugin             Network plugin to use. Available options are: [cni docker-bridge] (default cni)
+      --runtime runtime                   Container runtime to use. Available options are: [docker containerd] (default containerd)
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli/ignite/ignite_start.md
+++ b/docs/cli/ignite/ignite_start.md
@@ -26,11 +26,9 @@ ignite start <vm> [flags]
 ### Options inherited from parent commands
 
 ```
-      --ignite-config string    Ignite configuration path; refer to the 'Ignite Configuration' docs for more details
-      --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
-  -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
+      --ignite-config string   Ignite configuration path; refer to the 'Ignite Configuration' docs for more details
+      --log-level loglevel     Specify the loglevel for the program (default info)
+  -q, --quiet                  The quiet mode allows for machine-parsable output by printing only IDs
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_stop.md
+++ b/docs/cli/ignite/ignite_stop.md
@@ -28,11 +28,9 @@ ignite stop <vm>... [flags]
 ### Options inherited from parent commands
 
 ```
-      --ignite-config string    Ignite configuration path; refer to the 'Ignite Configuration' docs for more details
-      --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
-  -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
+      --ignite-config string   Ignite configuration path; refer to the 'Ignite Configuration' docs for more details
+      --log-level loglevel     Specify the loglevel for the program (default info)
+  -q, --quiet                  The quiet mode allows for machine-parsable output by printing only IDs
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_version.md
+++ b/docs/cli/ignite/ignite_version.md
@@ -20,11 +20,9 @@ ignite version [flags]
 ### Options inherited from parent commands
 
 ```
-      --ignite-config string    Ignite configuration path; refer to the 'Ignite Configuration' docs for more details
-      --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
-  -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
+      --ignite-config string   Ignite configuration path; refer to the 'Ignite Configuration' docs for more details
+      --log-level loglevel     Specify the loglevel for the program (default info)
+  -q, --quiet                  The quiet mode allows for machine-parsable output by printing only IDs
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_vm.md
+++ b/docs/cli/ignite/ignite_vm.md
@@ -21,11 +21,9 @@ ignite vm [flags]
 ### Options inherited from parent commands
 
 ```
-      --ignite-config string    Ignite configuration path; refer to the 'Ignite Configuration' docs for more details
-      --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
-  -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
+      --ignite-config string   Ignite configuration path; refer to the 'Ignite Configuration' docs for more details
+      --log-level loglevel     Specify the loglevel for the program (default info)
+  -q, --quiet                  The quiet mode allows for machine-parsable output by printing only IDs
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_vm_attach.md
+++ b/docs/cli/ignite/ignite_vm_attach.md
@@ -23,11 +23,9 @@ ignite vm attach <vm> [flags]
 ### Options inherited from parent commands
 
 ```
-      --ignite-config string    Ignite configuration path; refer to the 'Ignite Configuration' docs for more details
-      --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
-  -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
+      --ignite-config string   Ignite configuration path; refer to the 'Ignite Configuration' docs for more details
+      --log-level loglevel     Specify the loglevel for the program (default info)
+  -q, --quiet                  The quiet mode allows for machine-parsable output by printing only IDs
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_vm_create.md
+++ b/docs/cli/ignite/ignite_vm_create.md
@@ -43,8 +43,10 @@ ignite vm create <OCI image> [flags]
   -l, --label stringArray         Set a label (foo=bar)
       --memory size               Amount of RAM to allocate for the VM (default 512.0 MB)
   -n, --name string               Specify the name
+      --network-plugin plugin     Network plugin to use. Available options are: [cni docker-bridge] (default cni)
   -p, --ports strings             Map host ports to VM ports
       --require-name              Require VM name to be passed, no name generation
+      --runtime runtime           Container runtime to use. Available options are: [docker containerd] (default containerd)
       --sandbox-image oci-image   Specify an OCI image for the VM sandbox (default weaveworks/ignite:dev)
   -s, --size size                 VM filesystem size, for example 5GB or 2048MB (default 4.0 GB)
       --ssh[=<path>]              Enable SSH for the VM. If <path> is given, it will be imported as the public key. If just '--ssh' is specified, a new keypair will be generated. (default is unset, which disables SSH access to the VM)
@@ -54,11 +56,9 @@ ignite vm create <OCI image> [flags]
 ### Options inherited from parent commands
 
 ```
-      --ignite-config string    Ignite configuration path; refer to the 'Ignite Configuration' docs for more details
-      --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
-  -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
+      --ignite-config string   Ignite configuration path; refer to the 'Ignite Configuration' docs for more details
+      --log-level loglevel     Specify the loglevel for the program (default info)
+  -q, --quiet                  The quiet mode allows for machine-parsable output by printing only IDs
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_vm_kill.md
+++ b/docs/cli/ignite/ignite_vm_kill.md
@@ -23,11 +23,9 @@ ignite vm kill <vm>... [flags]
 ### Options inherited from parent commands
 
 ```
-      --ignite-config string    Ignite configuration path; refer to the 'Ignite Configuration' docs for more details
-      --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
-  -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
+      --ignite-config string   Ignite configuration path; refer to the 'Ignite Configuration' docs for more details
+      --log-level loglevel     Specify the loglevel for the program (default info)
+  -q, --quiet                  The quiet mode allows for machine-parsable output by printing only IDs
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_vm_logs.md
+++ b/docs/cli/ignite/ignite_vm_logs.md
@@ -22,11 +22,9 @@ ignite vm logs <vm> [flags]
 ### Options inherited from parent commands
 
 ```
-      --ignite-config string    Ignite configuration path; refer to the 'Ignite Configuration' docs for more details
-      --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
-  -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
+      --ignite-config string   Ignite configuration path; refer to the 'Ignite Configuration' docs for more details
+      --log-level loglevel     Specify the loglevel for the program (default info)
+  -q, --quiet                  The quiet mode allows for machine-parsable output by printing only IDs
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_vm_ps.md
+++ b/docs/cli/ignite/ignite_vm_ps.md
@@ -47,11 +47,9 @@ ignite vm ps [flags]
 ### Options inherited from parent commands
 
 ```
-      --ignite-config string    Ignite configuration path; refer to the 'Ignite Configuration' docs for more details
-      --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
-  -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
+      --ignite-config string   Ignite configuration path; refer to the 'Ignite Configuration' docs for more details
+      --log-level loglevel     Specify the loglevel for the program (default info)
+  -q, --quiet                  The quiet mode allows for machine-parsable output by printing only IDs
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_vm_rm.md
+++ b/docs/cli/ignite/ignite_vm_rm.md
@@ -26,11 +26,9 @@ ignite vm rm <vm>... [flags]
 ### Options inherited from parent commands
 
 ```
-      --ignite-config string    Ignite configuration path; refer to the 'Ignite Configuration' docs for more details
-      --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
-  -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
+      --ignite-config string   Ignite configuration path; refer to the 'Ignite Configuration' docs for more details
+      --log-level loglevel     Specify the loglevel for the program (default info)
+  -q, --quiet                  The quiet mode allows for machine-parsable output by printing only IDs
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_vm_run.md
+++ b/docs/cli/ignite/ignite_vm_run.md
@@ -39,8 +39,10 @@ ignite vm run <OCI image> [flags]
   -l, --label stringArray                 Set a label (foo=bar)
       --memory size                       Amount of RAM to allocate for the VM (default 512.0 MB)
   -n, --name string                       Specify the name
+      --network-plugin plugin             Network plugin to use. Available options are: [cni docker-bridge] (default cni)
   -p, --ports strings                     Map host ports to VM ports
       --require-name                      Require VM name to be passed, no name generation
+      --runtime runtime                   Container runtime to use. Available options are: [docker containerd] (default containerd)
       --sandbox-image oci-image           Specify an OCI image for the VM sandbox (default weaveworks/ignite:dev)
   -s, --size size                         VM filesystem size, for example 5GB or 2048MB (default 4.0 GB)
       --ssh[=<path>]                      Enable SSH for the VM. If <path> is given, it will be imported as the public key. If just '--ssh' is specified, a new keypair will be generated. (default is unset, which disables SSH access to the VM)
@@ -50,11 +52,9 @@ ignite vm run <OCI image> [flags]
 ### Options inherited from parent commands
 
 ```
-      --ignite-config string    Ignite configuration path; refer to the 'Ignite Configuration' docs for more details
-      --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
-  -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
+      --ignite-config string   Ignite configuration path; refer to the 'Ignite Configuration' docs for more details
+      --log-level loglevel     Specify the loglevel for the program (default info)
+  -q, --quiet                  The quiet mode allows for machine-parsable output by printing only IDs
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_vm_ssh.md
+++ b/docs/cli/ignite/ignite_vm_ssh.md
@@ -27,11 +27,9 @@ ignite vm ssh <vm> [flags]
 ### Options inherited from parent commands
 
 ```
-      --ignite-config string    Ignite configuration path; refer to the 'Ignite Configuration' docs for more details
-      --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
-  -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
+      --ignite-config string   Ignite configuration path; refer to the 'Ignite Configuration' docs for more details
+      --log-level loglevel     Specify the loglevel for the program (default info)
+  -q, --quiet                  The quiet mode allows for machine-parsable output by printing only IDs
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_vm_start.md
+++ b/docs/cli/ignite/ignite_vm_start.md
@@ -21,6 +21,8 @@ ignite vm start <vm> [flags]
   -h, --help                              help for start
       --ignore-preflight-checks strings   A list of checks whose errors will be shown as warnings. Example: 'BinaryInPath,Port,ExistingFile'. Value 'all' ignores errors from all checks.
   -i, --interactive                       Attach to the VM after starting
+      --network-plugin plugin             Network plugin to use. Available options are: [cni docker-bridge] (default cni)
+      --runtime runtime                   Container runtime to use. Available options are: [docker containerd] (default containerd)
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli/ignite/ignite_vm_start.md
+++ b/docs/cli/ignite/ignite_vm_start.md
@@ -26,11 +26,9 @@ ignite vm start <vm> [flags]
 ### Options inherited from parent commands
 
 ```
-      --ignite-config string    Ignite configuration path; refer to the 'Ignite Configuration' docs for more details
-      --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
-  -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
+      --ignite-config string   Ignite configuration path; refer to the 'Ignite Configuration' docs for more details
+      --log-level loglevel     Specify the loglevel for the program (default info)
+  -q, --quiet                  The quiet mode allows for machine-parsable output by printing only IDs
 ```
 
 ### SEE ALSO

--- a/docs/cli/ignite/ignite_vm_stop.md
+++ b/docs/cli/ignite/ignite_vm_stop.md
@@ -28,11 +28,9 @@ ignite vm stop <vm>... [flags]
 ### Options inherited from parent commands
 
 ```
-      --ignite-config string    Ignite configuration path; refer to the 'Ignite Configuration' docs for more details
-      --log-level loglevel      Specify the loglevel for the program (default info)
-      --network-plugin plugin   Network plugin to use. Available options are: [cni docker-bridge] (default cni)
-  -q, --quiet                   The quiet mode allows for machine-parsable output by printing only IDs
-      --runtime runtime         Container runtime to use. Available options are: [docker containerd] (default containerd)
+      --ignite-config string   Ignite configuration path; refer to the 'Ignite Configuration' docs for more details
+      --log-level loglevel     Specify the loglevel for the program (default info)
+  -q, --quiet                  The quiet mode allows for machine-parsable output by printing only IDs
 ```
 
 ### SEE ALSO

--- a/e2e/run_test.go
+++ b/e2e/run_test.go
@@ -23,8 +23,6 @@ func runWithRuntimeAndNetworkPlugin(t *testing.T, vmName, runtime, networkPlugin
 	igniteCmd := util.NewCommand(t, igniteBin)
 
 	defer igniteCmd.New().
-		WithRuntime(runtime).
-		WithNetwork(networkPlugin).
 		With("rm", "-f").
 		With(vmName).
 		Run()
@@ -73,8 +71,6 @@ func runCurl(t *testing.T, vmName, runtime, networkPlugin string) {
 	igniteCmd := util.NewCommand(t, igniteBin)
 
 	defer igniteCmd.New().
-		WithRuntime(runtime).
-		WithNetwork(networkPlugin).
 		With("rm", "-f", vmName).
 		Run()
 

--- a/e2e/run_volume_test.go
+++ b/e2e/run_volume_test.go
@@ -73,8 +73,6 @@ func runVolume(t *testing.T, vmName, runtime, networkPlugin string) {
 
 	// Clean-up the following VM.
 	defer igniteCmd.New().
-		WithRuntime(runtime).
-		WithNetwork(networkPlugin).
 		With("rm", "-f", vmName).
 		Run()
 
@@ -97,8 +95,6 @@ func runVolume(t *testing.T, vmName, runtime, networkPlugin string) {
 
 	// Stop the vm without force.
 	igniteCmd.New().
-		WithRuntime(runtime).
-		WithNetwork(networkPlugin).
 		With("stop", vmName).
 		Run()
 
@@ -106,8 +102,6 @@ func runVolume(t *testing.T, vmName, runtime, networkPlugin string) {
 
 	// Clean-up the following VM.
 	defer igniteCmd.New().
-		WithRuntime(runtime).
-		WithNetwork(networkPlugin).
 		With("rm", "-f", secondVMName).
 		Run()
 

--- a/e2e/vm_lifecycle_test.go
+++ b/e2e/vm_lifecycle_test.go
@@ -1,0 +1,133 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/weaveworks/ignite/e2e/util"
+	"gotest.tools/assert"
+)
+
+// runVMLifecycle is a helper for testing the VM lifecycle.
+// vmName should be unique for each test.
+func runVMLifecycle(t *testing.T, vmName, runtime, networkPlugin string) {
+	assert.Assert(t, e2eHome != "", "IGNITE_E2E_HOME should be set")
+
+	igniteCmd := util.NewCommand(t, igniteBin)
+
+	// Clean-up the following VM.
+	defer igniteCmd.New().
+		With("rm", "-f", vmName).
+		Run()
+
+	// Run VM.
+	igniteCmd.New().
+		WithRuntime(runtime).
+		WithNetwork(networkPlugin).
+		With("run").
+		With("--name=" + vmName).
+		With("--ssh").
+		With(util.DefaultVMImage).
+		Run()
+
+	// Check network access.
+	igniteCmd.New().
+		With("exec", vmName).
+		With("curl", "google.com").
+		Run()
+
+	// Stop VM.
+	igniteCmd.New().
+		With("stop", vmName).
+		Run()
+
+	// Start VM with explicit runtime and network because these info are
+	// removed when VM is stopped. Without it, the VM will start with the
+	// default provider configurations.
+	igniteCmd.New().
+		With("start", vmName).
+		WithRuntime(runtime).
+		WithNetwork(networkPlugin).
+		Run()
+
+	// Check network access after reboot.
+	igniteCmd.New().
+		With("exec", vmName).
+		With("curl", "google.com").
+		Run()
+}
+
+func TestVMLifecycleWithDockerAndDockerBridge(t *testing.T) {
+	runVMLifecycle(
+		t,
+		"e2e_test_vm_lifecycle_docker_and_docker_bridge",
+		"docker",
+		"docker-bridge",
+	)
+}
+
+func TestVMLifecycleWithDockerAndCNI(t *testing.T) {
+	runVMLifecycle(
+		t,
+		"e2e_test_vm_lifecycle_docker_and_cni",
+		"docker",
+		"cni",
+	)
+}
+
+func TestVMLifecycleWithContainerdAndCNI(t *testing.T) {
+	runVMLifecycle(
+		t,
+		"e2e_test_vm_lifecycle_containerd_and_cni",
+		"containerd",
+		"cni",
+	)
+}
+
+// TestVMProviderSwitch tests that a VM's runtime and network-plugin can be
+// changed.
+func TestVMProviderSwitch(t *testing.T) {
+	assert.Assert(t, e2eHome != "", "IGNITE_E2E_HOME should be set")
+
+	vmName := "e2e_test_vm_providers_switch"
+
+	igniteCmd := util.NewCommand(t, igniteBin)
+
+	// Clean-up the following VM.
+	defer igniteCmd.New().
+		With("rm", "-f", vmName).
+		Run()
+
+	// Run VM.
+	igniteCmd.New().
+		WithRuntime("containerd").
+		WithNetwork("cni").
+		With("run").
+		With("--name=" + vmName).
+		With("--ssh").
+		With(util.DefaultVMImage).
+		Run()
+
+	// Check network access.
+	igniteCmd.New().
+		With("exec", vmName).
+		With("curl", "google.com").
+		Run()
+
+	// Stop VM.
+	igniteCmd.New().
+		With("stop", vmName).
+		Run()
+
+	// Start VM with different providers.
+	igniteCmd.New().
+		With("start", vmName).
+		WithRuntime("docker").
+		WithNetwork("docker-bridge").
+		Run()
+
+	// Check network access.
+	igniteCmd.New().
+		With("exec", vmName).
+		With("curl", "google.com").
+		Run()
+}

--- a/go.mod
+++ b/go.mod
@@ -55,12 +55,13 @@ require (
 	github.com/vishvananda/netlink v1.1.0
 	github.com/weaveworks/libgitops v0.0.0-20200611103311-2c871bbbbf0c
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
-	golang.org/x/net v0.0.0-20200707034311-ab3426394381 // indirect
+	golang.org/x/net v0.0.0-20200822124328-c89045814202 // indirect
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208 // indirect
 	golang.org/x/sys v0.0.0-20200610111108-226ff32320da
 	golang.org/x/text v0.3.3 // indirect
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	gotest.tools v2.2.0+incompatible
 	k8s.io/apimachinery v0.18.3
-	k8s.io/kube-openapi v0.0.0-20200811211545-daf3cbb84823
+	k8s.io/kube-openapi v0.0.0-20200831175022-64514a1d5d59
 	sigs.k8s.io/yaml v1.2.0
 )

--- a/go.sum
+++ b/go.sum
@@ -829,8 +829,8 @@ golang.org/x/net v0.0.0-20191004110552-13f9640d40b9/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200301022130-244492dfa37a h1:GuSPYbZzB5/dcLNCwLQLsg3obCJtX9IJhpXkvY7kzk0=
 golang.org/x/net v0.0.0-20200301022130-244492dfa37a/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/net v0.0.0-20200707034311-ab3426394381 h1:VXak5I6aEWmAXeQjA+QSZzlgNrpq9mjcfDemuexIKsU=
-golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
+golang.org/x/net v0.0.0-20200822124328-c89045814202 h1:VvcQYSHwXgi7W+TpUR6A9g6Up98WAHf3f/ulnJ62IyA=
+golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -925,6 +925,8 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gomodules.xyz/jsonpatch/v2 v2.0.1/go.mod h1:IhYNNY4jnS53ZnfE4PAmpKtDpTCj1JFXc+3mwe7XcUU=
 gonum.org/v1/gonum v0.0.0-20190331200053-3d26580ed485/go.mod h1:2ltnJ7xHfj0zHS40VVPYEAAMTa3ZGguvHGBSJeRWqE0=
 gonum.org/v1/netlib v0.0.0-20190313105609-8cb42192e0e0/go.mod h1:wa6Ws7BG/ESfp6dHfk7C6KdzKA7wR7u/rKwOGE66zvw=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -11,6 +11,7 @@ import (
 	"github.com/weaveworks/ignite/pkg/constants"
 	"github.com/weaveworks/ignite/pkg/network"
 	"github.com/weaveworks/ignite/pkg/providers"
+	"github.com/weaveworks/ignite/pkg/providers/ignite"
 	"github.com/weaveworks/ignite/pkg/runtime"
 )
 
@@ -78,4 +79,11 @@ func getConfigFromFile(configPath string) (*api.Configuration, error) {
 	}
 
 	return componentConfig, nil
+}
+
+// SetAndPopulateProviders sets and populates the providers.
+func SetAndPopulateProviders(runtimeName runtime.Name, networkPlugin network.PluginName) error {
+	providers.RuntimeName = runtimeName
+	providers.NetworkPluginName = networkPlugin
+	return providers.Populate(ignite.Providers)
 }

--- a/vendor/golang.org/x/net/http2/transport.go
+++ b/vendor/golang.org/x/net/http2/transport.go
@@ -2525,6 +2525,7 @@ func strSliceContains(ss []string, s string) bool {
 
 type erringRoundTripper struct{ err error }
 
+func (rt erringRoundTripper) RoundTripErr() error                             { return rt.err }
 func (rt erringRoundTripper) RoundTrip(*http.Request) (*http.Response, error) { return nil, rt.err }
 
 // gzipReader wraps a response body so it can lazily

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -491,7 +491,7 @@ golang.org/x/crypto/ssh/agent
 golang.org/x/crypto/ssh/internal/bcrypt_pbkdf
 golang.org/x/crypto/ssh/knownhosts
 golang.org/x/crypto/ssh/terminal
-# golang.org/x/net v0.0.0-20200707034311-ab3426394381
+# golang.org/x/net v0.0.0-20200822124328-c89045814202
 ## explicit
 golang.org/x/net/bpf
 golang.org/x/net/context
@@ -525,6 +525,8 @@ golang.org/x/text/transform
 golang.org/x/text/unicode/bidi
 golang.org/x/text/unicode/norm
 golang.org/x/text/width
+# golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
+## explicit
 # google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55
 google.golang.org/genproto/googleapis/rpc/status
 # google.golang.org/grpc v1.27.0
@@ -617,7 +619,7 @@ k8s.io/apimachinery/third_party/forked/golang/json
 k8s.io/apimachinery/third_party/forked/golang/reflect
 # k8s.io/klog v1.0.0
 k8s.io/klog
-# k8s.io/kube-openapi v0.0.0-20200811211545-daf3cbb84823 => k8s.io/kube-openapi v0.0.0-20200121204235-bf4fb3bd569c
+# k8s.io/kube-openapi v0.0.0-20200831175022-64514a1d5d59 => k8s.io/kube-openapi v0.0.0-20200121204235-bf4fb3bd569c
 ## explicit
 k8s.io/kube-openapi/pkg/common
 k8s.io/kube-openapi/pkg/util/proto


### PR DESCRIPTION
This is a follow-up change to https://github.com/weaveworks/ignite/pull/651, which adds the runtime and
network-plugin info in the VM status.

- Remove the global flags `runtime` and `network-plugin` to be in VM `create`
command.
- Update all the VM commands (`run, stop, rm`) to read the `runtime` and
`network-plugin` info from VM status.
- Add `runtime` flag to `image import`.
- Update docs.
- Handle rm for stopped VMs - stopped VMs don't contain runtime info. Avoid runtime operations for them.
- Fix `patchStopped()` status patch data in ignite-spawn as per the recent status changes.
- Update e2e tests.
- Handle VM start after stop - since stopped VMs don't contain runtime info, add runtime and network flags
to VM start command.
- Add e2e tests for VM lifecycle, including VM provider switching.