### PR TITLE
Fix starting VM with non-default providers

### DIFF
--- a/cmd/ignite/cmd/vmcmd/run.go
+++ b/cmd/ignite/cmd/vmcmd/run.go
@@ -43,7 +43,7 @@ func NewCmdRun(out io.Writer) *cobra.Command {
 					return err
 				}
 
-				return run.Run(ro)
+				return run.Run(ro, cmd.Flags())
 			}())
 		},
 	}

--- a/cmd/ignite/cmd/vmcmd/start.go
+++ b/cmd/ignite/cmd/vmcmd/start.go
@@ -33,7 +33,7 @@ func NewCmdStart(out io.Writer) *cobra.Command {
 					return err
 				}
 
-				return run.Start(so)
+				return run.Start(so, cmd.Flags())
 			}())
 		},
 	}

--- a/cmd/ignite/run/run.go
+++ b/cmd/ignite/run/run.go
@@ -31,7 +31,7 @@ func (rf *RunFlags) NewRunOptions(args []string, fs *flag.FlagSet) (*RunOptions,
 	return &RunOptions{co, so}, nil
 }
 
-func Run(ro *RunOptions) error {
+func Run(ro *RunOptions, fs *flag.FlagSet) error {
 	if err := Create(ro.CreateOptions); err != nil {
 		return err
 	}
@@ -40,5 +40,5 @@ func Run(ro *RunOptions) error {
 	// TODO: This is pretty bad, fix this
 	ro.vm = ro.VM
 
-	return Start(ro.StartOptions)
+	return Start(ro.StartOptions, fs)
 }


### PR DESCRIPTION
At VM start, check if the providers flags are set before updating the
VM status with the providers info. This ensures that the providers of a
VM are changed only when explicitly set in the start command.

Add e2e test to verify the fix.

Follow-up to #669 