### PR TITLE
workflow: Upload release assets

### DIFF
--- a/.github/workflows/upload-release-assets.yml
+++ b/.github/workflows/upload-release-assets.yml
@@ -8,12 +8,14 @@ on:
         description: Git tag to checkout.
         required: true
 
+env:
+  DOCKER_TTY: ""  # using `docker run -t` seems to not work in github actions, maybe related to https://github.com/actions/runner/issues/241
+  REL_TAG: ${{ github.event.inputs.tag }}
+
 jobs:
   build-and-upload:
     runs-on: ubuntu-latest
     steps:
-      - name: Set tag name env var.
-        run: echo "REL_TAG=${{ github.event.inputs.tag }}" >> $GITHUB_ENV
       - uses: actions/checkout@v2
         with:
           ref: ${{ env.REL_TAG }}

--- a/.github/workflows/upload-release-assets.yml
+++ b/.github/workflows/upload-release-assets.yml
@@ -1,0 +1,42 @@
+name: Upload release assets
+
+on:
+  workflow_dispatch:
+    # Enable manual trigger of this action.
+    inputs:
+      tag:
+        description: Git tag to checkout.
+        required: true
+
+jobs:
+  build-and-upload:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set tag name env var.
+        run: echo "REL_TAG=${{ github.event.inputs.tag }}" >> $GITHUB_ENV
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ env.REL_TAG }}
+      - name: Login to container registry
+        uses: docker/login-action@v1
+        with:
+          registry: docker.io
+          username: ${{ secrets.CR_USER }}
+          password: ${{ secrets.CR_PAT }}
+      - name: Build binaries and push sandbox image
+        run: make release
+      - name: Prepare assets
+        run: |
+          mkdir -p release
+          cp bin/releases/${{ env.REL_TAG }}/amd64/ignite release/ignite-amd64
+          cp bin/releases/${{ env.REL_TAG }}/amd64/ignited release/ignited-amd64
+          cp bin/releases/${{ env.REL_TAG }}/arm64/ignite release/ignite-arm64
+          cp bin/releases/${{ env.REL_TAG }}/arm64/ignited release/ignited-arm64
+      - name: Upload assets
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ env.REL_TAG }}
+          file_glob: true
+          file: release/*
+          overwrite: true

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,11 @@ endif
 
 SHELL:=/bin/bash
 # Set the command for running `docker`
-# -- allows user to override for things like sudo usage or container images 
+# -- allows user to override for things like sudo usage or container images
 DOCKER := docker
+# DOCKER_TTY defaults for a nice docker buildkit tty experience on dev laptops -- can be disabled in CI if no tty available
+DOCKER_TTY ?= -t
+
 # Set the first containerd.sock that successfully stats -- fallback to the docker4mac default
 CONTAINERD_SOCK := $(shell \
 	$(DOCKER) run -i --rm \
@@ -99,7 +102,7 @@ local: # Do not use directly -- use $(GO_MAKE_TARGET)
 	$(COMMAND)
 go-in-docker: # Do not use directly -- use $(GO_MAKE_TARGET)
 	mkdir -p $(CACHE_DIR)/go $(CACHE_DIR)/cache
-	$(DOCKER) run -it --rm \
+	$(DOCKER) run -i $(DOCKER_TTY) --rm \
 		-v $(CACHE_DIR)/go:/go \
 		-v $(CACHE_DIR)/cache:/.cache/go-build \
 		-v $(shell pwd):/go/src/${PROJECT} \
@@ -208,7 +211,7 @@ api-doc:
 	mv bin/tmp/${GROUPVERSION}/*.go $(shell pwd)/pkg/apis/${GROUPVERSION}/
 	rm -r bin/tmp/${GROUPVERSION}
 	# Format the docs with pandoc
-	$(DOCKER) run -it --rm \
+	$(DOCKER) run -i $(DOCKER_TTY) --rm \
 		-v $(shell pwd):/data \
 		-u $(shell id -u):$(shell id -g) \
 		pandoc/core:2.10 `# TODO: let's try bumping this image tag in 2021` \

--- a/hack/release-common.sh
+++ b/hack/release-common.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
 
+DOCKER_TTY="${DOCKER_TTY:+"-t"}"
+
 if [[ ! -f bin/gren_token ]]; then
     echo "File bin/gren_token is needed; should contain a Github token with repo access"
     exit 1
 fi
 
 run_gren() {
-    docker run -it \
+    docker run -i ${DOCKER_TTY} \
         -v $(pwd):/data \
         -w /data \
         -u $(id -u):$(id -g) \

--- a/images/kernel/upgrade-config.sh
+++ b/images/kernel/upgrade-config.sh
@@ -2,6 +2,8 @@
 
 KERNEL_BUILDER_IMAGE=luxas/kernel-builder:gcc-7
 
+DOCKER_TTY="${DOCKER_TTY:+"-t"}"
+
 if [[ $# != 2 ]]; then
     echo "Usage: $0 [FROM] [TO]"
     exit 1
@@ -22,7 +24,7 @@ if [[ ${FROM} != ${TO} ]]; then
 fi
 
 docker pull ${KERNEL_BUILDER_IMAGE}
-docker run -it \
+docker run -i ${DOCKER_TTY} \
     ${ARCH_PARAMETER} \
 	-v $(pwd)/${TO}:/tmp/.config \
     ${KERNEL_BUILDER_IMAGE} /bin/bash -c "\


### PR DESCRIPTION
Adds a workflow for automating the ignite and ignited binary releases.
This builds the binaries with `make release` at a given tag and uploads
them to a given tagged release. The release make target also builds the
sandbox image and publishes it automatically with manifest list.

This is a manual workflow, to be run after a release tag is created. Since
the existing release tool creates a temporary tag and removed it, this workflow
is intended to be run manually after running the release tools, once the final
tag is created. The only input is the release tag to checkout and update with
the release assets.

It uses https://github.com/svenstaro/upload-release-action for uploading the
assets, instead of the official github action https://github.com/actions/upload-release-asset
due to the limitations in uploading multiple files and lack of maintenance.

NOTE: Running `make release` fails in github actions environment due to
running docker run with `-it` option:
```
the input device is not a TTY
```

For this workflow to work, docker should be run without that option. This is
not change in this PR yet.

Tested this on a fork https://github.com/darkowlzz/ignite/runs/1302989230?check_suite_focus=true 
without docker run in interactive mode. The binaries were automatically posted
https://github.com/darkowlzz/ignite/releases/tag/v0.98.0 .