### PR TITLE
Refactor: extract TarExtract function

### DIFF
--- a/pkg/dm/device.go
+++ b/pkg/dm/device.go
@@ -2,7 +2,6 @@ package dm
 
 import (
 	"fmt"
-	"os/exec"
 	"path"
 
 	log "github.com/sirupsen/logrus"
@@ -145,22 +144,8 @@ func (d *Device) Import(src source.Source) (*util.MountPoint, error) {
 		return nil, err
 	}
 
-	tarCmd := exec.Command("tar", "-x", "-C", mountPoint.Path)
-	reader, err := src.Reader()
+	err = source.TarExtract(src, mountPoint.Path)
 	if err != nil {
-		return nil, err
-	}
-
-	tarCmd.Stdin = reader
-	if err := tarCmd.Start(); err != nil {
-		return nil, err
-	}
-
-	if err := tarCmd.Wait(); err != nil {
-		return nil, err
-	}
-
-	if err := src.Cleanup(); err != nil {
 		return nil, err
 	}
 

--- a/pkg/dmlegacy/image_format.go
+++ b/pkg/dmlegacy/image_format.go
@@ -4,14 +4,12 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"unicode"
 
-	containerderr "github.com/containerd/containerd/errdefs"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	api "github.com/weaveworks/ignite/pkg/apis/ignite"
@@ -87,26 +85,9 @@ func addFiles(img *api.Image, src source.Source) (err error) {
 		return execErr
 	})
 
-	tarCmd := exec.Command("tar", "-x", "-C", tempDir)
-	reader, err := src.Reader()
+	err = source.TarExtract(src, tempDir)
 	if err != nil {
 		return
-	}
-
-	tarCmd.Stdin = reader
-	if err = tarCmd.Start(); err != nil {
-		return
-	}
-
-	if err = tarCmd.Wait(); err != nil {
-		return
-	}
-
-	if err = src.Cleanup(); err != nil {
-		// Ignore the cleanup error if the resource no longer exists.
-		if !errors.Is(err, containerderr.ErrNotFound) {
-			return
-		}
 	}
 
 	err = setupResolvConf(tempDir)

--- a/pkg/source/tar.go
+++ b/pkg/source/tar.go
@@ -1,0 +1,35 @@
+package source
+
+import (
+	"os/exec"
+
+	containerderr "github.com/containerd/containerd/errdefs"
+)
+
+// TarExtract extracts all files from a source to a directory
+func TarExtract(src Source, dir string, args ...string) error {
+	args = append([]string{"-x", "-C", dir}, args...)
+	tarCmd := exec.Command("tar", args...)
+	reader, err := src.Reader()
+	if err != nil {
+		return err
+	}
+	defer reader.Close()
+
+	tarCmd.Stdin = reader
+	if err := tarCmd.Start(); err != nil {
+		return err
+	}
+
+	if err := tarCmd.Wait(); err != nil {
+		return err
+	}
+
+	if err = src.Cleanup(); err != nil {
+		// Ignore the cleanup error if the resource no longer exists.
+		if !containerderr.IsNotFound(err) {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Same block of 15-20 lines was repeated three times.
This version is more consistent, calling Reader.Close() every time.