### PR TITLE
ps: Add out-of-date VM manifest status indicator

### DIFF
--- a/cmd/ignite/run/ps.go
+++ b/cmd/ignite/run/ps.go
@@ -6,11 +6,19 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/pkg/errors"
 	api "github.com/weaveworks/ignite/pkg/apis/ignite"
 	"github.com/weaveworks/ignite/pkg/filter"
 	"github.com/weaveworks/ignite/pkg/providers"
+	"github.com/weaveworks/ignite/pkg/runtime"
+	containerdruntime "github.com/weaveworks/ignite/pkg/runtime/containerd"
+	dockerruntime "github.com/weaveworks/ignite/pkg/runtime/docker"
 	"github.com/weaveworks/ignite/pkg/util"
 )
+
+// runtimeRunningStatus is the status returned from the container runtimes when
+// the VM container is in running state.
+const runtimeRunningStatus = "running"
 
 // PsFlags contains the flags supported by ps.
 type PsFlags struct {
@@ -67,6 +75,11 @@ func Ps(po *PsOptions) error {
 		}
 	}
 
+	outdatedVMs, err := fetchLatestStatus(filteredVMs)
+	if err != nil {
+		return err
+	}
+
 	// If template format is specified, render the template.
 	if po.PsFlags.TemplateFormat != "" {
 		// Parse the template format.
@@ -92,8 +105,13 @@ func Ps(po *PsOptions) error {
 	o.Write("VM ID", "IMAGE", "KERNEL", "SIZE", "CPUS", "MEMORY", "CREATED", "STATUS", "IPS", "PORTS", "NAME")
 	for _, vm := range filteredVMs {
 		o.Write(vm.GetUID(), vm.Spec.Image.OCI, vm.Spec.Kernel.OCI,
-			vm.Spec.DiskSize, vm.Spec.CPUs, vm.Spec.Memory, formatCreated(vm), formatStatus(vm), vm.Status.Network.IPAddresses,
+			vm.Spec.DiskSize, vm.Spec.CPUs, vm.Spec.Memory, formatCreated(vm), formatStatus(vm, outdatedVMs), vm.Status.Network.IPAddresses,
 			vm.Spec.Network.Ports, vm.GetName())
+	}
+
+	// Add a note at the bottom about the old manifest indicator in the status.
+	if len(outdatedVMs) > 0 {
+		o.Write("\nNOTE: The symbol * on the VM status indicates that the VM manifest on disk is not up-to-date with the actual VM status.")
 	}
 
 	return nil
@@ -110,10 +128,80 @@ func formatCreated(vm *api.VM) string {
 	return fmt.Sprint(created, suffix)
 }
 
-func formatStatus(vm *api.VM) string {
+func formatStatus(vm *api.VM, outdatedVMs map[string]bool) string {
+	oldManifestIndicator := ""
+	if _, ok := outdatedVMs[vm.Name]; ok {
+		oldManifestIndicator = "*"
+	}
 	if vm.Running() {
-		return fmt.Sprintf("Up %s", vm.Status.StartTime)
+		return fmt.Sprintf("%sUp %s", oldManifestIndicator, vm.Status.StartTime)
 	}
 
-	return "Stopped"
+	return oldManifestIndicator + "Stopped"
+}
+
+// fetchLatestStatus fetches the current status the VMs, updates the VM status
+// in memory and returns a list of outdated VMs.
+func fetchLatestStatus(vms []*api.VM) (outdatedVMs map[string]bool, err error) {
+	outdatedVMs = map[string]bool{}
+
+	// Container runtime clients. These clients are lazy initialized based on
+	// the VM's runtime.
+	var containerdClient, dockerClient runtime.Interface
+
+	// Iterate through the VMs, fetching the actual status from the runtime.
+	for _, vm := range vms {
+		// Skip VMs with no runtime info or no runtime ID.
+		if vm.Status.Runtime == nil || vm.Status.Runtime.ID == "" {
+			continue
+		}
+		containerID := vm.Status.Runtime.ID
+		currentRunning := false
+
+		// Runtime client of the VM.
+		var vmRuntime runtime.Interface
+
+		// Set the appropriate runtime client based on the VM runtime info.
+		switch vm.Status.Runtime.Name {
+		case runtime.RuntimeContainerd:
+			if containerdClient == nil {
+				containerdClient, err = containerdruntime.GetContainerdClient()
+				if err != nil {
+					return
+				}
+			}
+			vmRuntime = containerdClient
+		case runtime.RuntimeDocker:
+			if dockerClient == nil {
+				dockerClient, err = dockerruntime.GetDockerClient()
+				if err != nil {
+					return
+				}
+			}
+			vmRuntime = dockerClient
+		}
+
+		// Inspect the VM container using the runtime client.
+		ir, inspectErr := vmRuntime.InspectContainer(containerID)
+		if inspectErr != nil {
+			err = errors.Wrapf(inspectErr, "failed to inspect container for VM %s", containerID)
+			return
+		}
+
+		// Set current running based on the container status result.
+		if ir.Status == runtimeRunningStatus {
+			currentRunning = true
+		}
+
+		// If current running status and the VM object status don't match, mark
+		// it as an outdated VM and update the VM object staus in memory.
+		// NOTE: Avoid updating the VM manifest on disk here. That'll be
+		// indicated in the ps output.
+		if currentRunning != vm.Status.Running {
+			vm.Status.Running = currentRunning
+			outdatedVMs[vm.Name] = true
+		}
+	}
+
+	return
 }

--- a/e2e/vm_ps_test.go
+++ b/e2e/vm_ps_test.go
@@ -1,0 +1,79 @@
+package e2e
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gotest.tools/assert"
+
+	"github.com/weaveworks/ignite/e2e/util"
+	api "github.com/weaveworks/ignite/pkg/apis/ignite"
+	"github.com/weaveworks/ignite/pkg/apis/ignite/scheme"
+	"github.com/weaveworks/ignite/pkg/constants"
+)
+
+// TestVMpsWithOutdatedStatus checks if outdated status indicators are printed
+// in ps output when the VM manifest status on disk don't match with actual
+// status.
+func TestVMpsWithOutdatedStatus(t *testing.T) {
+	assert.Assert(t, e2eHome != "", "IGNITE_E2E_HOME should be set")
+
+	vmName := "e2e-test-ignite-ps-outdated"
+
+	igniteCmd := util.NewCommand(t, igniteBin)
+
+	defer igniteCmd.New().
+		With("rm", "-f", vmName).
+		Run()
+
+	igniteCmd.New().
+		With("run", "--name="+vmName).
+		With(util.DefaultVMImage).
+		With("--ssh").
+		Run()
+
+	// Filter the VM and obtain the UID.
+	nameFilter := fmt.Sprintf("{{.ObjectMeta.Name}}=%s", vmName)
+	psUIDCmd := igniteCmd.New().
+		With("ps", "-a").
+		With("-f", nameFilter).
+		With("-t", "{{.ObjectMeta.UID}}")
+	psUIDOut, psUIDErr := psUIDCmd.Cmd.CombinedOutput()
+	assert.NilError(t, psUIDErr, fmt.Sprintf("ps: \n%q\n%s", psUIDCmd.Cmd, psUIDOut))
+
+	uid := strings.TrimSpace(string(psUIDOut))
+
+	// Update the VM manifest with false info.
+	metadata_path := filepath.Join(constants.VM_DIR, uid, "metadata.json")
+	vm := &api.VM{}
+	assert.NilError(t, scheme.Serializer.DecodeFileInto(metadata_path, vm))
+	vm.Status.Running = false
+	vmBytes, err := scheme.Serializer.EncodeJSON(vm)
+	assert.NilError(t, err)
+	assert.NilError(t, ioutil.WriteFile(metadata_path, vmBytes, 0644))
+
+	// Revert the false data for proper cleanup.
+	// NOTE: This is needed because ignite rm believes the VM manifest status
+	// instead of checking for actual status itself.
+	defer func() {
+		vm.Status.Running = true
+		vmBytes, err = scheme.Serializer.EncodeJSON(vm)
+		assert.NilError(t, err)
+		assert.NilError(t, ioutil.WriteFile(metadata_path, vmBytes, 0644))
+	}()
+
+	// Run ps -a and look for the outdated status info.
+	psCmd := igniteCmd.New().
+		With("ps", "-a")
+
+	psOut, psErr := psCmd.Cmd.CombinedOutput()
+	assert.NilError(t, psErr, fmt.Sprintf("ps: \n%q\n%s", psCmd.Cmd, psOut))
+
+	psOutString := string(psOut)
+	// Check for the outdated status and the note about it.
+	assert.Check(t, strings.Contains(psOutString, "*Up"))
+	assert.Check(t, strings.Contains(psOutString, "NOTE: The symbol *"))
+}

--- a/e2e/vm_ps_test.go
+++ b/e2e/vm_ps_test.go
@@ -75,5 +75,5 @@ func TestVMpsWithOutdatedStatus(t *testing.T) {
 	psOutString := string(psOut)
 	// Check for the outdated status and the note about it.
 	assert.Check(t, strings.Contains(psOutString, "*Up"))
-	assert.Check(t, strings.Contains(psOutString, "NOTE: The symbol *"))
+	assert.Check(t, strings.Contains(psOutString, "The symbol *"))
 }


### PR DESCRIPTION
Update ps to check the current status of the VM containers by querying
the runtime and returning the actual status with an indicator for old
status info on disk manifest.

```console
$ sudo ./bin/ignite ps -a
VM ID                   IMAGE                           KERNEL                                  SIZE    CPUS    MEMORY          CREATED         STATUS       IPS              PORTS   NAME
234d704a81a053f9        weaveworks/ignite-ubuntu:latest weaveworks/ignite-kernel:4.19.125       4.0 GB  1       512.0 MB        9m50s ago       *Up 9m50s    10.61.0.4                my-vm2
a6a381776cc6c60c        weaveworks/ignite-ubuntu:latest weaveworks/ignite-kernel:4.19.125       4.0 GB  1       512.0 MB        118m ago        Up 118m      10.61.0.2                my-vm
c19c691a01ba8f01        weaveworks/ignite-ubuntu:latest weaveworks/ignite-kernel:4.19.125       4.0 GB  1       512.0 MB        64m ago         *Up 64m      172.17.0.2               my-vm3

NOTE: The symbol * on the VM status indicates that the VM manifest on disk is not up-to-date with the actual VM status.
```

The note at the bottom is shown only when there's an out-of-date status in the result.

This will show the actual VM status and help avoid confusing the user when the machine actual state is different from the displayed state.