### PR TITLE
Change the log level in RemoveContainer to debug

### DIFF
--- a/pkg/runtime/containerd/client.go
+++ b/pkg/runtime/containerd/client.go
@@ -690,7 +690,7 @@ func (cc *ctdClient) RemoveContainer(container string) error {
 	// Remove the container if it exists
 	cont, contLoadErr := cc.client.LoadContainer(cc.ctx, container)
 	if errdefs.IsNotFound(contLoadErr) {
-		log.Warn(contLoadErr)
+		log.Debug(contLoadErr)
 		return nil
 	} else if contLoadErr != nil {
 		return contLoadErr
@@ -699,20 +699,20 @@ func (cc *ctdClient) RemoveContainer(container string) error {
 	// Load the container's task without attaching
 	task, taskLoadErr := cont.Task(cc.ctx, nil)
 	if errdefs.IsNotFound(taskLoadErr) {
-		log.Warn(taskLoadErr)
+		log.Debug(taskLoadErr)
 	} else if taskLoadErr != nil {
 		return taskLoadErr
 	} else {
 		_, taskDeleteErr := task.Delete(cc.ctx)
 		if taskDeleteErr != nil {
-			log.Warn(taskDeleteErr)
+			log.Debug(taskDeleteErr)
 		}
 	}
 
 	// Delete the container
 	deleteContErr := cont.Delete(cc.ctx, containerd.WithSnapshotCleanup)
 	if errdefs.IsNotFound(contLoadErr) {
-		log.Warn(contLoadErr)
+		log.Debug(contLoadErr)
 	} else if deleteContErr != nil {
 		return deleteContErr
 	}


### PR DESCRIPTION
In #791, we refactored `RemoveContainer()` method of the containerd client
and added some warning logs. This resulted in unintended warning logs.

Run a new VM:
```console
$ sudo ./bin/ignite run weaveworks/ignite-ubuntu --ssh --name my-vm
INFO[0000] containerd image "weaveworks/ignite-kernel:5.4.102" not found locally, pulling...
INFO[0007] Imported OCI image "weaveworks/ignite-kernel:5.4.102" (62.6 MB) to kernel image with UID "7acfe8fbf902d09f"
INFO[0008] Created VM with ID "12def5918a82dac3" and name "my-vm"
WARN[0008] container "ignite-12def5918a82dac3" in namespace "firecracker": not found
INFO[0009] Networking is handled by "cni"
INFO[0009] Started Firecracker VM "12def5918a82dac3" in a container with ID "ignite-12def5918a82dac3"
INFO[0010] Waiting for the ssh daemon within the VM to start...
```

Delete a VM:
```console
$ sudo ./bin/ignite rm -f my-vm
INFO[0000] Removing the container with ID "ignite-12def5918a82dac3" from the "cni" network
WARN[0000] no running task found: task ignite-12def5918a82dac3 not found: not found
INFO[0000] Removed VM with name "my-vm" and ID "12def5918a82dac3"
```

RemoveContainer() is called before a VM is created and after a VM is
deleted. This results in warning logs with container or task not found
for the basic operations even when nothing wrong happened. The warning
could be misleading. Move the `not found` logs in RemoveContainer() to
debug level to avoid such confusion.

Maybe consider doing the same for all other `not found` errors in the runtime clients?