### PR TITLE
Bump CNI Plugins to 0.9.1

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -24,7 +24,7 @@ blocks:
             sudo which containerd || sudo apt-get install -y --no-install-recommends containerd
           - kvm-ok
           - |
-            export CNI_VERSION=v0.8.7
+            export CNI_VERSION=v0.9.1
             export ARCH=$([ $(uname -m) = "x86_64" ] && echo amd64 || echo arm64)
             sudo mkdir -p /opt/cni/bin
             curl -sSL https://github.com/containernetworking/plugins/releases/download/${CNI_VERSION}/cni-plugins-linux-${ARCH}-${CNI_VERSION}.tgz | sudo tar -xz -C /opt/cni/bin

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -58,7 +58,7 @@ With time, we aim to eliminate as many of these as possible.
 ### CNI plugins
 
 ```shell
-export CNI_VERSION=v0.8.7
+export CNI_VERSION=v0.9.1
 export ARCH=$([ $(uname -m) = "x86_64" ] && echo amd64 || echo arm64)
 curl -sSL https://github.com/containernetworking/plugins/releases/download/${CNI_VERSION}/cni-plugins-linux-${ARCH}-${CNI_VERSION}.tgz | tar -xz -C /opt/cni/bin
 ```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -79,7 +79,7 @@ which containerd || amazon-linux-extras enable docker && yum install -y containe
 Install the CNI binaries like this:
 
 ```shell
-export CNI_VERSION=v0.8.7
+export CNI_VERSION=v0.9.1
 export ARCH=$([ $(uname -m) = "x86_64" ] && echo amd64 || echo arm64)
 sudo mkdir -p /opt/cni/bin
 curl -sSL https://github.com/containernetworking/plugins/releases/download/${CNI_VERSION}/cni-plugins-linux-${ARCH}-${CNI_VERSION}.tgz | sudo tar -xz -C /opt/cni/bin


### PR DESCRIPTION
* Bumps the CNI plugins from 0.8.7 to 0.9.1

Changelog:

### Plugins: 0.9.0

Behavior changes
- tuning: revert values on delete (#540). Useful when using the host-device plugin.

Fixes:
- Delete stale UDP conntrack entries when adding new Portmaps to containers (#553).
Other improvements
- flannel: allow input ipam parameters as basis for delegate (#532).
move off of Travis 😢
- ipvlan: make master config as optional (#534).

### Plugins: 0.9.1:

New behavior:
- DHCP timeout is configurable (#565).
- host-device: Add support for DPDK device (#490). Host-device plugin is a noop for DPDK devices

Fixes:
- vlan: fix error message text by removing ptp references (#566). Fixing a few error messages that the vlan plugin returns. These appear to be mistaken references to the ptp plugin.
- vlan: Fix error handling for delegate IPAM plugin (#568).
- deps: bump coreos/go-iptables (#563).


Source: https://github.com/containernetworking/plugins/releases