### PR TITLE
Fix vm stop-start with default providers

### DIFF
--- a/cmd/ignite/run/start.go
+++ b/cmd/ignite/run/start.go
@@ -49,6 +49,15 @@ func Start(so *StartOptions, fs *flag.FlagSet) error {
 		return fmt.Errorf("VM %q is already running", so.vm.GetUID())
 	}
 
+	// Stopped VMs don't contain the runtime and network information. Set the
+	// default runtime and network from the providers if empty.
+	if so.vm.Status.Runtime.Name == "" {
+		so.vm.Status.Runtime.Name = providers.RuntimeName
+	}
+	if so.vm.Status.Network.Plugin == "" {
+		so.vm.Status.Network.Plugin = providers.NetworkPluginName
+	}
+
 	// In case the runtime and network-plugin are specified explicitly at
 	// start, set the runtime and network-plugin on the VM. This overrides the
 	// global config and config on the VM object, if any.

--- a/e2e/vm_lifecycle_test.go
+++ b/e2e/vm_lifecycle_test.go
@@ -171,3 +171,33 @@ func TestVMStartNonDefaultProvider(t *testing.T) {
 	gotInspect := strings.TrimSpace(string(inspectOut))
 	assert.Equal(t, gotInspect, wantInspect, fmt.Sprintf("unexpected VM properties:\n\t(WNT): %q\n\t(GOT): %q", wantInspect, gotInspect))
 }
+
+func TestVMStopStartDefaultProviders(t *testing.T) {
+	assert.Assert(t, e2eHome != "", "IGNITE_E2E_HOME should be set")
+
+	vmName := "e2e-test-vm-stop-start-default-providers"
+
+	igniteCmd := util.NewCommand(t, igniteBin)
+
+	// Clean-up the following VM.
+	defer igniteCmd.New().
+		With("rm", "-f", vmName).
+		Run()
+
+	// Run the VM.
+	igniteCmd.New().
+		With("run").
+		With(util.DefaultVMImage).
+		With("--name=" + vmName).
+		Run()
+
+	// Stop the VM.
+	igniteCmd.New().
+		With("stop", vmName).
+		Run()
+
+	// Start the VM.
+	igniteCmd.New().
+		With("start", vmName).
+		Run()
+}


### PR DESCRIPTION
When a running VM is stopped, the runtime and network info are removed
from the VM object status. Starting the VM without any explicit provider
flags fails due to lack of provider info.

```
$ sudo ./bin/ignite run weaveworks/ignite-ubuntu --name my-vm --ssh
...
INFO[0019] Started Firecracker VM "97eddf8562c22d03" in a container with ID "ignite-97eddf8562c22d03"
INFO[0020] Waiting for the ssh daemon within the VM to start...
$ sudo ./bin/ignite stop my-vm
INFO[0000] Removing the container with ID "ignite-97eddf8562c22d03" from the "cni" network
INFO[0001] Stopped VM with name "my-vm" and ID "97eddf8562c22d03"
$ sudo ./bin/ignite start my-vm
FATA[0000] unknown runtime ""
```

This change adds the default providers in the VM status if the runtime
and network are empty when attempting to start the VM. Any explicitly
passed provider flags continue to override the VM providers.

Also, adds an e2e test to verify the fix.