### PR TITLE
runtime: Handle error when container not found

### DIFF
--- a/pkg/runtime/containerd/client.go
+++ b/pkg/runtime/containerd/client.go
@@ -574,6 +574,11 @@ func withDevices(devices []*runtime.Bind) oci.SpecOpts {
 func (cc *ctdClient) StopContainer(container string, timeout *time.Duration) (err error) {
 	cont, err := cc.client.LoadContainer(cc.ctx, container)
 	if err != nil {
+		// If the container is not found, return nil, no-op.
+		if errdefs.IsNotFound(err) {
+			log.Warn(err)
+			err = nil
+		}
 		return
 	}
 
@@ -596,6 +601,11 @@ func (cc *ctdClient) StopContainer(container string, timeout *time.Duration) (er
 
 	task, err := cont.Task(cc.ctx, cio.Load)
 	if err != nil {
+		// If the task is not found, return nil, no-op.
+		if errdefs.IsNotFound(err) {
+			log.Warn(err)
+			err = nil
+		}
 		return
 	}
 

--- a/pkg/runtime/containerd/client.go
+++ b/pkg/runtime/containerd/client.go
@@ -639,11 +639,21 @@ func (cc *ctdClient) StopContainer(container string, timeout *time.Duration) (er
 func (cc *ctdClient) KillContainer(container, signal string) (err error) {
 	cont, err := cc.client.LoadContainer(cc.ctx, container)
 	if err != nil {
+		// If the container is not found, return nil, no-op.
+		if errdefs.IsNotFound(err) {
+			log.Warn(err)
+			err = nil
+		}
 		return
 	}
 
 	task, err := cont.Task(cc.ctx, cio.Load)
 	if err != nil {
+		// If the task is not found, return nil, no-op.
+		if errdefs.IsNotFound(err) {
+			log.Warn(err)
+			err = nil
+		}
 		return
 	}
 

--- a/pkg/runtime/docker/client.go
+++ b/pkg/runtime/docker/client.go
@@ -185,6 +185,11 @@ func (dc *dockerClient) StopContainer(container string, timeout *time.Duration) 
 	<-readyC // wait until removal detection has started
 
 	if err := dc.client.ContainerStop(context.Background(), container, timeout); err != nil {
+		// If the container is not found, return nil, no-op.
+		if errdefs.IsNotFound(err) {
+			log.Warn(err)
+			return nil
+		}
 		return err
 	}
 
@@ -225,6 +230,11 @@ func (dc *dockerClient) RemoveContainer(container string) error {
 
 	<-readyC // The ready channel is used to wait until removal detection has started
 	if err := dc.client.ContainerRemove(context.Background(), container, types.ContainerRemoveOptions{}); err != nil {
+		// If the container is not found, return nil, no-op.
+		if errdefs.IsNotFound(err) {
+			log.Warn(err)
+			return nil
+		}
 		return err
 	}
 

--- a/pkg/runtime/docker/client.go
+++ b/pkg/runtime/docker/client.go
@@ -12,6 +12,8 @@ import (
 	"github.com/docker/docker/api/types/container"
 	cont "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
+	"github.com/docker/docker/errdefs"
+	log "github.com/sirupsen/logrus"
 	meta "github.com/weaveworks/ignite/pkg/apis/meta/v1alpha1"
 	"github.com/weaveworks/ignite/pkg/preflight"
 	"github.com/weaveworks/ignite/pkg/preflight/checkers"
@@ -199,6 +201,11 @@ func (dc *dockerClient) KillContainer(container, signal string) error {
 	<-readyC // wait until removal detection has started
 
 	if err := dc.client.ContainerKill(context.Background(), container, signal); err != nil {
+		// If the container is not found, return nil, no-op.
+		if errdefs.IsNotFound(err) {
+			log.Warn(err)
+			return nil
+		}
 		return err
 	}
 


### PR DESCRIPTION
When removing or stopping a VM, if the container runtime returns error
because it can't find the associated VM container, the remove fails.
With this change, ignite will checks if the container runtime error is
about container not found and return without any error, no-op, letting
the operation succeed.

Before:
```console
$ sudo ./bin/ignite rm -f my-vm2
INFO[0000] Removing the container with ID "ignite-7e6c9464555b2513" from the "cni" network
INFO[0000] CNI failed to retrieve network namespace path: container "ignite-7e6c9464555b2513" in namespace "firecracker": not found
FATA[0000] failed to kill container for VM "7e6c9464555b2513": container "ignite-7e6c9464555b2513" in namespace "firecracker": not found
```
After(containerd):
```console
$ sudo ./bin/ignite rm -f my-vm2
INFO[0000] Removing the container with ID "ignite-7e6c9464555b2513" from the "cni" network
INFO[0000] CNI failed to retrieve network namespace path: container "ignite-7e6c9464555b2513" in namespace "firecracker": not found
WARN[0000] container "ignite-7e6c9464555b2513" in namespace "firecracker": not found
INFO[0000] Removed VM with name "my-vm2" and ID "7e6c9464555b2513"
```
Docker:
```console
$ sudo ./bin/ignite rm -f my-vm2
INFO[0000] Removing the container with ID "ignite-7e6c9464555b2513" from the "docker-bridge" network
WARN[0000] Error response from daemon: Cannot kill container: ignite-7e6c9464555b2513: No such container: ignite-7e6c9464555b2513
INFO[0000] Removed VM with name "my-vm2" and ID "7e6c9464555b2513"
```

NOTE: This change avoids the usage of `ifFound()` in containred/client.go to keep the changes minimal for now. Using `ifFound()` results in a lot of code restructuring due to named error return, easily resulting in shadowed error related issues. A proper refactoring could be done separately.

Fixes #751 