### PR TITLE
ps: Mark VM with * when the state can't be confirmed

### DIFF
--- a/cmd/ignite/run/ps.go
+++ b/cmd/ignite/run/ps.go
@@ -82,7 +82,7 @@ func Ps(po *PsOptions) error {
 	if len(outdatedVMs) > 0 {
 		endWarnings = append(
 			endWarnings,
-			fmt.Errorf("The symbol %s on the VM status indicates that the VM manifest on disk is not up-to-date with the actual VM status from the container runtime", oldManifestIndicator),
+			fmt.Errorf("The symbol %s on the VM status indicates that the VM manifest on disk may not be up-to-date with the actual VM status from the container runtime", oldManifestIndicator),
 		)
 	}
 	if len(errList) > 0 {
@@ -200,6 +200,9 @@ func fetchLatestStatus(vms []*api.VM) (outdatedVMs map[string]bool, errList []er
 		// Inspect the VM container using the runtime client.
 		ir, inspectErr := vmRuntime.InspectContainer(containerID)
 		if inspectErr != nil {
+			// Failed to get the container status. Latest status can't be
+			// confirmed.
+			outdatedVMs[vm.Name] = true
 			errList = append(errList, errors.Wrapf(inspectErr, "failed to inspect container for VM %s", containerID))
 			continue
 		}


### PR DESCRIPTION
While listing the VMs, if the latest status of the VMs can't be
confirmed due to a runtime engine error, the status can't be confirmed.
Mark such VMs with the * symbol to indicate potentially outdated status.

```console
VM ID                   IMAGE                           KERNEL                                  SIZE    CPUS    MEMORY          CREATED         STATUS          IPS         PORTS   NAME
77e0d9469b154da3        weaveworks/ignite-ubuntu:latest weaveworks/ignite-kernel:4.19.125       4.0 GB  1       512.0 MB        55m ago         Up 55m          10.61.0.2           my-vm
7e6c9464555b2513        weaveworks/ignite-ubuntu:latest weaveworks/ignite-kernel:4.19.125       4.0 GB  1       512.0 MB        4m19s ago       *Up 4m19s       172.17.0.2          my-vm2
WARN[0000] The symbol * on the VM status indicates that the VM manifest on disk may not be up-to-date with the actual VM status from the container runtime
WARN[0000] failed to inspect container for VM e52958f1852002e002a5a1d01c40a13d59ea6d13fbe6a5ecd4d61834a42a62b1: Error: No such container: e52958f1852002e002a5a1d01c40a13d59ea6d13fbe6a5ecd4d61834a42a62b1

```