### PR TITLE
Export command option types

### DIFF
--- a/cmd/ignite/run/attach.go
+++ b/cmd/ignite/run/attach.go
@@ -10,18 +10,18 @@ import (
 
 // checkRunning can be used to skip the running check, this is used by Start and Run
 // as the in-container ignite takes some time to start up and update the state
-type attachOptions struct {
+type AttachOptions struct {
 	checkRunning bool
 	vm           *api.VM
 }
 
-func NewAttachOptions(vmMatch string) (ao *attachOptions, err error) {
-	ao = &attachOptions{checkRunning: true}
+func NewAttachOptions(vmMatch string) (ao *AttachOptions, err error) {
+	ao = &AttachOptions{checkRunning: true}
 	ao.vm, err = getVMForMatch(vmMatch)
 	return
 }
 
-func Attach(ao *attachOptions) error {
+func Attach(ao *AttachOptions) error {
 	// Check if the VM is running
 	if ao.checkRunning && !ao.vm.Running() {
 		return fmt.Errorf("VM %q is not running", ao.vm.GetUID())

--- a/cmd/ignite/run/cp.go
+++ b/cmd/ignite/run/cp.go
@@ -29,7 +29,7 @@ type CPFlags struct {
 	IdentityFile string
 }
 
-type cpOptions struct {
+type CpOptions struct {
 	*CPFlags
 	vm            *api.VM
 	source        string
@@ -48,8 +48,8 @@ const (
 )
 
 // NewCPOptions parses the command inputs and returns a copy option.
-func (cf *CPFlags) NewCPOptions(source string, dest string) (co *cpOptions, err error) {
-	co = &cpOptions{CPFlags: cf}
+func (cf *CPFlags) NewCPOptions(source string, dest string) (co *CpOptions, err error) {
+	co = &CpOptions{CPFlags: cf}
 
 	// Identify the direction of copy from the source and destination.
 	// If the source contains <file path> and destination contains
@@ -95,7 +95,7 @@ func (cf *CPFlags) NewCPOptions(source string, dest string) (co *cpOptions, err 
 
 // CP connects to a VM and copies files between the host and the VM based on the
 // copy options.
-func CP(co *cpOptions) error {
+func CP(co *CpOptions) error {
 	// Check if the VM is running
 	if !co.vm.Running() {
 		return fmt.Errorf("VM %q is not running", co.vm.GetUID())

--- a/cmd/ignite/run/create.go
+++ b/cmd/ignite/run/create.go
@@ -41,13 +41,13 @@ type CreateFlags struct {
 	RequireName bool
 }
 
-type createOptions struct {
+type CreateOptions struct {
 	*CreateFlags
 	image  *api.Image
 	kernel *api.Kernel
 }
 
-func (cf *CreateFlags) NewCreateOptions(args []string, fs *flag.FlagSet) (*createOptions, error) {
+func (cf *CreateFlags) NewCreateOptions(args []string, fs *flag.FlagSet) (*CreateOptions, error) {
 	// Create a new base VM and configure it by combining the component config,
 	// VM config file and flags.
 	baseVM := providers.Client.VMs().New()
@@ -92,7 +92,7 @@ func (cf *CreateFlags) NewCreateOptions(args []string, fs *flag.FlagSet) (*creat
 		return nil, err
 	}
 
-	co := &createOptions{CreateFlags: cf}
+	co := &CreateOptions{CreateFlags: cf}
 
 	// Get the image, or import it if it doesn't exist.
 	var err error
@@ -215,7 +215,7 @@ func applyVMFlagOverrides(baseVM *api.VM, cf *CreateFlags, fs *flag.FlagSet) err
 	return err
 }
 
-func Create(co *createOptions) (err error) {
+func Create(co *CreateOptions) (err error) {
 	// Generate a random UID and Name
 	if err = metadata.SetNameAndUID(co.VM, providers.Client); err != nil {
 		return

--- a/cmd/ignite/run/exec.go
+++ b/cmd/ignite/run/exec.go
@@ -11,15 +11,15 @@ type ExecFlags struct {
 	Tty          bool
 }
 
-type execOptions struct {
+type ExecOptions struct {
 	*ExecFlags
 	vm      *api.VM
 	command []string
 }
 
-// NewExecOptions constructs and returns an execOptions.
-func (ef *ExecFlags) NewExecOptions(vmMatch string, command ...string) (eo *execOptions, err error) {
-	eo = &execOptions{
+// NewExecOptions constructs and returns an ExecOptions.
+func (ef *ExecFlags) NewExecOptions(vmMatch string, command ...string) (eo *ExecOptions, err error) {
+	eo = &ExecOptions{
 		ExecFlags: ef,
 		command:   command,
 	}
@@ -28,7 +28,7 @@ func (ef *ExecFlags) NewExecOptions(vmMatch string, command ...string) (eo *exec
 	return
 }
 
-// Exec executes command in a VM based on the provided execOptions.
-func Exec(eo *execOptions) error {
+// Exec executes command in a VM based on the provided ExecOptions.
+func Exec(eo *ExecOptions) error {
 	return runSSH(eo.vm, eo.IdentityFile, eo.command, eo.Tty, eo.Timeout)
 }

--- a/cmd/ignite/run/images.go
+++ b/cmd/ignite/run/images.go
@@ -7,17 +7,17 @@ import (
 	"github.com/weaveworks/libgitops/pkg/filter"
 )
 
-type imagesOptions struct {
+type ImagesOptions struct {
 	allImages []*api.Image
 }
 
-func NewImagesOptions() (io *imagesOptions, err error) {
-	io = &imagesOptions{}
+func NewImagesOptions() (io *ImagesOptions, err error) {
+	io = &ImagesOptions{}
 	io.allImages, err = providers.Client.Images().FindAll(filter.NewAllFilter())
 	return
 }
 
-func Images(io *imagesOptions) error {
+func Images(io *ImagesOptions) error {
 	o := util.NewOutput()
 	defer o.Flush()
 

--- a/cmd/ignite/run/inspect.go
+++ b/cmd/ignite/run/inspect.go
@@ -19,17 +19,17 @@ type InspectFlags struct {
 	TemplateFormat string
 }
 
-type inspectOptions struct {
+type InspectOptions struct {
 	*InspectFlags
 	object runtime.Object
 }
 
-// NewInspectOptions constructs and returns inspectOptions with the given kind
+// NewInspectOptions constructs and returns InspectOptions with the given kind
 // and object ID.
-func (i *InspectFlags) NewInspectOptions(k, objectMatch string) (*inspectOptions, error) {
+func (i *InspectFlags) NewInspectOptions(k, objectMatch string) (*InspectOptions, error) {
 	var err error
 	var kind runtime.Kind
-	io := &inspectOptions{InspectFlags: i}
+	io := &InspectOptions{InspectFlags: i}
 
 	switch strings.ToLower(k) {
 	case api.KindImage.Lower():
@@ -50,8 +50,8 @@ func (i *InspectFlags) NewInspectOptions(k, objectMatch string) (*inspectOptions
 }
 
 // Inspect renders the result of inspect in different formats based on the
-// inspectOptions.
-func Inspect(io *inspectOptions) error {
+// InspectOptions.
+func Inspect(io *InspectOptions) error {
 	var b []byte
 	var err error
 

--- a/cmd/ignite/run/inspect_test.go
+++ b/cmd/ignite/run/inspect_test.go
@@ -54,7 +54,7 @@ func TestInspect(t *testing.T) {
 				t.Fatalf("failed to create test vm: %v", err)
 			}
 
-			iop := &inspectOptions{InspectFlags: rt.inspectFlags, object: runtime.Object(vm)}
+			iop := &InspectOptions{InspectFlags: rt.inspectFlags, object: runtime.Object(vm)}
 
 			// Run inspect and capture stdout.
 			oldStdout := os.Stdout

--- a/cmd/ignite/run/kernels.go
+++ b/cmd/ignite/run/kernels.go
@@ -7,17 +7,17 @@ import (
 	"github.com/weaveworks/libgitops/pkg/filter"
 )
 
-type kernelsOptions struct {
+type KernelsOptions struct {
 	allKernels []*api.Kernel
 }
 
-func NewKernelsOptions() (ko *kernelsOptions, err error) {
-	ko = &kernelsOptions{}
+func NewKernelsOptions() (ko *KernelsOptions, err error) {
+	ko = &KernelsOptions{}
 	ko.allKernels, err = providers.Client.Kernels().FindAll(filter.NewAllFilter())
 	return
 }
 
-func Kernels(ko *kernelsOptions) error {
+func Kernels(ko *KernelsOptions) error {
 	o := util.NewOutput()
 	defer o.Flush()
 

--- a/cmd/ignite/run/logs.go
+++ b/cmd/ignite/run/logs.go
@@ -9,17 +9,17 @@ import (
 	"github.com/weaveworks/ignite/pkg/util"
 )
 
-type logsOptions struct {
+type LogsOptions struct {
 	vm *api.VM
 }
 
-func NewLogsOptions(vmMatch string) (lo *logsOptions, err error) {
-	lo = &logsOptions{}
+func NewLogsOptions(vmMatch string) (lo *LogsOptions, err error) {
+	lo = &LogsOptions{}
 	lo.vm, err = getVMForMatch(vmMatch)
 	return
 }
 
-func Logs(lo *logsOptions) error {
+func Logs(lo *LogsOptions) error {
 	// Check if the VM is running
 	if !lo.vm.Running() {
 		return fmt.Errorf("VM %q is not running", lo.vm.GetUID())

--- a/cmd/ignite/run/ps.go
+++ b/cmd/ignite/run/ps.go
@@ -18,20 +18,20 @@ type PsFlags struct {
 	TemplateFormat string
 }
 
-type psOptions struct {
+type PsOptions struct {
 	*PsFlags
 	allVMs []*api.VM
 }
 
-// NewPsOptions constructs and returns psOptions.
-func (pf *PsFlags) NewPsOptions() (po *psOptions, err error) {
-	po = &psOptions{PsFlags: pf}
+// NewPsOptions constructs and returns PsOptions.
+func (pf *PsFlags) NewPsOptions() (po *PsOptions, err error) {
+	po = &PsOptions{PsFlags: pf}
 	po.allVMs, err = providers.Client.VMs().FindAll(filter.NewVMFilterAll("", po.All))
 	return
 }
 
-// Ps filters and renders the VMs based on the psOptions.
-func Ps(po *psOptions) error {
+// Ps filters and renders the VMs based on the PsOptions.
+func Ps(po *PsOptions) error {
 	var filters *filter.MultipleMetaFilter
 	var err error
 	var filtering bool

--- a/cmd/ignite/run/ps_test.go
+++ b/cmd/ignite/run/ps_test.go
@@ -122,7 +122,7 @@ func TestPs(t *testing.T) {
 				vms = append(vms, vm)
 			}
 
-			psop := &psOptions{PsFlags: rt.psFlags, allVMs: vms}
+			psop := &PsOptions{PsFlags: rt.psFlags, allVMs: vms}
 
 			// Run vm list and capture stdout.
 			oldStdout := os.Stdout

--- a/cmd/ignite/run/rm.go
+++ b/cmd/ignite/run/rm.go
@@ -15,15 +15,15 @@ type RmFlags struct {
 	ConfigFile string
 }
 
-type rmOptions struct {
+type RmOptions struct {
 	*RmFlags
 	vms []*api.VM
 }
 
-// NewRmOptions creates and returns rmOptions with all the flags and VMs to be
+// NewRmOptions creates and returns RmOptions with all the flags and VMs to be
 // removed.
-func (rf *RmFlags) NewRmOptions(vmMatches []string) (*rmOptions, error) {
-	ro := &rmOptions{RmFlags: rf}
+func (rf *RmFlags) NewRmOptions(vmMatches []string) (*RmOptions, error) {
+	ro := &RmOptions{RmFlags: rf}
 
 	// If config file is provided, use it to find the VM to be removed.
 	if len(rf.ConfigFile) != 0 {
@@ -52,8 +52,8 @@ func (rf *RmFlags) NewRmOptions(vmMatches []string) (*rmOptions, error) {
 	return ro, err
 }
 
-// Rm removes VMs based on rmOptions.
-func Rm(ro *rmOptions) error {
+// Rm removes VMs based on RmOptions.
+func Rm(ro *RmOptions) error {
 	for _, vm := range ro.vms {
 		// If the VM is running, but we haven't enabled force-mode, return an error
 		if vm.Running() && !ro.Force {

--- a/cmd/ignite/run/rmi.go
+++ b/cmd/ignite/run/rmi.go
@@ -15,14 +15,14 @@ type RmiFlags struct {
 	Force bool
 }
 
-type rmiOptions struct {
+type RmiOptions struct {
 	*RmiFlags
 	images []*api.Image
 	allVMs []*api.VM
 }
 
-func (rf *RmiFlags) NewRmiOptions(imageMatches []string) (*rmiOptions, error) {
-	ro := &rmiOptions{RmiFlags: rf}
+func (rf *RmiFlags) NewRmiOptions(imageMatches []string) (*RmiOptions, error) {
+	ro := &RmiOptions{RmiFlags: rf}
 
 	for _, match := range imageMatches {
 		if image, err := providers.Client.Images().Find(filter.NewIDNameFilter(match)); err == nil {
@@ -41,7 +41,7 @@ func (rf *RmiFlags) NewRmiOptions(imageMatches []string) (*rmiOptions, error) {
 	return ro, nil
 }
 
-func Rmi(ro *rmiOptions) error {
+func Rmi(ro *RmiOptions) error {
 	for _, image := range ro.images {
 		for _, vm := range ro.allVMs {
 			imageUID, err := lookup.ImageUIDForVM(vm, providers.Client)
@@ -54,7 +54,7 @@ func Rmi(ro *rmiOptions) error {
 			if imageUID == image.GetUID() {
 				if ro.Force {
 					// Force-kill and remove the VM used by this image
-					if err := Rm(&rmOptions{
+					if err := Rm(&RmOptions{
 						&RmFlags{Force: true},
 						[]*api.VM{vm},
 					}); err != nil {

--- a/cmd/ignite/run/rmk.go
+++ b/cmd/ignite/run/rmk.go
@@ -15,14 +15,14 @@ type RmkFlags struct {
 	Force bool
 }
 
-type rmkOptions struct {
+type RmkOptions struct {
 	*RmkFlags
 	kernels []*api.Kernel
 	allVMs  []*api.VM
 }
 
-func (rf *RmkFlags) NewRmkOptions(kernelMatches []string) (*rmkOptions, error) {
-	ro := &rmkOptions{RmkFlags: rf}
+func (rf *RmkFlags) NewRmkOptions(kernelMatches []string) (*RmkOptions, error) {
+	ro := &RmkOptions{RmkFlags: rf}
 
 	for _, match := range kernelMatches {
 		if kernel, err := providers.Client.Kernels().Find(filter.NewIDNameFilter(match)); err == nil {
@@ -41,7 +41,7 @@ func (rf *RmkFlags) NewRmkOptions(kernelMatches []string) (*rmkOptions, error) {
 	return ro, nil
 }
 
-func Rmk(ro *rmkOptions) error {
+func Rmk(ro *RmkOptions) error {
 	for _, kernel := range ro.kernels {
 		for _, vm := range ro.allVMs {
 			kernelUID, err := lookup.KernelUIDForVM(vm, providers.Client)
@@ -54,7 +54,7 @@ func Rmk(ro *rmkOptions) error {
 			if kernelUID == kernel.GetUID() {
 				if ro.Force {
 					// Force-kill and remove the VM used by this kernel
-					if err := Rm(&rmOptions{
+					if err := Rm(&RmOptions{
 						&RmFlags{Force: true},
 						[]*api.VM{vm},
 					}); err != nil {

--- a/cmd/ignite/run/run.go
+++ b/cmd/ignite/run/run.go
@@ -9,30 +9,30 @@ type RunFlags struct {
 	*StartFlags
 }
 
-type runOptions struct {
-	*createOptions
-	*startOptions
+type RunOptions struct {
+	*CreateOptions
+	*StartOptions
 }
 
-func (rf *RunFlags) NewRunOptions(args []string, fs *flag.FlagSet) (*runOptions, error) {
+func (rf *RunFlags) NewRunOptions(args []string, fs *flag.FlagSet) (*RunOptions, error) {
 	co, err := rf.NewCreateOptions(args, fs)
 	if err != nil {
 		return nil, err
 	}
 
 	// TODO: We should be able to use the constructor here instead...
-	so := &startOptions{
+	so := &StartOptions{
 		StartFlags: rf.StartFlags,
-		attachOptions: &attachOptions{
+		AttachOptions: &AttachOptions{
 			checkRunning: false,
 		},
 	}
 
-	return &runOptions{co, so}, nil
+	return &RunOptions{co, so}, nil
 }
 
-func Run(ro *runOptions) error {
-	if err := Create(ro.createOptions); err != nil {
+func Run(ro *RunOptions) error {
+	if err := Create(ro.CreateOptions); err != nil {
 		return err
 	}
 
@@ -40,5 +40,5 @@ func Run(ro *runOptions) error {
 	// TODO: This is pretty bad, fix this
 	ro.vm = ro.VM
 
-	return Start(ro.startOptions)
+	return Start(ro.StartOptions)
 }

--- a/cmd/ignite/run/ssh.go
+++ b/cmd/ignite/run/ssh.go
@@ -31,20 +31,20 @@ type SSHFlags struct {
 	Tty          bool
 }
 
-type sshOptions struct {
+type SshOptions struct {
 	*SSHFlags
 	vm *api.VM
 }
 
 // NewSSHOptions returns ssh options for a given VM.
-func (sf *SSHFlags) NewSSHOptions(vmMatch string) (so *sshOptions, err error) {
-	so = &sshOptions{SSHFlags: sf}
+func (sf *SSHFlags) NewSSHOptions(vmMatch string) (so *SshOptions, err error) {
+	so = &SshOptions{SSHFlags: sf}
 	so.vm, err = getVMForMatch(vmMatch)
 	return
 }
 
 // SSH starts a ssh session as per the provided ssh options.
-func SSH(so *sshOptions) error {
+func SSH(so *SshOptions) error {
 	return runSSH(so.vm, so.IdentityFile, []string{}, so.Tty, so.Timeout)
 }
 

--- a/cmd/ignite/run/start.go
+++ b/cmd/ignite/run/start.go
@@ -22,12 +22,12 @@ type StartFlags struct {
 	IgnoredPreflightErrors []string
 }
 
-type startOptions struct {
+type StartOptions struct {
 	*StartFlags
-	*attachOptions
+	*AttachOptions
 }
 
-func (sf *StartFlags) NewStartOptions(vmMatch string) (*startOptions, error) {
+func (sf *StartFlags) NewStartOptions(vmMatch string) (*StartOptions, error) {
 	ao, err := NewAttachOptions(vmMatch)
 	if err != nil {
 		return nil, err
@@ -36,10 +36,10 @@ func (sf *StartFlags) NewStartOptions(vmMatch string) (*startOptions, error) {
 	// Disable running check as it takes a while for ignite-spawn to update the state
 	ao.checkRunning = false
 
-	return &startOptions{sf, ao}, nil
+	return &StartOptions{sf, ao}, nil
 }
 
-func Start(so *startOptions) error {
+func Start(so *StartOptions) error {
 	// Check if the given VM is already running
 	if so.vm.Running() {
 		return fmt.Errorf("VM %q is already running", so.vm.GetUID())
@@ -63,7 +63,7 @@ func Start(so *startOptions) error {
 
 	// If starting interactively, attach after starting
 	if so.Interactive {
-		return Attach(so.attachOptions)
+		return Attach(so.AttachOptions)
 	}
 	return nil
 }

--- a/cmd/ignite/run/stop.go
+++ b/cmd/ignite/run/stop.go
@@ -9,18 +9,18 @@ type StopFlags struct {
 	Kill bool
 }
 
-type stopOptions struct {
+type StopOptions struct {
 	*StopFlags
 	vms []*api.VM
 }
 
-func (sf *StopFlags) NewStopOptions(vmMatches []string) (so *stopOptions, err error) {
-	so = &stopOptions{StopFlags: sf}
+func (sf *StopFlags) NewStopOptions(vmMatches []string) (so *StopOptions, err error) {
+	so = &StopOptions{StopFlags: sf}
 	so.vms, err = getVMsForMatches(vmMatches)
 	return
 }
 
-func Stop(so *stopOptions) error {
+func Stop(so *StopOptions) error {
 	for _, vm := range so.vms {
 		// Stop the VM, and optionally kill it
 		if err := operations.StopVM(vm, so.Kill, false); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -55,12 +55,13 @@ require (
 	github.com/vishvananda/netlink v1.1.0
 	github.com/weaveworks/libgitops v0.0.0-20200611103311-2c871bbbbf0c
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
-	golang.org/x/net v0.0.0-20200707034311-ab3426394381 // indirect
+	golang.org/x/net v0.0.0-20200822124328-c89045814202 // indirect
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208 // indirect
 	golang.org/x/sys v0.0.0-20200610111108-226ff32320da
 	golang.org/x/text v0.3.3 // indirect
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	gotest.tools v2.2.0+incompatible
 	k8s.io/apimachinery v0.18.3
-	k8s.io/kube-openapi v0.0.0-20200811211545-daf3cbb84823
+	k8s.io/kube-openapi v0.0.0-20200831175022-64514a1d5d59
 	sigs.k8s.io/yaml v1.2.0
 )

--- a/go.sum
+++ b/go.sum
@@ -829,8 +829,8 @@ golang.org/x/net v0.0.0-20191004110552-13f9640d40b9/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200301022130-244492dfa37a h1:GuSPYbZzB5/dcLNCwLQLsg3obCJtX9IJhpXkvY7kzk0=
 golang.org/x/net v0.0.0-20200301022130-244492dfa37a/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/net v0.0.0-20200707034311-ab3426394381 h1:VXak5I6aEWmAXeQjA+QSZzlgNrpq9mjcfDemuexIKsU=
-golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
+golang.org/x/net v0.0.0-20200822124328-c89045814202 h1:VvcQYSHwXgi7W+TpUR6A9g6Up98WAHf3f/ulnJ62IyA=
+golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -925,6 +925,8 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gomodules.xyz/jsonpatch/v2 v2.0.1/go.mod h1:IhYNNY4jnS53ZnfE4PAmpKtDpTCj1JFXc+3mwe7XcUU=
 gonum.org/v1/gonum v0.0.0-20190331200053-3d26580ed485/go.mod h1:2ltnJ7xHfj0zHS40VVPYEAAMTa3ZGguvHGBSJeRWqE0=
 gonum.org/v1/netlib v0.0.0-20190313105609-8cb42192e0e0/go.mod h1:wa6Ws7BG/ESfp6dHfk7C6KdzKA7wR7u/rKwOGE66zvw=

--- a/vendor/golang.org/x/net/http2/transport.go
+++ b/vendor/golang.org/x/net/http2/transport.go
@@ -2525,6 +2525,7 @@ func strSliceContains(ss []string, s string) bool {
 
 type erringRoundTripper struct{ err error }
 
+func (rt erringRoundTripper) RoundTripErr() error                             { return rt.err }
 func (rt erringRoundTripper) RoundTrip(*http.Request) (*http.Response, error) { return nil, rt.err }
 
 // gzipReader wraps a response body so it can lazily

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -491,7 +491,7 @@ golang.org/x/crypto/ssh/agent
 golang.org/x/crypto/ssh/internal/bcrypt_pbkdf
 golang.org/x/crypto/ssh/knownhosts
 golang.org/x/crypto/ssh/terminal
-# golang.org/x/net v0.0.0-20200707034311-ab3426394381
+# golang.org/x/net v0.0.0-20200822124328-c89045814202
 ## explicit
 golang.org/x/net/bpf
 golang.org/x/net/context
@@ -525,6 +525,8 @@ golang.org/x/text/transform
 golang.org/x/text/unicode/bidi
 golang.org/x/text/unicode/norm
 golang.org/x/text/width
+# golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
+## explicit
 # google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55
 google.golang.org/genproto/googleapis/rpc/status
 # google.golang.org/grpc v1.27.0
@@ -617,7 +619,7 @@ k8s.io/apimachinery/third_party/forked/golang/json
 k8s.io/apimachinery/third_party/forked/golang/reflect
 # k8s.io/klog v1.0.0
 k8s.io/klog
-# k8s.io/kube-openapi v0.0.0-20200811211545-daf3cbb84823 => k8s.io/kube-openapi v0.0.0-20200121204235-bf4fb3bd569c
+# k8s.io/kube-openapi v0.0.0-20200831175022-64514a1d5d59 => k8s.io/kube-openapi v0.0.0-20200121204235-bf4fb3bd569c
 ## explicit
 k8s.io/kube-openapi/pkg/common
 k8s.io/kube-openapi/pkg/util/proto


### PR DESCRIPTION
Ignite command functions accept unexported types like `startOptions`,
`createOptions`, etc. This makes the cmd/ignite/run package unusable for
projects that import ignite.
IDEs warn about unexported return type for functions like
`NewStartOptions()`, `NewCreateOptions()`, etc.
This change makes those option types public.

