### PR TITLE
Fix MASTER_IP definition in kubeadm README

### DIFF
--- a/images/kubeadm/README.md
+++ b/images/kubeadm/README.md
@@ -29,7 +29,7 @@ ignite run weaveworks/ignite-kubeadm:latest \
     --name master-0
 
 # Get the IP address of the initial master, for the kubeadm join command below
-export MASTER_IP=$($ignite inspect vm master-0 | jq -r ".status.ipAddresses[0]")
+export MASTER_IP=$(ignite inspect vm master-0 | jq -r ".status.network.ipAddresses[0]")
 ```
 
 Initialize it with `kubeadm` using `ignite exec`:


### PR DESCRIPTION
Resolves #740. Tested by spawning a VM with name `master-0`, running the command, and reading `$MASTER_IP`.

```bash
ignite run ... --name master-0
export MASTER_IP=$(ignite inspect vm master-0 | jq -r ".status.network.ipAddresses[0]")
echo $MASTER_IP # Prints a valid IP address.
```