### PR TITLE
is_git_repo: Return without echo

### DIFF
--- a/hack/ldflags.sh
+++ b/hack/ldflags.sh
@@ -4,7 +4,7 @@
 
 is_git_repo() {
   # https://stackoverflow.com/a/2180367
-  [ -d .git ] && echo .git || git rev-parse --git-dir > /dev/null 2>&1
+  [ -d .git ] && return 0 || git rev-parse --git-dir > /dev/null 2>&1
 }
 
 git_to_image_tag() {


### PR DESCRIPTION
This was resulting in `GIT_VERSION` to be
`".git v0.8.0-87+b5214a06643efb-dirty"` and causing errors like
`/bin/bash: line 1: v0.8.0-87+b5214a06643efb-dirty: command not found`
when building ignite.

Instead of echo-ing, this returns 0 - true from the function.

To reproduce, run `make` and notice the first line:
```console
$ make
/usr/bin/bash: line 1: v0.8.0-87+b5214a06643efb-dirty: command not found
make GOARCH=amd64 ignite ignited ignite-spawn
make[1]: Entering directory '~/go/src/github.com/weaveworks/ignite'
/usr/bin/bash: line 1: v0.8.0-87+b5214a06643efb-dirty: command not found
make go-make TARGETS="bin/amd64/ignite"
...
```

Introduced in https://github.com/weaveworks/ignite/commit/e3add4e21c1e85357ba9b7e9a409e10075e65755 recently where we were trying to help improve the AUR package build from tarballs.