### PR TITLE
Add kernel image release workflow

### DIFF
--- a/.github/workflows/release-kernel-images.yml
+++ b/.github/workflows/release-kernel-images.yml
@@ -1,0 +1,92 @@
+name: Release kernel images
+
+on:
+  workflow_dispatch:
+    # Enable manual trigger of this action.
+    inputs:
+      kernel1:
+        description: Kernel 1 version.
+        default: 4.14.182
+        required: true
+      kernel2:
+        description: Kernel 2 version.
+        default: 4.19.125
+        required: true
+      kernel3:
+        description: Kernel 3 version.
+        default: 5.4.43
+        required: true
+
+defaults:
+  run:
+    working-directory: images/kernel
+
+jobs:
+  kernel1:
+    runs-on: ubuntu-latest
+    env:
+      KERNEL_VERSIONS: ${{ github.event.inputs.kernel1 }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to container registry
+        uses: docker/login-action@v1
+        with:
+          registry: docker.io
+          username: ${{ secrets.CR_USER }}
+          password: ${{ secrets.CR_PAT }}
+      - name: Build kernel for amd64
+        env:
+          GOARCH: amd64
+        run: make
+      - name: Build kernel for arm64
+        env:
+          GOARCH: arm64
+        run: make
+      - name: Push images
+        run: make push
+
+  kernel2:
+    runs-on: ubuntu-latest
+    env:
+      KERNEL_VERSIONS: ${{ github.event.inputs.kernel2 }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to container registry
+        uses: docker/login-action@v1
+        with:
+          registry: docker.io
+          username: ${{ secrets.CR_USER }}
+          password: ${{ secrets.CR_PAT }}
+      - name: Build kernel for amd64
+        env:
+          GOARCH: amd64
+        run: make
+      - name: Build kernel for arm64
+        env:
+          GOARCH: arm64
+        run: make
+      - name: Push images
+        run: make push
+
+  kernel3:
+    runs-on: ubuntu-latest
+    env:
+      KERNEL_VERSIONS: ${{ github.event.inputs.kernel3 }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to container registry
+        uses: docker/login-action@v1
+        with:
+          registry: docker.io
+          username: ${{ secrets.CR_USER }}
+          password: ${{ secrets.CR_PAT }}
+      - name: Build kernel for amd64
+        env:
+          GOARCH: amd64
+        run: make
+      - name: Build kernel for arm64
+        env:
+          GOARCH: arm64
+        run: make
+      - name: Push images
+        run: make push

--- a/.github/workflows/release-kernel-images.yml
+++ b/.github/workflows/release-kernel-images.yml
@@ -2,30 +2,19 @@ name: Release kernel images
 
 on:
   workflow_dispatch:
-    # Enable manual trigger of this action.
-    inputs:
-      kernel1:
-        description: Kernel 1 version.
-        default: 4.14.182
-        required: true
-      kernel2:
-        description: Kernel 2 version.
-        default: 4.19.125
-        required: true
-      kernel3:
-        description: Kernel 3 version.
-        default: 5.4.43
-        required: true
 
 defaults:
   run:
     working-directory: images/kernel
 
 jobs:
-  kernel1:
+  kernel:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version: [ 4.14.182, 4.19.125, 5.4.43 ]
     env:
-      KERNEL_VERSIONS: ${{ github.event.inputs.kernel1 }}
+      KERNEL_VERSIONS: ${{ matrix.version }}
     steps:
       - uses: actions/checkout@v2
       - name: Login to container registry
@@ -34,59 +23,10 @@ jobs:
           registry: docker.io
           username: ${{ secrets.CR_USER }}
           password: ${{ secrets.CR_PAT }}
-      - name: Build kernel for amd64
+      - run: make
         env:
           GOARCH: amd64
-        run: make
-      - name: Build kernel for arm64
+      - run: make
         env:
           GOARCH: arm64
-        run: make
-      - name: Push images
-        run: make push
-
-  kernel2:
-    runs-on: ubuntu-latest
-    env:
-      KERNEL_VERSIONS: ${{ github.event.inputs.kernel2 }}
-    steps:
-      - uses: actions/checkout@v2
-      - name: Login to container registry
-        uses: docker/login-action@v1
-        with:
-          registry: docker.io
-          username: ${{ secrets.CR_USER }}
-          password: ${{ secrets.CR_PAT }}
-      - name: Build kernel for amd64
-        env:
-          GOARCH: amd64
-        run: make
-      - name: Build kernel for arm64
-        env:
-          GOARCH: arm64
-        run: make
-      - name: Push images
-        run: make push
-
-  kernel3:
-    runs-on: ubuntu-latest
-    env:
-      KERNEL_VERSIONS: ${{ github.event.inputs.kernel3 }}
-    steps:
-      - uses: actions/checkout@v2
-      - name: Login to container registry
-        uses: docker/login-action@v1
-        with:
-          registry: docker.io
-          username: ${{ secrets.CR_USER }}
-          password: ${{ secrets.CR_PAT }}
-      - name: Build kernel for amd64
-        env:
-          GOARCH: amd64
-        run: make
-      - name: Build kernel for arm64
-        env:
-          GOARCH: arm64
-        run: make
-      - name: Push images
-        run: make push
+      - run: make push

--- a/images/kernel/Makefile
+++ b/images/kernel/Makefile
@@ -25,10 +25,10 @@ CTR := $(DOCKER) run -i --rm \
 		linuxkit/containerd:751de142273e1b5d2d247d2832d654ab92e907bc \
 		ctr
 
-# Check https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/refs/ for updates
 REGISTRY?=weaveworks
 IMAGE_NAME?=${REGISTRY}/ignite-kernel
-KERNEL_VERSIONS ?= 4.14.182 4.19.125 5.4.43
+# Check https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/refs/ for updates
+KERNEL_VERSIONS ?= 4.14.182 4.19.125 5.4.43  # If you update this, please keep the .github/workflows/release-kernel-images.yml matrix up to date
 GOARCH?=amd64
 GOARCH_LIST = amd64 arm64
 


### PR DESCRIPTION
This adds a new workflow for building and releasing kernel images.
It builds different versions of kernels in different jobs. Different
kernel arch are build in the same job and pushed together to the
container registry. Once pushed, the manifest list is also updated for
the pushed images.

Tested this on a fork https://github.com/darkowlzz/ignite/runs/1315667990?check_suite_focus=true. Took about an hour to build everything and publish.
The images were pushed to https://github.com/users/darkowlzz/packages/container/package/ignite-kernel
Manually tested the kernel image with a VM to ensure it works.