### PR TITLE
Add build-binaries github action

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -1,0 +1,42 @@
+name: Build binaries
+
+on:
+  workflow_dispatch:
+    # Enable manual trigger of this action.
+    inputs:
+      GOARCH:
+        description: GOARCH build environment variable.
+        default: amd64
+        required: true
+      repository:
+        description: Git repository to checkout for building.
+        default: weaveworks/ignite
+        required: true
+      ref:
+        description: Git branch, tag or SHA to checkout.
+        default: master
+        required: true
+
+env:
+  GOARCH: ${{ github.event.inputs.GOARCH }}
+
+jobs:
+  build-binaries:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          repository: ${{ github.event.inputs.repository }}
+          ref: ${{ github.event.inputs.ref }}
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.14.2'
+      - name: Build binaries for ${{ env.GOARCH }}
+        run: make ignite ignite-spawn ignited bin/${{ env.GOARCH }}/Dockerfile GO_MAKE_TARGET=local GOARCH=${{ env.GOARCH }}
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ${{ env.GOARCH }} binaries
+          path: |
+            bin/${{ env.GOARCH }}/ignite
+            bin/${{ env.GOARCH }}/ignited
+            bin/${{ env.GOARCH }}/ignite-spawn


### PR DESCRIPTION
Build binaries action is a manually triggered action with parameters
GOARCH, repository and ref as inputs to build ignite binaries and upload
them as actions artifacts.
It is a developer automation action to easily build the binaries for
testing purposes.

Tested the action in a fork for building arm64 binaries and manually verified
that the binaries work on raspberry-pi (arm64).
Refer: https://github.com/darkowlzz/ignite/actions/runs/273081585 