### PR TITLE
Use declarative port mappings and copy files values when CLI flags are empty

### DIFF
--- a/cmd/ignite/run/create.go
+++ b/cmd/ignite/run/create.go
@@ -217,10 +217,12 @@ func applyVMFlagOverrides(baseVM *api.VM, cf *CreateFlags, fs *flag.FlagSet) err
 		return err
 	}
 
-	// Parse the given port mappings.
-	baseVM.Spec.Network.Ports, err = meta.ParsePortMappings(cf.PortMappings)
-	if err != nil {
-		return err
+	if len(cf.PortMappings) > 0 {
+		// Parse the given port mappings.
+		baseVM.Spec.Network.Ports, err = meta.ParsePortMappings(cf.PortMappings)
+		if err != nil {
+			return err
+		}
 	}
 
 	// If the SSH flag was set, copy it over to the API type

--- a/cmd/ignite/run/create.go
+++ b/cmd/ignite/run/create.go
@@ -211,10 +211,12 @@ func applyVMFlagOverrides(baseVM *api.VM, cf *CreateFlags, fs *flag.FlagSet) err
 		baseVM.Spec.Storage = cf.VM.Spec.Storage
 	}
 
-	// Parse the --copy-files flag.
-	baseVM.Spec.CopyFiles, err = parseFileMappings(cf.CopyFiles)
-	if err != nil {
-		return err
+	if len(cf.CopyFiles) > 0 {
+		// Parse the --copy-files flag.
+		baseVM.Spec.CopyFiles, err = parseFileMappings(cf.CopyFiles)
+		if err != nil {
+			return err
+		}
 	}
 
 	if len(cf.PortMappings) > 0 {

--- a/cmd/ignite/run/create_test.go
+++ b/cmd/ignite/run/create_test.go
@@ -220,6 +220,27 @@ func TestApplyVMFlagOverrides(t *testing.T) {
 			err: true,
 		},
 		{
+			name: "copy files in baseVM",
+			createFlag: &CreateFlags{
+				VM: &api.VM{
+					Spec: api.VMSpec{
+						CopyFiles: []api.FileMapping{
+							{
+								HostPath: "/tmp/foo",
+								VMPath:   "/tmp/bar",
+							},
+						},
+					},
+				},
+			},
+			wantCopyFiles: []api.FileMapping{
+				{
+					HostPath: "/tmp/foo",
+					VMPath:   "/tmp/bar",
+				},
+			},
+		},
+		{
 			name: "valid port mapping",
 			createFlag: &CreateFlags{
 				VM:           &api.VM{},
@@ -241,6 +262,33 @@ func TestApplyVMFlagOverrides(t *testing.T) {
 				PortMappings: []string{"1.1.1.1:foo:bar"},
 			},
 			err: true,
+		},
+		{
+			name: "port mapping in base VM",
+			createFlag: &CreateFlags{
+				VM: &api.VM{
+					Spec: api.VMSpec{
+						Network: api.VMNetworkSpec{
+							Ports: meta.PortMappings{
+								{
+									BindAddress: net.IPv4(0, 0, 0, 0),
+									HostPort:    uint64(80),
+									VMPort:      uint64(80),
+									Protocol:    meta.ProtocolTCP,
+								},
+							},
+						},
+					},
+				},
+			},
+			wantPortMapping: meta.PortMappings{
+				meta.PortMapping{
+					BindAddress: net.IPv4(0, 0, 0, 0),
+					HostPort:    uint64(80),
+					VMPort:      uint64(80),
+					Protocol:    meta.ProtocolTCP,
+				},
+			},
 		},
 		{
 			name: "ssh public key set",

--- a/cmd/ignite/run/create_test.go
+++ b/cmd/ignite/run/create_test.go
@@ -187,7 +187,7 @@ func TestApplyVMFlagOverrides(t *testing.T) {
 		createFlag      *CreateFlags
 		wantCopyFiles   []api.FileMapping
 		wantPortMapping meta.PortMappings
-		wantSSH         api.SSH
+		wantSSH         *api.SSH
 		err             bool
 	}{
 		{
@@ -251,7 +251,7 @@ func TestApplyVMFlagOverrides(t *testing.T) {
 					PublicKey: "some-pub-key",
 				},
 			},
-			wantSSH: api.SSH{
+			wantSSH: &api.SSH{
 				Generate:  true,
 				PublicKey: "some-pub-key",
 			},
@@ -273,23 +273,23 @@ func TestApplyVMFlagOverrides(t *testing.T) {
 				// Check if copy files are set as expected.
 				if len(rt.wantCopyFiles) > 0 {
 					if !reflect.DeepEqual(vm.Spec.CopyFiles, rt.wantCopyFiles) {
-						t.Errorf("expected VM.Spec.CopyFiles to be %v, actual: %v", rt.wantCopyFiles, rt.createFlag.VM.Spec.CopyFiles)
+						t.Errorf("expected VM.Spec.CopyFiles to be %v, actual: %v", rt.wantCopyFiles, vm.Spec.CopyFiles)
 					}
 				} else {
 					// If the copy files map is empty, compare their sizes.
-					if len(rt.wantCopyFiles) != len(rt.createFlag.VM.Spec.CopyFiles) {
-						t.Errorf("expected VM.Spec.CopyFiles to be %v, actual: %v", rt.wantCopyFiles, rt.createFlag.VM.Spec.CopyFiles)
+					if len(rt.wantCopyFiles) != len(vm.Spec.CopyFiles) {
+						t.Errorf("expected VM.Spec.CopyFiles to be %v, actual: %v", rt.wantCopyFiles, vm.Spec.CopyFiles)
 					}
 				}
 
 				// Check if port mappings are set as expected.
-				if reflect.DeepEqual(rt.createFlag.VM.Spec.Network.Ports, rt.wantPortMapping) {
-					t.Errorf("expected VM.Spec.Network.Ports to be %v, actual: %v", rt.wantPortMapping, rt.createFlag.VM.Spec.Network.Ports)
+				if vm.Spec.Network.Ports.String() != rt.wantPortMapping.String() {
+					t.Errorf("expected VM.Spec.Network.Ports to be %s, actual: %s", rt.wantPortMapping.String(), vm.Spec.Network.Ports.String())
 				}
 
 				// Check if the SSH values are set as expected.
-				if reflect.DeepEqual(rt.createFlag.VM.Spec.SSH, rt.wantSSH) {
-					t.Errorf("expected VM.Spec.SSH to be %v, actual: %v", rt.wantSSH, rt.createFlag.VM.Spec.SSH)
+				if !reflect.DeepEqual(vm.Spec.SSH, rt.wantSSH) {
+					t.Errorf("expected VM.Spec.SSH to be %v, actual: %v", rt.wantSSH, vm.Spec.SSH)
 				}
 			}
 		})


### PR DESCRIPTION
Fixes #795 