### PR TITLE
workflow/release-os-images: Disable fail-fast

### DIFF
--- a/.github/workflows/release-os-images.yml
+++ b/.github/workflows/release-os-images.yml
@@ -24,6 +24,7 @@ jobs:
   image-build-push:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         what: [alpine, amazon-kernel, amazonlinux, centos, kubeadm, opensuse, ubuntu]
     steps:


### PR DESCRIPTION
Disable fail-fast while building OS images. Let the build continue even
if a few fails.