### PR TITLE
Fix VM name generation when not specified 

### DIFF
--- a/cmd/ignite/run/create.go
+++ b/cmd/ignite/run/create.go
@@ -77,6 +77,11 @@ func (cf *CreateFlags) NewCreateOptions(args []string, fs *flag.FlagSet) (*Creat
 		baseVM.Spec.Image.OCI = ociRef
 	}
 
+	// Generate a VM name and UID if not set yet.
+	if err := metadata.SetNameAndUID(baseVM, providers.Client); err != nil {
+		return nil, err
+	}
+
 	// Apply the VM config on the base VM, if a VM config is given.
 	if len(cf.ConfigFile) != 0 {
 		if err := applyVMConfigFile(baseVM, cf.ConfigFile); err != nil {


### PR DESCRIPTION
Call `SetNameAndUID()` before Validating the VM config in
`NewCreateOptions()`.

Add e2e test to check VM name generation.