### PR TITLE
Avoid race between stop/kill and wait

### DIFF
--- a/e2e/run_volume_test.go
+++ b/e2e/run_volume_test.go
@@ -124,8 +124,6 @@ func runVolume(t *testing.T, vmName, runtime, networkPlugin string) {
 }
 
 func TestVolumeWithDockerAndDockerBridge(t *testing.T) {
-	// TODO: https://github.com/weaveworks/ignite/issues/658
-	t.Skip("SKIPPING\nThis test fails to stop the VM within docker\nTODO: https://github.com/weaveworks/ignite/issues/658")
 	runVolume(
 		t,
 		"e2e-test-volume-docker-and-docker-bridge",

--- a/pkg/runtime/docker/client.go
+++ b/pkg/runtime/docker/client.go
@@ -245,7 +245,7 @@ func (dc *dockerClient) waitForContainer(container string, condition cont.WaitCo
 			return fmt.Errorf("failed to wait for container %q: %s", container, result.Error.Message)
 		}
 	case err := <-errC:
-		return err
+		return fmt.Errorf("error waiting for container %q: %w", container, err)
 	}
 
 	return nil


### PR DESCRIPTION
Depending on how fast Docker actions the auto-remove on container death, the wait can fail with "No such container".
Code adapted from RemoveContainer() which already had this fix.

Also make clear that such an error comes from waiting for container.

Fixes #679,  #658
