### PR TITLE
Add VM name validation

### DIFF
--- a/e2e/config_test.go
+++ b/e2e/config_test.go
@@ -167,7 +167,7 @@ spec:
 				assert.NilError(t, vmConfigFile.Close())
 			}
 
-			vmName := "e2e_test_ignite_config_file"
+			vmName := "e2e-test-ignite-config-file"
 
 			igniteCmd := util.NewCommand(t, igniteBin)
 

--- a/e2e/cp_test.go
+++ b/e2e/cp_test.go
@@ -57,11 +57,11 @@ func TestCopyFileFromHostToVM(t *testing.T) {
 		content []byte
 	}{
 		{
-			name:    "file_with_content",
+			name:    "file-with-content",
 			content: []byte("some example file content"),
 		},
 		{
-			name:    "empty_file",
+			name:    "empty-file",
 			content: []byte(""),
 		},
 	}
@@ -83,7 +83,7 @@ func TestCopyFileFromHostToVM(t *testing.T) {
 				t.Errorf("failed to close file: %v", err)
 			}
 
-			vmName := "e2e_test_copy_to_vm_" + rt.name
+			vmName := "e2e-test-copy-to-vm-" + rt.name
 			runCopyFilesToVM(
 				t,
 				vmName,
@@ -119,7 +119,7 @@ func TestCopySymlinkedFileFromHostToVM(t *testing.T) {
 	}
 	defer os.Remove(newName)
 
-	vmName := "e2e_test_copy_symlink_to_vm"
+	vmName := "e2e-test-copy-symlink-to-vm"
 
 	runCopyFilesToVM(
 		t,
@@ -133,7 +133,7 @@ func TestCopySymlinkedFileFromHostToVM(t *testing.T) {
 func TestCopyFileFromVMToHost(t *testing.T) {
 	assert.Assert(t, e2eHome != "", "IGNITE_E2E_HOME should be set")
 
-	vmName := "e2e_test_copy_file_from_vm_to_host"
+	vmName := "e2e-test-copy-file-from-vm-to-host"
 
 	igniteCmd := util.NewCommand(t, igniteBin)
 
@@ -202,7 +202,7 @@ func TestCopyDirectoryFromHostToVM(t *testing.T) {
 		t.Errorf("failed to close file: %v", err)
 	}
 
-	vmName := "e2e_test_copy_dir_to_vm"
+	vmName := "e2e-test-copy-dir-to-vm"
 	source := dir
 	dest := fmt.Sprintf("%s:%s", vmName, source)
 
@@ -249,7 +249,7 @@ func TestCopyDirectoryFromHostToVM(t *testing.T) {
 func TestCopyDirectoryFromVMToHost(t *testing.T) {
 	assert.Assert(t, e2eHome != "", "IGNITE_E2E_HOME should be set")
 
-	vmName := "e2e_test_copy_dir_from_vm_to_host"
+	vmName := "e2e-test-copy-dir-from-vm-to-host"
 
 	igniteCmd := util.NewCommand(t, igniteBin)
 

--- a/e2e/run_test.go
+++ b/e2e/run_test.go
@@ -39,7 +39,7 @@ func runWithRuntimeAndNetworkPlugin(t *testing.T, vmName, runtime, networkPlugin
 func TestIgniteRunWithDockerAndDockerBridge(t *testing.T) {
 	runWithRuntimeAndNetworkPlugin(
 		t,
-		"e2e_test_ignite_run_docker_and_docker_bridge",
+		"e2e-test-ignite-run-docker-and-docker-bridge",
 		"docker",
 		"docker-bridge",
 	)
@@ -48,7 +48,7 @@ func TestIgniteRunWithDockerAndDockerBridge(t *testing.T) {
 func TestIgniteRunWithDockerAndCNI(t *testing.T) {
 	runWithRuntimeAndNetworkPlugin(
 		t,
-		"e2e_test_ignite_run_docker_and_cni",
+		"e2e-test-ignite-run-docker-and-cni",
 		"docker",
 		"cni",
 	)
@@ -57,7 +57,7 @@ func TestIgniteRunWithDockerAndCNI(t *testing.T) {
 func TestIgniteRunWithContainerdAndCNI(t *testing.T) {
 	runWithRuntimeAndNetworkPlugin(
 		t,
-		"e2e_test_ignite_run_containerd_and_cni",
+		"e2e-test-ignite-run-containerd-and-cni",
 		"containerd",
 		"cni",
 	)
@@ -91,7 +91,7 @@ func runCurl(t *testing.T, vmName, runtime, networkPlugin string) {
 func TestCurlWithDockerAndDockerBridge(t *testing.T) {
 	runCurl(
 		t,
-		"e2e_test_curl_docker_and_docker_bridge",
+		"e2e-test-curl-docker-and-docker-bridge",
 		"docker",
 		"docker-bridge",
 	)
@@ -100,7 +100,7 @@ func TestCurlWithDockerAndDockerBridge(t *testing.T) {
 func TestCurlWithDockerAndCNI(t *testing.T) {
 	runCurl(
 		t,
-		"e2e_test_curl_docker_and_cni",
+		"e2e-test-curl-docker-and-cni",
 		"docker",
 		"cni",
 	)
@@ -109,7 +109,7 @@ func TestCurlWithDockerAndCNI(t *testing.T) {
 func TestCurlWithContainerdAndCNI(t *testing.T) {
 	runCurl(
 		t,
-		"e2e_test_curl_containerd_and_cni",
+		"e2e-test-curl-containerd-and-cni",
 		"containerd",
 		"cni",
 	)

--- a/e2e/run_volume_test.go
+++ b/e2e/run_volume_test.go
@@ -98,7 +98,7 @@ func runVolume(t *testing.T, vmName, runtime, networkPlugin string) {
 		With("stop", vmName).
 		Run()
 
-	secondVMName := vmName + "_2"
+	secondVMName := vmName + "-2"
 
 	// Clean-up the following VM.
 	defer igniteCmd.New().
@@ -128,7 +128,7 @@ func TestVolumeWithDockerAndDockerBridge(t *testing.T) {
 	t.Skip("SKIPPING\nThis test fails to stop the VM within docker\nTODO: https://github.com/weaveworks/ignite/issues/658")
 	runVolume(
 		t,
-		"e2e_test_volume_docker_and_docker_bridge",
+		"e2e-test-volume-docker-and-docker-bridge",
 		"docker",
 		"docker-bridge",
 	)
@@ -137,7 +137,7 @@ func TestVolumeWithDockerAndDockerBridge(t *testing.T) {
 func TestVolumeWithDockerAndCNI(t *testing.T) {
 	runVolume(
 		t,
-		"e2e_test_volume_docker_and_cni",
+		"e2e-test-volume-docker-and-cni",
 		"docker",
 		"cni",
 	)
@@ -146,7 +146,7 @@ func TestVolumeWithDockerAndCNI(t *testing.T) {
 func TestVolumeWithContainerdAndCNI(t *testing.T) {
 	runVolume(
 		t,
-		"e2e_test_volume_containerd_and_cni",
+		"e2e-test-volume-containerd-and-cni",
 		"containerd",
 		"cni",
 	)

--- a/e2e/vm_exec_test.go
+++ b/e2e/vm_exec_test.go
@@ -13,7 +13,7 @@ import (
 func TestVMExecInteractive(t *testing.T) {
 	assert.Assert(t, e2eHome != "", "IGNITE_E2E_HOME should be set")
 
-	vmName := "e2e_test_ignite_exec_interactive"
+	vmName := "e2e-test-ignite-exec-interactive"
 
 	igniteCmd := util.NewCommand(t, igniteBin)
 

--- a/e2e/vm_lifecycle_test.go
+++ b/e2e/vm_lifecycle_test.go
@@ -59,7 +59,7 @@ func runVMLifecycle(t *testing.T, vmName, runtime, networkPlugin string) {
 func TestVMLifecycleWithDockerAndDockerBridge(t *testing.T) {
 	runVMLifecycle(
 		t,
-		"e2e_test_vm_lifecycle_docker_and_docker_bridge",
+		"e2e-test-vm-lifecycle-docker-and-docker-bridge",
 		"docker",
 		"docker-bridge",
 	)
@@ -68,7 +68,7 @@ func TestVMLifecycleWithDockerAndDockerBridge(t *testing.T) {
 func TestVMLifecycleWithDockerAndCNI(t *testing.T) {
 	runVMLifecycle(
 		t,
-		"e2e_test_vm_lifecycle_docker_and_cni",
+		"e2e-test-vm-lifecycle-docker-and-cni",
 		"docker",
 		"cni",
 	)
@@ -77,7 +77,7 @@ func TestVMLifecycleWithDockerAndCNI(t *testing.T) {
 func TestVMLifecycleWithContainerdAndCNI(t *testing.T) {
 	runVMLifecycle(
 		t,
-		"e2e_test_vm_lifecycle_containerd_and_cni",
+		"e2e-test-vm-lifecycle-containerd-and-cni",
 		"containerd",
 		"cni",
 	)
@@ -88,7 +88,7 @@ func TestVMLifecycleWithContainerdAndCNI(t *testing.T) {
 func TestVMProviderSwitch(t *testing.T) {
 	assert.Assert(t, e2eHome != "", "IGNITE_E2E_HOME should be set")
 
-	vmName := "e2e_test_vm_providers_switch"
+	vmName := "e2e-test-vm-providers-switch"
 
 	igniteCmd := util.NewCommand(t, igniteBin)
 


### PR DESCRIPTION
Adds VM name validation using IsDNS1123Subdomain from k8s api-machinery
validator package.

Updates all the e2e tests to replace "_" in the VM names with "-". Underscore
in the name is not a valid DNS subdomain name.

```console
$ sudo ./bin/ignite create weaveworks/ignite-ubuntu --name my_vm
FATA[0000] metadata.name: Invalid value: "my_vm": a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
```

Fixes #622 