### PR TITLE
Add OS image release workflow

### DIFF
--- a/.github/workflows/release-os-images.yml
+++ b/.github/workflows/release-os-images.yml
@@ -1,0 +1,158 @@
+name: Release OS images
+
+on:
+  workflow_dispatch:
+    # Enable manual trigger of this action.
+    inputs:
+      user:
+        description: Container registry user.
+        default: weaveworks
+        required: true
+
+env:
+  DOCKER_USER: ${{ github.event.inputs.user }}
+
+jobs:
+  ubuntu:
+    runs-on: ubuntu-latest
+    env:
+      WHAT: ubuntu
+      IS_MANIFEST_LIST: 1
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to container registry
+        uses: docker/login-action@v1
+        with:
+          registry: docker.io
+          username: ${{ secrets.CR_USER }}
+          password: ${{ secrets.CR_PAT }}
+      - name: Build ubuntu 18.04 amd64 image
+        env:
+          GOARCH: amd64
+          RELEASE: 18.04
+        run: cd images && make build
+      - name: Build ubuntu 18.04 arm64 image
+        env:
+          GOARCH: arm64
+          RELEASE: 18.04
+        run: cd images && make build
+      - name: Update manifest list for ubuntu 18.04
+        env:
+          RELEASE: 18.04
+        run: cd images && make push
+      - name: Build ubuntu 20.04 amd64 image
+        env:
+          GOARCH: amd64
+          RELEASE: 20.04
+        run: cd images && make build
+      - name: Build ubuntu 20.04 arm64 image
+        env:
+          GOARCH: arm64
+          RELEASE: 20.04
+        run: cd images && make build
+      - name: Update manifest list for ubuntu 20.04
+        env:
+          RELEASE: 20.04
+        run: cd images && make push
+
+  centos:
+    runs-on: ubuntu-latest
+    env:
+      WHAT: centos
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to container registry
+        uses: docker/login-action@v1
+        with:
+          registry: docker.io
+          username: ${{ secrets.CR_USER }}
+          password: ${{ secrets.CR_PAT }}
+      - name: Build and push centos 7 image
+        env:
+          RELEASE: 7
+        run: cd images && make build && make push
+      - name: Build and push centos 8 image
+        env:
+          RELEASE: 8
+        run: cd images && make build && make push
+
+  amazonlinux:
+    runs-on: ubuntu-latest
+    env:
+      WHAT: amazonlinux
+      RELEASE: 2
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to container registry
+        uses: docker/login-action@v1
+        with:
+          registry: docker.io
+          username: ${{ secrets.CR_USER }}
+          password: ${{ secrets.CR_PAT }}
+      - name: Build image
+        run: cd images && make build && make push
+
+  opensuse:
+    runs-on: ubuntu-latest
+    env:
+      WHAT: opensuse
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to container registry
+        uses: docker/login-action@v1
+        with:
+          registry: docker.io
+          username: ${{ secrets.CR_USER }}
+          password: ${{ secrets.CR_PAT }}
+      - name: Build opensuse leap image
+        env:
+          RELEASE: leap
+        run: cd images && make build && make push
+      - name: Build opensuse tumbleweed image
+        env:
+          RELEASE: tumbleweed
+        run: cd images && make build && make push
+
+  kubeadm:
+    runs-on: ubuntu-latest
+    env:
+      WHAT: kubeadm
+      IS_MANIFEST_LIST: 1
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to container registry
+        uses: docker/login-action@v1
+        with:
+          registry: docker.io
+          username: ${{ secrets.CR_USER }}
+          password: ${{ secrets.CR_PAT }}
+      - name: Build kubeadm v1.18.3 amd64 image
+        env:
+          GOARCH: amd64
+          RELEASE: v1.18.3
+        run: cd images && make build
+      - name: Build kubeadm v1.18.3 arm64 image
+        env:
+          GOARCH: arm64
+          RELEASE: v1.18.3
+        run: cd images && make build
+      - name: Update manifest list for kubeadm v1.18.3
+        env:
+          RELEASE: v1.18.3
+        run: cd images && make push
+
+  # aline:
+  #   runs-on: ubuntu-latest
+  #   env:
+  #     WHAT: alpine
+  #     RELEASE: latest
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Login to container registry
+  #       uses: docker/login-action@v1
+  #         with:
+  #         registry: docker.io
+  #         username: ${{ secrets.CR_USER }}
+  #         password: ${{ secrets.CR_PAT }}
+  #     - name: Build image
+  #       run: cd images && make build

--- a/.github/workflows/release-os-images.yml
+++ b/.github/workflows/release-os-images.yml
@@ -8,16 +8,24 @@ on:
         description: Container registry user.
         default: weaveworks
         required: true
+      version:
+        description: ignite version used for image tags.
+        required: true
 
 env:
   DOCKER_USER: ${{ github.event.inputs.user }}
+  VERSION: ${{ github.event.inputs.version }}
+
+defaults:
+  run:
+    working-directory: images
 
 jobs:
-  ubuntu:
+  image-build-push:
     runs-on: ubuntu-latest
-    env:
-      WHAT: ubuntu
-      IS_MANIFEST_LIST: 1
+    strategy:
+      matrix:
+        what: [alpine, amazon-kernel, amazonlinux, centos, kubeadm, opensuse, ubuntu]
     steps:
       - uses: actions/checkout@v2
       - name: Login to container registry
@@ -26,133 +34,5 @@ jobs:
           registry: docker.io
           username: ${{ secrets.CR_USER }}
           password: ${{ secrets.CR_PAT }}
-      - name: Build ubuntu 18.04 amd64 image
-        env:
-          GOARCH: amd64
-          RELEASE: 18.04
-        run: cd images && make build
-      - name: Build ubuntu 18.04 arm64 image
-        env:
-          GOARCH: arm64
-          RELEASE: 18.04
-        run: cd images && make build
-      - name: Update manifest list for ubuntu 18.04
-        env:
-          RELEASE: 18.04
-        run: cd images && make push
-      - name: Build ubuntu 20.04 amd64 image
-        env:
-          GOARCH: amd64
-          RELEASE: 20.04
-        run: cd images && make build
-      - name: Build ubuntu 20.04 arm64 image
-        env:
-          GOARCH: arm64
-          RELEASE: 20.04
-        run: cd images && make build
-      - name: Update manifest list for ubuntu 20.04
-        env:
-          RELEASE: 20.04
-        run: cd images && make push
-
-  centos:
-    runs-on: ubuntu-latest
-    env:
-      WHAT: centos
-    steps:
-      - uses: actions/checkout@v2
-      - name: Login to container registry
-        uses: docker/login-action@v1
-        with:
-          registry: docker.io
-          username: ${{ secrets.CR_USER }}
-          password: ${{ secrets.CR_PAT }}
-      - name: Build and push centos 7 image
-        env:
-          RELEASE: 7
-        run: cd images && make build && make push
-      - name: Build and push centos 8 image
-        env:
-          RELEASE: 8
-        run: cd images && make build && make push
-
-  amazonlinux:
-    runs-on: ubuntu-latest
-    env:
-      WHAT: amazonlinux
-      RELEASE: 2
-    steps:
-      - uses: actions/checkout@v2
-      - name: Login to container registry
-        uses: docker/login-action@v1
-        with:
-          registry: docker.io
-          username: ${{ secrets.CR_USER }}
-          password: ${{ secrets.CR_PAT }}
-      - name: Build image
-        run: cd images && make build && make push
-
-  opensuse:
-    runs-on: ubuntu-latest
-    env:
-      WHAT: opensuse
-    steps:
-      - uses: actions/checkout@v2
-      - name: Login to container registry
-        uses: docker/login-action@v1
-        with:
-          registry: docker.io
-          username: ${{ secrets.CR_USER }}
-          password: ${{ secrets.CR_PAT }}
-      - name: Build opensuse leap image
-        env:
-          RELEASE: leap
-        run: cd images && make build && make push
-      - name: Build opensuse tumbleweed image
-        env:
-          RELEASE: tumbleweed
-        run: cd images && make build && make push
-
-  kubeadm:
-    runs-on: ubuntu-latest
-    env:
-      WHAT: kubeadm
-      IS_MANIFEST_LIST: 1
-    steps:
-      - uses: actions/checkout@v2
-      - name: Login to container registry
-        uses: docker/login-action@v1
-        with:
-          registry: docker.io
-          username: ${{ secrets.CR_USER }}
-          password: ${{ secrets.CR_PAT }}
-      - name: Build kubeadm v1.18.3 amd64 image
-        env:
-          GOARCH: amd64
-          RELEASE: v1.18.3
-        run: cd images && make build
-      - name: Build kubeadm v1.18.3 arm64 image
-        env:
-          GOARCH: arm64
-          RELEASE: v1.18.3
-        run: cd images && make build
-      - name: Update manifest list for kubeadm v1.18.3
-        env:
-          RELEASE: v1.18.3
-        run: cd images && make push
-
-  # aline:
-  #   runs-on: ubuntu-latest
-  #   env:
-  #     WHAT: alpine
-  #     RELEASE: latest
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Login to container registry
-  #       uses: docker/login-action@v1
-  #         with:
-  #         registry: docker.io
-  #         username: ${{ secrets.CR_USER }}
-  #         password: ${{ secrets.CR_PAT }}
-  #     - name: Build image
-  #       run: cd images && make build
+      - run: make OP=build build-${{ matrix.what }}
+      - run: make OP=push build-${{ matrix.what }}

--- a/images/Makefile
+++ b/images/Makefile
@@ -141,18 +141,37 @@ push-all: build-all
 	$(MAKE) OP=push build-all
 
 
-build-all:
-	$(MAKE) ${OP} WHAT=amazon-kernel
-	$(MAKE) ${OP} WHAT=amazonlinux    RELEASE=2                                        IS_LATEST=true
+build-all: build-alpine build-amazon-kernel build-amazonlinux build-centos build-kubeadm build-opensuse build-ubuntu
+
+build-alpine:
+ifeq ($(OP),build)
+	pushd alpine; \
+		${MAKE} alpine.tar; \
+	popd;
+endif
 	$(MAKE) ${OP} WHAT=alpine
+
+build-amazon-kernel:
+	$(MAKE) ${OP} WHAT=amazon-kernel
+
+build-amazonlinux:
+	$(MAKE) ${OP} WHAT=amazonlinux    RELEASE=2                                        IS_LATEST=true
+
+build-centos:
+	$(MAKE) ${OP} WHAT=centos         RELEASE=7
+	$(MAKE) ${OP} WHAT=centos         RELEASE=8                                        IS_LATEST=true
+
+build-kubeadm:
+	$(MAKE) ${OP} WHAT=kubeadm        RELEASE=v1.18.3  BINARY_REF=release/stable-1.18  IS_LATEST=true  IS_MANIFEST_LIST=1  GOARCH=arm64
+	$(MAKE) ${OP} WHAT=kubeadm        RELEASE=v1.18.3  BINARY_REF=release/stable-1.18  IS_LATEST=true  IS_MANIFEST_LIST=1  GOARCH=amd64
+
+build-opensuse:
 	$(MAKE) ${OP} WHAT=opensuse       RELEASE=leap                                     IS_LATEST=true
 	$(MAKE) ${OP} WHAT=opensuse       RELEASE=tumbleweed
+
+build-ubuntu:
 	$(MAKE) ${OP} WHAT=ubuntu         RELEASE=16.04                                                    IS_MANIFEST_LIST=0
 	$(MAKE) ${OP} WHAT=ubuntu         RELEASE=18.04                                                    IS_MANIFEST_LIST=1  GOARCH=arm64
 	$(MAKE) ${OP} WHAT=ubuntu         RELEASE=18.04                                                    IS_MANIFEST_LIST=1  GOARCH=amd64
 	$(MAKE) ${OP} WHAT=ubuntu         RELEASE=20.04                                    IS_LATEST=true  IS_MANIFEST_LIST=1  GOARCH=arm64
 	$(MAKE) ${OP} WHAT=ubuntu         RELEASE=20.04                                    IS_LATEST=true  IS_MANIFEST_LIST=1  GOARCH=amd64
-	$(MAKE) ${OP} WHAT=centos         RELEASE=7
-	$(MAKE) ${OP} WHAT=centos         RELEASE=8                                        IS_LATEST=true
-	$(MAKE) ${OP} WHAT=kubeadm        RELEASE=v1.18.3  BINARY_REF=release/stable-1.18  IS_LATEST=true  IS_MANIFEST_LIST=1  GOARCH=arm64
-	$(MAKE) ${OP} WHAT=kubeadm        RELEASE=v1.18.3  BINARY_REF=release/stable-1.18  IS_LATEST=true  IS_MANIFEST_LIST=1  GOARCH=amd64


### PR DESCRIPTION
This workflow can be used to build all the OS images in parallel and
publish them together.

Duplicate configurations due to lack of YAML anchors support in github actions, refer: https://github.community/t/support-for-yaml-anchors/16128/39