### PR TITLE
Handle error when the backend storage is uninitialized

### DIFF
--- a/cmd/ignite/run/images.go
+++ b/cmd/ignite/run/images.go
@@ -1,6 +1,8 @@
 package run
 
 import (
+	"os"
+
 	api "github.com/weaveworks/ignite/pkg/apis/ignite"
 	"github.com/weaveworks/ignite/pkg/providers"
 	"github.com/weaveworks/ignite/pkg/util"
@@ -14,6 +16,11 @@ type ImagesOptions struct {
 func NewImagesOptions() (io *ImagesOptions, err error) {
 	io = &ImagesOptions{}
 	io.allImages, err = providers.Client.Images().FindAll(filter.NewAllFilter())
+	// If the storage is uninitialized, avoid failure and continue with empty
+	// image list.
+	if err != nil && os.IsNotExist(err) {
+		err = nil
+	}
 	return
 }
 

--- a/cmd/ignite/run/kernels.go
+++ b/cmd/ignite/run/kernels.go
@@ -1,6 +1,8 @@
 package run
 
 import (
+	"os"
+
 	api "github.com/weaveworks/ignite/pkg/apis/ignite"
 	"github.com/weaveworks/ignite/pkg/providers"
 	"github.com/weaveworks/ignite/pkg/util"
@@ -14,6 +16,11 @@ type KernelsOptions struct {
 func NewKernelsOptions() (ko *KernelsOptions, err error) {
 	ko = &KernelsOptions{}
 	ko.allKernels, err = providers.Client.Kernels().FindAll(filter.NewAllFilter())
+	// If the storage is uninitialized, avoid failure and continue with empty
+	// kernel list.
+	if err != nil && os.IsNotExist(err) {
+		err = nil
+	}
 	return
 }
 

--- a/cmd/ignite/run/ps.go
+++ b/cmd/ignite/run/ps.go
@@ -3,7 +3,7 @@ package run
 import (
 	"bytes"
 	"fmt"
-	"strings"
+	"os"
 	"text/template"
 
 	"github.com/pkg/errors"
@@ -40,7 +40,7 @@ func (pf *PsFlags) NewPsOptions() (po *PsOptions, err error) {
 	po.allVMs, err = providers.Client.VMs().FindAll(filter.NewVMFilterAll("", po.All))
 	// If the storage is uninitialized, avoid failure and continue with empty
 	// VM list.
-	if err != nil && strings.Contains(err.Error(), "no such file or directory") {
+	if err != nil && os.IsNotExist(err) {
 		err = nil
 	}
 	return


### PR DESCRIPTION
VM, image and kernel list return error when the backend storage is
uninitialized (/var/lib/firecracker/{vm,image,kernel} don't exist).

```
FATA[0000] open /var/lib/firecracker/kernel: no such file or directory
...
FATA[0000] open /var/lib/firecracker/image: no such file or directory
```

This was fixed for VM in #778. This change improves the error check.