### PR TITLE
Limit Travis branch builds to just master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ services:
 env:
 - GIMME_GO_VERSION=1.14.2
 
+branches:
+  only:
+    - "master"
+
 install:
 - eval "$(curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | bash)" # install specific go version
 - |


### PR DESCRIPTION
PRs always get sent to Travis by GitHub integration, so we don't need Travis to do the identical build for the branch too.

Once the PR is merged, that will be a commit on master, which we do want Travis to build.

Found at https://github.com/travis-ci/travis-ci/issues/1147
