### PR TITLE
Bump Kernel versions. Bump default kernel version to 5.4.108

### DIFF
--- a/cmd/ignite/run/testdata/output/apply-vm-config-empty.json
+++ b/cmd/ignite/run/testdata/output/apply-vm-config-empty.json
@@ -13,7 +13,7 @@
       "oci": "weaveworks/ignite:dev"
     },
     "kernel": {
-      "oci": "weaveworks/ignite-kernel:5.4.102",
+      "oci": "weaveworks/ignite-kernel:5.4.108",
       "cmdLine": "console=ttyS0 reboot=k panic=1 pci=off ip=dhcp"
     },
     "cpus": 1,

--- a/docs/cli/ignite/ignite_create.md
+++ b/docs/cli/ignite/ignite_create.md
@@ -7,7 +7,7 @@ Create a new VM without starting it
 
 Create a new VM by combining the given image with a kernel. If no
 kernel is given using the kernel flag (-k, --kernel-image), use the
-default kernel (weaveworks/ignite-kernel:5.4.102).
+default kernel (weaveworks/ignite-kernel:5.4.108).
 
 Various configuration options can be set during creation by using
 the flags for this command.
@@ -40,7 +40,7 @@ ignite create <OCI image> [flags]
   -h, --help                      help for create
       --id-prefix string          Prefix string for system identifiers (default ignite)
       --kernel-args string        Set the command line for the kernel (default "console=ttyS0 reboot=k panic=1 pci=off ip=dhcp")
-  -k, --kernel-image oci-image    Specify an OCI image containing the kernel at /boot/vmlinux and optionally, modules (default weaveworks/ignite-kernel:5.4.102)
+  -k, --kernel-image oci-image    Specify an OCI image containing the kernel at /boot/vmlinux and optionally, modules (default weaveworks/ignite-kernel:5.4.108)
   -l, --label stringArray         Set a label (foo=bar)
       --memory size               Amount of RAM to allocate for the VM (default 512.0 MB)
   -n, --name string               Specify the name

--- a/docs/cli/ignite/ignite_run.md
+++ b/docs/cli/ignite/ignite_run.md
@@ -36,7 +36,7 @@ ignite run <OCI image> [flags]
       --ignore-preflight-checks strings   A list of checks whose errors will be shown as warnings. Example: 'BinaryInPath,Port,ExistingFile'. Value 'all' ignores errors from all checks.
   -i, --interactive                       Attach to the VM after starting
       --kernel-args string                Set the command line for the kernel (default "console=ttyS0 reboot=k panic=1 pci=off ip=dhcp")
-  -k, --kernel-image oci-image            Specify an OCI image containing the kernel at /boot/vmlinux and optionally, modules (default weaveworks/ignite-kernel:5.4.102)
+  -k, --kernel-image oci-image            Specify an OCI image containing the kernel at /boot/vmlinux and optionally, modules (default weaveworks/ignite-kernel:5.4.108)
   -l, --label stringArray                 Set a label (foo=bar)
       --memory size                       Amount of RAM to allocate for the VM (default 512.0 MB)
   -n, --name string                       Specify the name

--- a/docs/cli/ignite/ignite_vm_create.md
+++ b/docs/cli/ignite/ignite_vm_create.md
@@ -7,7 +7,7 @@ Create a new VM without starting it
 
 Create a new VM by combining the given image with a kernel. If no
 kernel is given using the kernel flag (-k, --kernel-image), use the
-default kernel (weaveworks/ignite-kernel:5.4.102).
+default kernel (weaveworks/ignite-kernel:5.4.108).
 
 Various configuration options can be set during creation by using
 the flags for this command.
@@ -40,7 +40,7 @@ ignite vm create <OCI image> [flags]
   -h, --help                      help for create
       --id-prefix string          Prefix string for system identifiers (default ignite)
       --kernel-args string        Set the command line for the kernel (default "console=ttyS0 reboot=k panic=1 pci=off ip=dhcp")
-  -k, --kernel-image oci-image    Specify an OCI image containing the kernel at /boot/vmlinux and optionally, modules (default weaveworks/ignite-kernel:5.4.102)
+  -k, --kernel-image oci-image    Specify an OCI image containing the kernel at /boot/vmlinux and optionally, modules (default weaveworks/ignite-kernel:5.4.108)
   -l, --label stringArray         Set a label (foo=bar)
       --memory size               Amount of RAM to allocate for the VM (default 512.0 MB)
   -n, --name string               Specify the name

--- a/docs/cli/ignite/ignite_vm_run.md
+++ b/docs/cli/ignite/ignite_vm_run.md
@@ -36,7 +36,7 @@ ignite vm run <OCI image> [flags]
       --ignore-preflight-checks strings   A list of checks whose errors will be shown as warnings. Example: 'BinaryInPath,Port,ExistingFile'. Value 'all' ignores errors from all checks.
   -i, --interactive                       Attach to the VM after starting
       --kernel-args string                Set the command line for the kernel (default "console=ttyS0 reboot=k panic=1 pci=off ip=dhcp")
-  -k, --kernel-image oci-image            Specify an OCI image containing the kernel at /boot/vmlinux and optionally, modules (default weaveworks/ignite-kernel:5.4.102)
+  -k, --kernel-image oci-image            Specify an OCI image containing the kernel at /boot/vmlinux and optionally, modules (default weaveworks/ignite-kernel:5.4.108)
   -l, --label stringArray                 Set a label (foo=bar)
       --memory size                       Amount of RAM to allocate for the VM (default 512.0 MB)
   -n, --name string                       Specify the name

--- a/docs/declarative-config.md
+++ b/docs/declarative-config.md
@@ -70,7 +70,7 @@ spec:
     # Default: "console=ttyS0 reboot=k panic=1 pci=off ip=dhcp"
     cmdLine: [string]
     # Required, what OCI image to get the kernel binary (and optionally modules) from
-    # Default: weaveworks/ignite-kernel:5.4.102
+    # Default: weaveworks/ignite-kernel:5.4.108
     oci:  [OCI image reference]
   sandbox:
     # Optional, what OCI image to use as the ignite sandbox.

--- a/docs/footloose.md
+++ b/docs/footloose.md
@@ -47,10 +47,10 @@ machines:
       cpus: 2
       memory: 1GB
       diskSize: 5GB
-      kernel: "weaveworks/ignite-kernel:5.4.102"
+      kernel: "weaveworks/ignite-kernel:5.4.108"
 ```
 
-This Footloose API object specifies an Ignite VM with 2 vCPUs, 1GB of RAM, `weaveworks/ignite-kernel:5.4.102` kernel and 5GB of disk.
+This Footloose API object specifies an Ignite VM with 2 vCPUs, 1GB of RAM, `weaveworks/ignite-kernel:5.4.108` kernel and 5GB of disk.
 
 Given that you have [Footloose](https://github.com/weaveworks/footloose#install) and [Ignite](installation.md) installed, and the above file
 created as `footloose.yaml` in the current directory, you can run
@@ -67,7 +67,7 @@ SSH into the VM:
 
 ```console
 $ footloose ssh vm0
-Welcome to Ubuntu 18.04.2 LTS (GNU/Linux 5.4.102 x86_64)
+Welcome to Ubuntu 18.04.2 LTS (GNU/Linux 5.4.108 x86_64)
 
  * Documentation:  https://help.ubuntu.com
  * Management:     https://landscape.canonical.com

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -206,7 +206,7 @@ Now in a new terminal/console:
 # ignite ps
 VM ID                   IMAGE                           KERNEL                                  SIZE    CPU
 S       MEMORY          CREATED STATUS  IPS             PORTS   NAME
-rpfrdqxmffadvn6t        weaveworks/ignite-ubuntu:latest weaveworks/ignite-kernel:5.4.102        1.2 GB  1 4
+rpfrdqxmffadvn6t        weaveworks/ignite-ubuntu:latest weaveworks/ignite-kernel:5.4.108        1.2 GB  1 4
 56.0 MB 43m ago Up 39m  10.61.0.2               smoke-test
 ```
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -111,14 +111,14 @@ If no error occured, your `VM` is now running.
 
 Ignite currently manages three kinds of resources: `images`, `kernels` and `VMs`.
 The `kernels` are quite transparent, and get automatically imported from the docker
-image `weaveworks/ignite-kernel:5.4.102` by default (overridable during `create`).
+image `weaveworks/ignite-kernel:5.4.108` by default (overridable during `create`).
 
 To list the available `kernels`, enter:
 
 ```
 # ignite kernels
 KERNEL ID               NAME                                    CREATED SIZE    VERSION
-aefb459546315344        weaveworks/ignite-kernel:5.4.102        61m ago 49.0 MB 5.4.102
+aefb459546315344        weaveworks/ignite-kernel:5.4.108        61m ago 49.0 MB 5.4.108
 ```
 
 To list the imported `images`, enter:
@@ -134,7 +134,7 @@ And to list the running `VMs`, enter:
 ```
 # ignite ps
 VM ID                   IMAGE                           KERNEL                                  CREATED SIZE    CPUS    MEMORY          STATE   IPS             PORTS   NAME
-3c5fa9a18682741f        weaveworks/ignite-ubuntu:latest weaveworks/ignite-kernel:5.4.102        63m ago 4.0 GB  2       1.0 GB          Running 172.17.0.3              my-vm
+3c5fa9a18682741f        weaveworks/ignite-ubuntu:latest weaveworks/ignite-kernel:5.4.108        63m ago 4.0 GB  2       1.0 GB          Running 172.17.0.3              my-vm
 ```
 
 To list all `VMs` instead of just running ones, add the `-a` flag to `ps`.
@@ -178,7 +178,7 @@ To SSH into a `VM`, enter:
 
 ```console
 # ignite ssh my-vm
-Welcome to Ubuntu 18.04.2 LTS (GNU/Linux 5.4.102 x86_64)
+Welcome to Ubuntu 18.04.2 LTS (GNU/Linux 5.4.108 x86_64)
 ...
 root@3c5fa9a18682741f:~#
 ```

--- a/pkg/apis/meta/v1alpha1/image_test.go
+++ b/pkg/apis/meta/v1alpha1/image_test.go
@@ -10,8 +10,8 @@ func TestNewOCIImageRef(t *testing.T) {
 		err     bool
 	}{
 		{
-			in:  "weaveworks/ignite-kernel:5.4.102",
-			out: "weaveworks/ignite-kernel:5.4.102",
+			in:  "weaveworks/ignite-kernel:5.4.108",
+			out: "weaveworks/ignite-kernel:5.4.108",
 		},
 		{
 			in:  "centos",

--- a/pkg/constants/kernel.go
+++ b/pkg/constants/kernel.go
@@ -14,5 +14,5 @@ const (
 	DEFAULT_KERNEL_IMAGE_NAME = "weaveworks/ignite-kernel"
 
 	// The kernel image tag to be used as the default
-	DEFAULT_KERNEL_IMAGE_TAG = "5.4.102"
+	DEFAULT_KERNEL_IMAGE_TAG = "5.4.108"
 )


### PR DESCRIPTION
* Bump all kernel versions to: 4.14.227, 4.19.183, 5.4.108, 5.10.25
* Bump default kernel version from 5.4.102 to 5.4.108

For future reference on how to quickly bump the default kernel in all the files: 

```
git clone git@github.com:weaveworks/ignite.git
cd ignite
grep -rl 'CURRENT_VERSION' ./ | xargs sed -i 's/CURRENT_VERSION/FUTURE_VERSION/g'
```