### PR TITLE
Show output in test to aid debugging

### DIFF
--- a/e2e/util/command.go
+++ b/e2e/util/command.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"testing"
 
@@ -64,6 +65,13 @@ func (c *Command) WithNetwork(arg string) *Command {
 // Dir sets the command execution directory.
 func (c *Command) Dir(path string) *Command {
 	c.Cmd.Dir = path
+	return c
+}
+
+// PassThrough makes output from the command go to the same place as this process.
+func (c *Command) PassThrough() *Command {
+	c.Cmd.Stderr = os.Stderr
+	c.Cmd.Stdout = os.Stdout
 	return c
 }
 

--- a/e2e/zconcurrent_vm_test.go
+++ b/e2e/zconcurrent_vm_test.go
@@ -24,6 +24,7 @@ func TestConcurrentVMCreation(t *testing.T) {
 		cmds = append(
 			cmds,
 			util.NewCommand(t, igniteBin).
+				PassThrough().
 				With("run").
 				With("--name="+name).
 				With("--ssh").


### PR DESCRIPTION
Otherwise when it fails we just get something like `exit status 1`
