### PR TITLE
Add loading credentials from docker cli config

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -62,6 +62,45 @@ INFO[0002] Created image with ID "cae0ac317cca74ba" and name "weaveworks/ignite-
 
 Now the `weaveworks/ignite-ubuntu` image is imported and ready for VM use.
 
+### Configuring image registries
+
+Ignite's runtime configuration for image registry uses the docker client
+configuration. To add a new registry to docker client configuration, run
+`docker login <registry-address>`. This will create `$HOME/.docker/config.json`
+in the user's home directory. When ignite runs, it'll check the user's home
+directory for docker client configuration file, load the registry configuration
+if found and use it.
+
+An example of a docker client configuration file:
+
+```json
+
+{
+        "auths": {
+                "https://index.docker.io/v1/": {
+                        "auth": "<token>"
+                },
+                "gcr.io": {
+                        "auth": "<token>"
+                }
+        }
+}
+```
+
+The value of token is based on the registry provider. For `index.docker.io`,
+the token is a base64 encoded value of `<username>:<auth-token>`. For `gcr.io`,
+it's a [json key][json-key] file. Using docker
+[credential helpers][credential-helpers] also works but please ensure that the
+required credential helper program is installed to handle the credentials. If
+the docker client configuration contains `"credHelpers"` block, but the
+associated helper program isn't installed or not configured properly, ignite
+image pull will fail with errors related to the specific credential helper. In
+presence of both auth tokens and credential helpers in a configuration file,
+credential helper takes precedence.
+
+[json-key]: https://cloud.google.com/container-registry/docs/advanced-authentication#json-key
+[credential-helpers]: https://docs.docker.com/engine/reference/commandline/login/#credential-helpers
+
 ## Creating a new VM based on the imported image
 
 The `images` are read-only references of what every VM based on them should contain.

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/containernetworking/plugins v0.8.7
 	github.com/containers/image v3.0.2+incompatible
 	github.com/coreos/go-iptables v0.4.5
+	github.com/docker/cli v0.0.0-20200130152716-5d0cf8839492
 	github.com/docker/docker v20.10.6+incompatible
 	github.com/docker/go-connections v0.4.0
 	github.com/firecracker-microvm/firecracker-go-sdk v0.22.0

--- a/go.sum
+++ b/go.sum
@@ -263,6 +263,7 @@ github.com/dgrijalva/jwt-go v0.0.0-20170104182250-a601269ab70c/go.mod h1:E3ru+11
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
+github.com/docker/cli v0.0.0-20200130152716-5d0cf8839492 h1:FwssHbCDJD025h+BchanCwE1Q8fyMgqDr2mOQAWOLGw=
 github.com/docker/cli v0.0.0-20200130152716-5d0cf8839492/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/distribution v0.0.0-20190711223531-1fb7fffdb266 h1:6BCth6L0iZKTU3F0OxqlkECwdmUDLbHdD9qz6HXlpb4=
 github.com/docker/distribution v0.0.0-20190711223531-1fb7fffdb266/go.mod h1:0+TTO4EOBfRPhZXAeF1Vu+W3hHZ8eLp8PgKVZlcvtFY=
@@ -270,6 +271,7 @@ github.com/docker/docker v0.7.3-0.20190327010347-be7ac8be2ae0/go.mod h1:eEKB0N0r
 github.com/docker/docker v1.4.2-0.20200203170920-46ec8731fbce/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker v20.10.6+incompatible h1:oXI3Vas8TI8Eu/EjH4srKHJBVqraSzJybhxY7Om9faQ=
 github.com/docker/docker v20.10.6+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker-credential-helpers v0.6.3 h1:zI2p9+1NQYdnG6sMU26EX4aVGlqbInSQxQXLvzJ4RPQ=
 github.com/docker/docker-credential-helpers v0.6.3/go.mod h1:WRaJzqw3CTB9bk10avuGsjVBZsD05qeibJ1/TYlvc0Y=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=

--- a/pkg/runtime/auth/auth.go
+++ b/pkg/runtime/auth/auth.go
@@ -1,0 +1,97 @@
+package auth
+
+import (
+	"fmt"
+
+	"github.com/containerd/containerd/remotes/docker"
+	dockercliconfig "github.com/docker/cli/cli/config"
+	"github.com/docker/cli/cli/config/credentials"
+	dockercliconfigtypes "github.com/docker/cli/cli/config/types"
+	log "github.com/sirupsen/logrus"
+)
+
+// NOTE: This file is based on nerdctl's dockerconfigresolver.
+// Refer: https://github.com/containerd/nerdctl/blob/v0.8.1/pkg/imgutil/dockerconfigresolver/dockerconfigresolver.go
+
+// AuthCreds is for docker.WithAuthCreds used in containerd remote resolver.
+type AuthCreds func(string) (string, string, error)
+
+// NewAuthCreds returns an AuthCreds which loads the credentials from the
+// docker client config.
+func NewAuthCreds(refHostname string) (AuthCreds, error) {
+	// Load does not raise an error on ENOENT
+	dockerConfigFile, err := dockercliconfig.Load("")
+	if err != nil {
+		return nil, err
+	}
+
+	// DefaultHost converts "docker.io" to "registry-1.docker.io",
+	// which is wanted  by credFunc .
+	credFuncExpectedHostname, err := docker.DefaultHost(refHostname)
+	if err != nil {
+		return nil, err
+	}
+
+	var credFunc AuthCreds
+
+	authConfigHostnames := []string{refHostname}
+	if refHostname == "docker.io" || refHostname == "registry-1.docker.io" {
+		// "docker.io" appears as ""https://index.docker.io/v1/" in ~/.docker/config.json .
+		// GetAuthConfig takes the hostname part as the argument: "index.docker.io"
+		authConfigHostnames = append([]string{"index.docker.io"}, refHostname)
+	}
+
+	for _, authConfigHostname := range authConfigHostnames {
+		// GetAuthConfig does not raise an error on ENOENT
+		ac, err := dockerConfigFile.GetAuthConfig(authConfigHostname)
+		if err != nil {
+			log.Errorf("cannot get auth config for authConfigHostname=%q (refHostname=%q): %v",
+				authConfigHostname, refHostname, err)
+		} else {
+			// When refHostname is "docker.io":
+			// - credFuncExpectedHostname: "registry-1.docker.io"
+			// - credFuncArg:              "registry-1.docker.io"
+			// - authConfigHostname:       "index.docker.io"
+			// - ac.ServerAddress:         "https://index.docker.io/v1/".
+			if !isAuthConfigEmpty(ac) {
+				if ac.ServerAddress == "" {
+					log.Warnf("failed to get ac.ServerAddress for authConfigHostname=%q (refHostname=%q)",
+						authConfigHostname, refHostname)
+				} else {
+					acsaHostname := credentials.ConvertToHostname(ac.ServerAddress)
+					if acsaHostname != authConfigHostname {
+						return nil, fmt.Errorf("expected the hostname part of ac.ServerAddress (%q) to be authConfigHostname=%q, got %q",
+							ac.ServerAddress, authConfigHostname, acsaHostname)
+					}
+				}
+
+				// if ac.RegistryToken != "" {
+				//     // Even containerd/CRI does not support RegistryToken as of v1.4.3,
+				//     // so, nobody is actually using RegistryToken?
+				//     log.Warnf("ac.RegistryToken (for %q) is not supported yet (FIXME)", authConfigHostname)
+				// }
+
+				credFunc = func(credFuncArg string) (string, string, error) {
+					if credFuncArg != credFuncExpectedHostname {
+						return "", "", fmt.Errorf("expected credFuncExpectedHostname=%q (refHostname=%q), got credFuncArg=%q",
+							credFuncExpectedHostname, refHostname, credFuncArg)
+					}
+					if ac.IdentityToken != "" {
+						return "", ac.IdentityToken, nil
+					}
+					return ac.Username, ac.Password, nil
+				}
+				break
+			}
+		}
+	}
+	// credFunc can be nil here.
+	return credFunc, nil
+}
+
+func isAuthConfigEmpty(ac dockercliconfigtypes.AuthConfig) bool {
+	if ac.IdentityToken != "" || ac.Username != "" || ac.Password != "" || ac.RegistryToken != "" {
+		return false
+	}
+	return true
+}

--- a/vendor/github.com/docker/cli/AUTHORS
+++ b/vendor/github.com/docker/cli/AUTHORS
@@ -1,0 +1,723 @@
+# This file lists all individuals having contributed content to the repository.
+# For how it is generated, see `scripts/docs/generate-authors.sh`.
+
+Aanand Prasad <aanand.prasad@gmail.com>
+Aaron L. Xu <liker.xu@foxmail.com>
+Aaron Lehmann <aaron.lehmann@docker.com>
+Aaron.L.Xu <likexu@harmonycloud.cn>
+Abdur Rehman <abdur_rehman@mentor.com>
+Abhinandan Prativadi <abhi@docker.com>
+Abin Shahab <ashahab@altiscale.com>
+Ace Tang <aceapril@126.com>
+Addam Hardy <addam.hardy@gmail.com>
+Adolfo Ochagavía <aochagavia92@gmail.com>
+Adrian Plata <adrian.plata@docker.com>
+Adrien Duermael <adrien@duermael.com>
+Adrien Folie <folie.adrien@gmail.com>
+Ahmet Alp Balkan <ahmetb@microsoft.com>
+Aidan Feldman <aidan.feldman@gmail.com>
+Aidan Hobson Sayers <aidanhs@cantab.net>
+AJ Bowen <aj@gandi.net>
+Akihiro Suda <suda.akihiro@lab.ntt.co.jp>
+Akim Demaille <akim.demaille@docker.com>
+Alan Thompson <cloojure@gmail.com>
+Albert Callarisa <shark234@gmail.com>
+Aleksa Sarai <asarai@suse.de>
+Alessandro Boch <aboch@tetrationanalytics.com>
+Alex Mavrogiannis <alex.mavrogiannis@docker.com>
+Alex Mayer <amayer5125@gmail.com>
+Alexander Boyd <alex@opengroove.org>
+Alexander Larsson <alexl@redhat.com>
+Alexander Morozov <lk4d4@docker.com>
+Alexander Ryabov <i@sepa.spb.ru>
+Alexandre González <agonzalezro@gmail.com>
+Alfred Landrum <alfred.landrum@docker.com>
+Alicia Lauerman <alicia@eta.im>
+Allen Sun <allensun.shl@alibaba-inc.com>
+Alvin Deng <alvin.q.deng@utexas.edu>
+Amen Belayneh <amenbelayneh@gmail.com>
+Amir Goldstein <amir73il@aquasec.com>
+Amit Krishnan <amit.krishnan@oracle.com>
+Amit Shukla <amit.shukla@docker.com>
+Amy Lindburg <amy.lindburg@docker.com>
+Anda Xu <anda.xu@docker.com>
+Andrea Luzzardi <aluzzardi@gmail.com>
+Andreas Köhler <andi5.py@gmx.net>
+Andrew France <andrew@avito.co.uk>
+Andrew Hsu <andrewhsu@docker.com>
+Andrew Macpherson <hopscotch23@gmail.com>
+Andrew McDonnell <bugs@andrewmcdonnell.net>
+Andrew Po <absourd.noise@gmail.com>
+Andrey Petrov <andrey.petrov@shazow.net>
+André Martins <aanm90@gmail.com>
+Andy Goldstein <agoldste@redhat.com>
+Andy Rothfusz <github@developersupport.net>
+Anil Madhavapeddy <anil@recoil.org>
+Ankush Agarwal <ankushagarwal11@gmail.com>
+Anne Henmi <anne.henmi@docker.com>
+Anton Polonskiy <anton.polonskiy@gmail.com>
+Antonio Murdaca <antonio.murdaca@gmail.com>
+Antonis Kalipetis <akalipetis@gmail.com>
+Anusha Ragunathan <anusha.ragunathan@docker.com>
+Ao Li <la9249@163.com>
+Arash Deshmeh <adeshmeh@ca.ibm.com>
+Arnaud Porterie <arnaud.porterie@docker.com>
+Ashwini Oruganti <ashwini.oruganti@gmail.com>
+Azat Khuyiyakhmetov <shadow_uz@mail.ru>
+Bardia Keyoumarsi <bkeyouma@ucsc.edu>
+Barnaby Gray <barnaby@pickle.me.uk>
+Bastiaan Bakker <bbakker@xebia.com>
+BastianHofmann <bastianhofmann@me.com>
+Ben Bonnefoy <frenchben@docker.com>
+Ben Creasy <ben@bencreasy.com>
+Ben Firshman <ben@firshman.co.uk>
+Benjamin Boudreau <boudreau.benjamin@gmail.com>
+Benoit Sigoure <tsunanet@gmail.com>
+Bhumika Bayani <bhumikabayani@gmail.com>
+Bill Wang <ozbillwang@gmail.com>
+Bin Liu <liubin0329@gmail.com>
+Bingshen Wang <bingshen.wbs@alibaba-inc.com>
+Boaz Shuster <ripcurld.github@gmail.com>
+Bogdan Anton <contact@bogdananton.ro>
+Boris Pruessmann <boris@pruessmann.org>
+Bradley Cicenas <bradley.cicenas@gmail.com>
+Brandon Mitchell <git@bmitch.net>
+Brandon Philips <brandon.philips@coreos.com>
+Brent Salisbury <brent.salisbury@docker.com>
+Bret Fisher <bret@bretfisher.com>
+Brian (bex) Exelbierd <bexelbie@redhat.com>
+Brian Goff <cpuguy83@gmail.com>
+Bryan Bess <squarejaw@bsbess.com>
+Bryan Boreham <bjboreham@gmail.com>
+Bryan Murphy <bmurphy1976@gmail.com>
+bryfry <bryon.fryer@gmail.com>
+Cameron Spear <cameronspear@gmail.com>
+Cao Weiwei <cao.weiwei30@zte.com.cn>
+Carlo Mion <mion00@gmail.com>
+Carlos Alexandro Becker <caarlos0@gmail.com>
+Ce Gao <ce.gao@outlook.com>
+Cedric Davies <cedricda@microsoft.com>
+Cezar Sa Espinola <cezarsa@gmail.com>
+Chad Faragher <wyckster@hotmail.com>
+Chao Wang <wangchao.fnst@cn.fujitsu.com>
+Charles Chan <charleswhchan@users.noreply.github.com>
+Charles Law <claw@conduce.com>
+Charles Smith <charles.smith@docker.com>
+Charlie Drage <charlie@charliedrage.com>
+ChaYoung You <yousbe@gmail.com>
+Chen Chuanliang <chen.chuanliang@zte.com.cn>
+Chen Hanxiao <chenhanxiao@cn.fujitsu.com>
+Chen Mingjie <chenmingjie0828@163.com>
+Chen Qiu <cheney-90@hotmail.com>
+Chris Gavin <chris@chrisgavin.me>
+Chris Gibson <chris@chrisg.io>
+Chris McKinnel <chrismckinnel@gmail.com>
+Chris Snow <chsnow123@gmail.com>
+Chris Weyl <cweyl@alumni.drew.edu>
+Christian Persson <saser@live.se>
+Christian Stefanescu <st.chris@gmail.com>
+Christophe Robin <crobin@nekoo.com>
+Christophe Vidal <kriss@krizalys.com>
+Christopher Biscardi <biscarch@sketcht.com>
+Christopher Crone <christopher.crone@docker.com>
+Christopher Jones <tophj@linux.vnet.ibm.com>
+Christy Norman <christy@linux.vnet.ibm.com>
+Chun Chen <ramichen@tencent.com>
+Clinton Kitson <clintonskitson@gmail.com>
+Coenraad Loubser <coenraad@wish.org.za>
+Colin Hebert <hebert.colin@gmail.com>
+Collin Guarino <collin.guarino@gmail.com>
+Colm Hally <colmhally@gmail.com>
+Corey Farrell <git@cfware.com>
+Corey Quon <corey.quon@docker.com>
+Craig Wilhite <crwilhit@microsoft.com>
+Cristian Staretu <cristian.staretu@gmail.com>
+Daehyeok Mun <daehyeok@gmail.com>
+Dafydd Crosby <dtcrsby@gmail.com>
+dalanlan <dalanlan925@gmail.com>
+Damien Nadé <github@livna.org>
+Dan Cotora <dan@bluevision.ro>
+Daniel Cassidy <mail@danielcassidy.me.uk>
+Daniel Dao <dqminh@cloudflare.com>
+Daniel Farrell <dfarrell@redhat.com>
+Daniel Gasienica <daniel@gasienica.ch>
+Daniel Goosen <daniel.goosen@surveysampling.com>
+Daniel Hiltgen <daniel.hiltgen@docker.com>
+Daniel J Walsh <dwalsh@redhat.com>
+Daniel Nephin <dnephin@docker.com>
+Daniel Norberg <dano@spotify.com>
+Daniel Watkins <daniel@daniel-watkins.co.uk>
+Daniel Zhang <jmzwcn@gmail.com>
+Danny Berger <dpb587@gmail.com>
+Darren Shepherd <darren.s.shepherd@gmail.com>
+Darren Stahl <darst@microsoft.com>
+Dattatraya Kumbhar <dattatraya.kumbhar@gslab.com>
+Dave Goodchild <buddhamagnet@gmail.com>
+Dave Henderson <dhenderson@gmail.com>
+Dave Tucker <dt@docker.com>
+David Beitey <david@davidjb.com>
+David Calavera <david.calavera@gmail.com>
+David Cramer <davcrame@cisco.com>
+David Dooling <dooling@gmail.com>
+David Gageot <david@gageot.net>
+David Lechner <david@lechnology.com>
+David Scott <dave@recoil.org>
+David Sheets <dsheets@docker.com>
+David Williamson <david.williamson@docker.com>
+David Xia <dxia@spotify.com>
+David Young <yangboh@cn.ibm.com>
+Deng Guangxing <dengguangxing@huawei.com>
+Denis Defreyne <denis@soundcloud.com>
+Denis Gladkikh <denis@gladkikh.email>
+Denis Ollier <larchunix@users.noreply.github.com>
+Dennis Docter <dennis@d23.nl>
+Derek McGowan <derek@mcgstyle.net>
+Deshi Xiao <dxiao@redhat.com>
+Dharmit Shah <shahdharmit@gmail.com>
+Dhawal Yogesh Bhanushali <dbhanushali@vmware.com>
+Dieter Reuter <dieter.reuter@me.com>
+Dima Stopel <dima@twistlock.com>
+Dimitry Andric <d.andric@activevideo.com>
+Ding Fei <dingfei@stars.org.cn>
+Diogo Monica <diogo@docker.com>
+Dmitry Gusev <dmitry.gusev@gmail.com>
+Dmitry Smirnov <onlyjob@member.fsf.org>
+Dmitry V. Krivenok <krivenok.dmitry@gmail.com>
+Don Kjer <don.kjer@gmail.com>
+Dong Chen <dongluo.chen@docker.com>
+Doug Davis <dug@us.ibm.com>
+Drew Erny <drew.erny@docker.com>
+Ed Costello <epc@epcostello.com>
+Elango Sivanandam <elango.siva@docker.com>
+Eli Uriegas <eli.uriegas@docker.com>
+Eli Uriegas <seemethere101@gmail.com>
+Elias Faxö <elias.faxo@tre.se>
+Elliot Luo <956941328@qq.com>
+Eric Curtin <ericcurtin17@gmail.com>
+Eric G. Noriega <enoriega@vizuri.com>
+Eric Rosenberg <ehaydenr@gmail.com>
+Eric Sage <eric.david.sage@gmail.com>
+Eric-Olivier Lamey <eo@lamey.me>
+Erica Windisch <erica@windisch.us>
+Erik Hollensbe <github@hollensbe.org>
+Erik St. Martin <alakriti@gmail.com>
+Essam A. Hassan <es.hassan187@gmail.com>
+Ethan Haynes <ethanhaynes@alumni.harvard.edu>
+Euan Kemp <euank@euank.com>
+Eugene Yakubovich <eugene.yakubovich@coreos.com>
+Evan Allrich <evan@unguku.com>
+Evan Hazlett <ejhazlett@gmail.com>
+Evan Krall <krall@yelp.com>
+Evelyn Xu <evelynhsu21@gmail.com>
+Everett Toews <everett.toews@rackspace.com>
+Fabio Falci <fabiofalci@gmail.com>
+Fabrizio Soppelsa <fsoppelsa@mirantis.com>
+Felix Hupfeld <felix@quobyte.com>
+Felix Rabe <felix@rabe.io>
+Filip Jareš <filipjares@gmail.com>
+Flavio Crisciani <flavio.crisciani@docker.com>
+Florian Klein <florian.klein@free.fr>
+Forest Johnson <fjohnson@peoplenetonline.com>
+Foysal Iqbal <foysal.iqbal.fb@gmail.com>
+François Scala <francois.scala@swiss-as.com>
+Fred Lifton <fred.lifton@docker.com>
+Frederic Hemberger <mail@frederic-hemberger.de>
+Frederick F. Kautz IV <fkautz@redhat.com>
+Frederik Nordahl Jul Sabroe <frederikns@gmail.com>
+Frieder Bluemle <frieder.bluemle@gmail.com>
+Gabriel Nicolas Avellaneda <avellaneda.gabriel@gmail.com>
+Gaetan de Villele <gdevillele@gmail.com>
+Gang Qiao <qiaohai8866@gmail.com>
+Gary Schaetz <gary@schaetzkc.com>
+Genki Takiuchi <genki@s21g.com>
+George MacRorie <gmacr31@gmail.com>
+George Xie <georgexsh@gmail.com>
+Gianluca Borello <g.borello@gmail.com>
+Gildas Cuisinier <gildas.cuisinier@gcuisinier.net>
+Goksu Toprak <goksu.toprak@docker.com>
+Gou Rao <gou@portworx.com>
+Grant Reaber <grant.reaber@gmail.com>
+Greg Pflaum <gpflaum@users.noreply.github.com>
+Guilhem Lettron <guilhem+github@lettron.fr>
+Guillaume J. Charmes <guillaume.charmes@docker.com>
+Guillaume Le Floch <glfloch@gmail.com>
+gwx296173 <gaojing3@huawei.com>
+Günther Jungbluth <gunther@gameslabs.net>
+Hakan Özler <hakan.ozler@kodcu.com>
+Hao Zhang <21521210@zju.edu.cn>
+Harald Albers <github@albersweb.de>
+Harold Cooper <hrldcpr@gmail.com>
+Harry Zhang <harryz@hyper.sh>
+He Simei <hesimei@zju.edu.cn>
+Helen Xie <chenjg@harmonycloud.cn>
+Henning Sprang <henning.sprang@gmail.com>
+Henry N <henrynmail-github@yahoo.de>
+Hernan Garcia <hernandanielg@gmail.com>
+Hongbin Lu <hongbin034@gmail.com>
+Hu Keping <hukeping@huawei.com>
+Huayi Zhang <irachex@gmail.com>
+huqun <huqun@zju.edu.cn>
+Huu Nguyen <huu@prismskylabs.com>
+Hyzhou Zhy <hyzhou.zhy@alibaba-inc.com>
+Ian Campbell <ian.campbell@docker.com>
+Ian Philpot <ian.philpot@microsoft.com>
+Ignacio Capurro <icapurrofagian@gmail.com>
+Ilya Dmitrichenko <errordeveloper@gmail.com>
+Ilya Khlopotov <ilya.khlopotov@gmail.com>
+Ilya Sotkov <ilya@sotkov.com>
+Ioan Eugen Stan <eu@ieugen.ro>
+Isabel Jimenez <contact.isabeljimenez@gmail.com>
+Ivan Grcic <igrcic@gmail.com>
+Ivan Markin <sw@nogoegst.net>
+Jacob Atzen <jacob@jacobatzen.dk>
+Jacob Tomlinson <jacob@tom.linson.uk>
+Jaivish Kothari <janonymous.codevulture@gmail.com>
+Jake Lambert <jake.lambert@volusion.com>
+Jake Sanders <jsand@google.com>
+James Nesbitt <james.nesbitt@wunderkraut.com>
+James Turnbull <james@lovedthanlost.net>
+Jamie Hannaford <jamie@limetree.org>
+Jan Koprowski <jan.koprowski@gmail.com>
+Jan Pazdziora <jpazdziora@redhat.com>
+Jan-Jaap Driessen <janjaapdriessen@gmail.com>
+Jana Radhakrishnan <mrjana@docker.com>
+Jared Hocutt <jaredh@netapp.com>
+Jasmine Hegman <jasmine@jhegman.com>
+Jason Heiss <jheiss@aput.net>
+Jason Plum <jplum@devonit.com>
+Jay Kamat <github@jgkamat.33mail.com>
+Jean Rouge <rougej+github@gmail.com>
+Jean-Christophe Sirot <jean-christophe.sirot@docker.com>
+Jean-Pierre Huynh <jean-pierre.huynh@ounet.fr>
+Jeff Lindsay <progrium@gmail.com>
+Jeff Nickoloff <jeff.nickoloff@gmail.com>
+Jeff Silberman <jsilberm@gmail.com>
+Jeremy Chambers <jeremy@thehipbot.com>
+Jeremy Unruh <jeremybunruh@gmail.com>
+Jeremy Yallop <yallop@docker.com>
+Jeroen Franse <jeroenfranse@gmail.com>
+Jesse Adametz <jesseadametz@gmail.com>
+Jessica Frazelle <jessfraz@google.com>
+Jezeniel Zapanta <jpzapanta22@gmail.com>
+Jian Zhang <zhangjian.fnst@cn.fujitsu.com>
+Jie Luo <luo612@zju.edu.cn>
+Jilles Oldenbeuving <ojilles@gmail.com>
+Jim Galasyn <jim.galasyn@docker.com>
+Jimmy Leger <jimmy.leger@gmail.com>
+Jimmy Song <rootsongjc@gmail.com>
+jimmyxian <jimmyxian2004@yahoo.com.cn>
+Jintao Zhang <zhangjintao9020@gmail.com>
+Joao Fernandes <joao.fernandes@docker.com>
+Joe Doliner <jdoliner@pachyderm.io>
+Joe Gordon <joe.gordon0@gmail.com>
+Joel Handwell <joelhandwell@gmail.com>
+Joey Geiger <jgeiger@gmail.com>
+Joffrey F <joffrey@docker.com>
+Johan Euphrosine <proppy@google.com>
+Johannes 'fish' Ziemke <github@freigeist.org>
+John Feminella <jxf@jxf.me>
+John Harris <john@johnharris.io>
+John Howard (VM) <John.Howard@microsoft.com>
+John Laswell <john.n.laswell@gmail.com>
+John Maguire <jmaguire@duosecurity.com>
+John Mulhausen <john@docker.com>
+John Starks <jostarks@microsoft.com>
+John Stephens <johnstep@docker.com>
+John Tims <john.k.tims@gmail.com>
+John V. Martinez <jvmatl@gmail.com>
+John Willis <john.willis@docker.com>
+Jonathan Boulle <jonathanboulle@gmail.com>
+Jonathan Lee <jonjohn1232009@gmail.com>
+Jonathan Lomas <jonathan@floatinglomas.ca>
+Jonathan McCrohan <jmccrohan@gmail.com>
+Jonh Wendell <jonh.wendell@redhat.com>
+Jordan Jennings <jjn2009@gmail.com>
+Joseph Kern <jkern@semafour.net>
+Josh Bodah <jb3689@yahoo.com>
+Josh Chorlton <jchorlton@gmail.com>
+Josh Hawn <josh.hawn@docker.com>
+Josh Horwitz <horwitz@addthis.com>
+Josh Soref <jsoref@gmail.com>
+Julien Barbier <write0@gmail.com>
+Julien Kassar <github@kassisol.com>
+Julien Maitrehenry <julien.maitrehenry@me.com>
+Justas Brazauskas <brazauskasjustas@gmail.com>
+Justin Cormack <justin.cormack@docker.com>
+Justin Simonelis <justin.p.simonelis@gmail.com>
+Justyn Temme <justyntemme@gmail.com>
+Jyrki Puttonen <jyrkiput@gmail.com>
+Jérémie Drouet <jeremie.drouet@gmail.com>
+Jérôme Petazzoni <jerome.petazzoni@docker.com>
+Jörg Thalheim <joerg@higgsboson.tk>
+Kai Blin <kai@samba.org>
+Kai Qiang Wu (Kennan) <wkq5325@gmail.com>
+Kara Alexandra <kalexandra@us.ibm.com>
+Kareem Khazem <karkhaz@karkhaz.com>
+Karthik Nayak <Karthik.188@gmail.com>
+Kat Samperi <kat.samperi@gmail.com>
+Kathryn Spiers <kathryn@spiers.me>
+Katie McLaughlin <katie@glasnt.com>
+Ke Xu <leonhartx.k@gmail.com>
+Kei Ohmura <ohmura.kei@gmail.com>
+Keith Hudgins <greenman@greenman.org>
+Ken Cochrane <kencochrane@gmail.com>
+Ken ICHIKAWA <ichikawa.ken@jp.fujitsu.com>
+Kenfe-Mickaël Laventure <mickael.laventure@gmail.com>
+Kevin Burke <kev@inburke.com>
+Kevin Feyrer <kevin.feyrer@btinternet.com>
+Kevin Kern <kaiwentan@harmonycloud.cn>
+Kevin Kirsche <Kev.Kirsche+GitHub@gmail.com>
+Kevin Meredith <kevin.m.meredith@gmail.com>
+Kevin Richardson <kevin@kevinrichardson.co>
+khaled souf <khaled.souf@gmail.com>
+Kim Eik <kim@heldig.org>
+Kir Kolyshkin <kolyshkin@gmail.com>
+Kotaro Yoshimatsu <kotaro.yoshimatsu@gmail.com>
+Krasi Georgiev <krasi@vip-consult.solutions>
+Kris-Mikael Krister <krismikael@protonmail.com>
+Kun Zhang <zkazure@gmail.com>
+Kunal Kushwaha <kushwaha_kunal_v7@lab.ntt.co.jp>
+Lachlan Cooper <lachlancooper@gmail.com>
+Lai Jiangshan <jiangshanlai@gmail.com>
+Lars Kellogg-Stedman <lars@redhat.com>
+Laura Frank <ljfrank@gmail.com>
+Laurent Erignoux <lerignoux@gmail.com>
+Lee Gaines <eightlimbed@gmail.com>
+Lei Jitang <leijitang@huawei.com>
+Lennie <github@consolejunkie.net>
+Leo Gallucci <elgalu3@gmail.com>
+Lewis Daly <lewisdaly@me.com>
+Li Yi <denverdino@gmail.com>
+Li Yi <weiyuan.yl@alibaba-inc.com>
+Liang-Chi Hsieh <viirya@gmail.com>
+Lifubang <lifubang@acmcoder.com>
+Lihua Tang <lhtang@alauda.io>
+Lily Guo <lily.guo@docker.com>
+Lin Lu <doraalin@163.com>
+Linus Heckemann <lheckemann@twig-world.com>
+Liping Xue <lipingxue@gmail.com>
+Liron Levin <liron@twistlock.com>
+liwenqi <vikilwq@zju.edu.cn>
+lixiaobing10051267 <li.xiaobing1@zte.com.cn>
+Lloyd Dewolf <foolswisdom@gmail.com>
+Lorenzo Fontana <lo@linux.com>
+Louis Opter <kalessin@kalessin.fr>
+Luca Favatella <luca.favatella@erlang-solutions.com>
+Luca Marturana <lucamarturana@gmail.com>
+Lucas Chan <lucas-github@lucaschan.com>
+Luka Hartwig <mail@lukahartwig.de>
+Lukasz Zajaczkowski <Lukasz.Zajaczkowski@ts.fujitsu.com>
+Lydell Manganti <LydellManganti@users.noreply.github.com>
+Lénaïc Huard <lhuard@amadeus.com>
+Ma Shimiao <mashimiao.fnst@cn.fujitsu.com>
+Mabin <bin.ma@huawei.com>
+Madhav Puri <madhav.puri@gmail.com>
+Madhu Venugopal <madhu@socketplane.io>
+Malte Janduda <mail@janduda.net>
+Manjunath A Kumatagi <mkumatag@in.ibm.com>
+Mansi Nahar <mmn4185@rit.edu>
+mapk0y <mapk0y@gmail.com>
+Marc Bihlmaier <marc.bihlmaier@reddoxx.com>
+Marco Mariani <marco.mariani@alterway.fr>
+Marco Vedovati <mvedovati@suse.com>
+Marcus Martins <marcus@docker.com>
+Marianna Tessel <mtesselh@gmail.com>
+Marius Sturm <marius@graylog.com>
+Mark Oates <fl0yd@me.com>
+Marsh Macy <marsma@microsoft.com>
+Martin Mosegaard Amdisen <martin.amdisen@praqma.com>
+Mary Anthony <mary.anthony@docker.com>
+Mason Fish <mason.fish@docker.com>
+Mason Malone <mason.malone@gmail.com>
+Mateusz Major <apkd@users.noreply.github.com>
+Mathieu Champlon <mathieu.champlon@docker.com>
+Matt Gucci <matt9ucci@gmail.com>
+Matt Robenolt <matt@ydekproductions.com>
+Matteo Orefice <matteo.orefice@bites4bits.software>
+Matthew Heon <mheon@redhat.com>
+Matthieu Hauglustaine <matt.hauglustaine@gmail.com>
+Mauro Porras P <mauroporrasp@gmail.com>
+Max Shytikov <mshytikov@gmail.com>
+Maxime Petazzoni <max@signalfuse.com>
+Mei ChunTao <mei.chuntao@zte.com.cn>
+Micah Zoltu <micah@newrelic.com>
+Michael A. Smith <michael@smith-li.com>
+Michael Bridgen <mikeb@squaremobius.net>
+Michael Crosby <michael@docker.com>
+Michael Friis <friism@gmail.com>
+Michael Irwin <mikesir87@gmail.com>
+Michael Käufl <docker@c.michael-kaeufl.de>
+Michael Prokop <github@michael-prokop.at>
+Michael Scharf <github@scharf.gr>
+Michael Spetsiotis <michael_spets@hotmail.com>
+Michael Steinert <mike.steinert@gmail.com>
+Michael West <mwest@mdsol.com>
+Michal Minář <miminar@redhat.com>
+Michał Czeraszkiewicz <czerasz@gmail.com>
+Miguel Angel Alvarez Cabrerizo <doncicuto@gmail.com>
+Mihai Borobocea <MihaiBorob@gmail.com>
+Mihuleacc Sergiu <mihuleac.sergiu@gmail.com>
+Mike Brown <brownwm@us.ibm.com>
+Mike Casas <mkcsas0@gmail.com>
+Mike Danese <mikedanese@google.com>
+Mike Dillon <mike@embody.org>
+Mike Goelzer <mike.goelzer@docker.com>
+Mike MacCana <mike.maccana@gmail.com>
+mikelinjie <294893458@qq.com>
+Mikhail Vasin <vasin@cloud-tv.ru>
+Milind Chawre <milindchawre@gmail.com>
+Mindaugas Rukas <momomg@gmail.com>
+Misty Stanley-Jones <misty@docker.com>
+Mohammad Banikazemi <mb@us.ibm.com>
+Mohammed Aaqib Ansari <maaquib@gmail.com>
+Mohini Anne Dsouza <mohini3917@gmail.com>
+Moorthy RS <rsmoorthy@gmail.com>
+Morgan Bauer <mbauer@us.ibm.com>
+Moysés Borges <moysesb@gmail.com>
+Mrunal Patel <mrunalp@gmail.com>
+muicoder <muicoder@gmail.com>
+Muthukumar R <muthur@gmail.com>
+Máximo Cuadros <mcuadros@gmail.com>
+Mårten Cassel <marten.cassel@gmail.com>
+Nace Oroz <orkica@gmail.com>
+Nahum Shalman <nshalman@omniti.com>
+Nalin Dahyabhai <nalin@redhat.com>
+Nao YONASHIRO <owan.orisano@gmail.com>
+Nassim 'Nass' Eddequiouaq <eddequiouaq.nassim@gmail.com>
+Natalie Parker <nparker@omnifone.com>
+Nate Brennand <nate.brennand@clever.com>
+Nathan Hsieh <hsieh.nathan@gmail.com>
+Nathan LeClaire <nathan.leclaire@docker.com>
+Nathan McCauley <nathan.mccauley@docker.com>
+Neil Peterson <neilpeterson@outlook.com>
+Nick Adcock <nick.adcock@docker.com>
+Nico Stapelbroek <nstapelbroek@gmail.com>
+Nicola Kabar <nicolaka@gmail.com>
+Nicolas Borboën <ponsfrilus@gmail.com>
+Nicolas De Loof <nicolas.deloof@gmail.com>
+Nikhil Chawla <chawlanikhil24@gmail.com>
+Nikolas Garofil <nikolas.garofil@uantwerpen.be>
+Nikolay Milovanov <nmil@itransformers.net>
+Nir Soffer <nsoffer@redhat.com>
+Nishant Totla <nishanttotla@gmail.com>
+NIWA Hideyuki <niwa.niwa@nifty.ne.jp>
+Noah Treuhaft <noah.treuhaft@docker.com>
+O.S. Tezer <ostezer@gmail.com>
+ohmystack <jun.jiang02@ele.me>
+Olle Jonsson <olle.jonsson@gmail.com>
+Olli Janatuinen <olli.janatuinen@gmail.com>
+Otto Kekäläinen <otto@seravo.fi>
+Ovidio Mallo <ovidio.mallo@gmail.com>
+Pascal Borreli <pascal@borreli.com>
+Patrick Böänziger <patrick.baenziger@bsi-software.com>
+Patrick Hemmer <patrick.hemmer@gmail.com>
+Patrick Lang <plang@microsoft.com>
+Paul <paul9869@gmail.com>
+Paul Kehrer <paul.l.kehrer@gmail.com>
+Paul Lietar <paul@lietar.net>
+Paul Weaver <pauweave@cisco.com>
+Pavel Pospisil <pospispa@gmail.com>
+Paweł Szczekutowicz <pszczekutowicz@gmail.com>
+Peeyush Gupta <gpeeyush@linux.vnet.ibm.com>
+Per Lundberg <per.lundberg@ecraft.com>
+Peter Edge <peter.edge@gmail.com>
+Peter Hsu <shhsu@microsoft.com>
+Peter Jaffe <pjaffe@nevo.com>
+Peter Kehl <peter.kehl@gmail.com>
+Peter Nagy <xificurC@gmail.com>
+Peter Salvatore <peter@psftw.com>
+Peter Waller <p@pwaller.net>
+Phil Estes <estesp@linux.vnet.ibm.com>
+Philip Alexander Etling <paetling@gmail.com>
+Philipp Gillé <philipp.gille@gmail.com>
+Philipp Schmied <pschmied@schutzwerk.com>
+pidster <pid@pidster.com>
+pixelistik <pixelistik@users.noreply.github.com>
+Pratik Karki <prertik@outlook.com>
+Prayag Verma <prayag.verma@gmail.com>
+Preston Cowley <preston.cowley@sony.com>
+Pure White <daniel48@126.com>
+Qiang Huang <h.huangqiang@huawei.com>
+Qinglan Peng <qinglanpeng@zju.edu.cn>
+qudongfang <qudongfang@gmail.com>
+Raghavendra K T <raghavendra.kt@linux.vnet.ibm.com>
+Ravi Shekhar Jethani <rsjethani@gmail.com>
+Ray Tsang <rayt@google.com>
+Reficul <xuzhenglun@gmail.com>
+Remy Suen <remy.suen@gmail.com>
+Renaud Gaubert <rgaubert@nvidia.com>
+Ricardo N Feliciano <FelicianoTech@gmail.com>
+Rich Moyse <rich@moyse.us>
+Richard Mathie <richard.mathie@amey.co.uk>
+Richard Scothern <richard.scothern@gmail.com>
+Rick Wieman <git@rickw.nl>
+Ritesh H Shukla <sritesh@vmware.com>
+Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>
+Robert Wallis <smilingrob@gmail.com>
+Robin Naundorf <r.naundorf@fh-muenster.de>
+Robin Speekenbrink <robin@kingsquare.nl>
+Rodolfo Ortiz <rodolfo.ortiz@definityfirst.com>
+Rogelio Canedo <rcanedo@mappy.priv>
+Rohan Verma <hello@rohanverma.net>
+Roland Kammerer <roland.kammerer@linbit.com>
+Roman Dudin <katrmr@gmail.com>
+Rory Hunter <roryhunter2@gmail.com>
+Ross Boucher <rboucher@gmail.com>
+Rubens Figueiredo <r.figueiredo.52@gmail.com>
+Rui Cao <ruicao@alauda.io>
+Ryan Belgrave <rmb1993@gmail.com>
+Ryan Detzel <ryan.detzel@gmail.com>
+Ryan Stelly <ryan.stelly@live.com>
+Ryan Wilson-Perkin <ryanwilsonperkin@gmail.com>
+Ryan Zhang <ryan.zhang@docker.com>
+Sainath Grandhi <sainath.grandhi@intel.com>
+Sakeven Jiang <jc5930@sina.cn>
+Sally O'Malley <somalley@redhat.com>
+Sam Neirinck <sam@samneirinck.com>
+Sambuddha Basu <sambuddhabasu1@gmail.com>
+Sami Tabet <salph.tabet@gmail.com>
+Samuel Karp <skarp@amazon.com>
+Santhosh Manohar <santhosh@docker.com>
+Scott Brenner <scott@scottbrenner.me>
+Scott Collier <emailscottcollier@gmail.com>
+Sean Christopherson <sean.j.christopherson@intel.com>
+Sean Rodman <srodman7689@gmail.com>
+Sebastiaan van Stijn <github@gone.nl>
+Sergey Tryuber <Sergeant007@users.noreply.github.com>
+Serhat Gülçiçek <serhat25@gmail.com>
+Sevki Hasirci <s@sevki.org>
+Shaun Kaasten <shaunk@gmail.com>
+Sheng Yang <sheng@yasker.org>
+Shijiang Wei <mountkin@gmail.com>
+Shishir Mahajan <shishir.mahajan@redhat.com>
+Shoubhik Bose <sbose78@gmail.com>
+Shukui Yang <yangshukui@huawei.com>
+Sian Lerk Lau <kiawin@gmail.com>
+Sidhartha Mani <sidharthamn@gmail.com>
+sidharthamani <sid@rancher.com>
+Silvin Lubecki <silvin.lubecki@docker.com>
+Simei He <hesimei@zju.edu.cn>
+Simon Ferquel <simon.ferquel@docker.com>
+Sindhu S <sindhus@live.in>
+Slava Semushin <semushin@redhat.com>
+Solomon Hykes <solomon@docker.com>
+Song Gao <song@gao.io>
+Spencer Brown <spencer@spencerbrown.org>
+squeegels <1674195+squeegels@users.noreply.github.com>
+Srini Brahmaroutu <srbrahma@us.ibm.com>
+Stefan S. <tronicum@user.github.com>
+Stefan Scherer <stefan.scherer@docker.com>
+Stefan Weil <sw@weilnetz.de>
+Stephane Jeandeaux <stephane.jeandeaux@gmail.com>
+Stephen Day <stevvooe@gmail.com>
+Stephen Rust <srust@blockbridge.com>
+Steve Durrheimer <s.durrheimer@gmail.com>
+Steve Richards <steve.richards@docker.com>
+Steven Burgess <steven.a.burgess@hotmail.com>
+Subhajit Ghosh <isubuz.g@gmail.com>
+Sun Jianbo <wonderflow.sun@gmail.com>
+Sune Keller <absukl@almbrand.dk>
+Sungwon Han <sungwon.han@navercorp.com>
+Sunny Gogoi <indiasuny000@gmail.com>
+Sven Dowideit <SvenDowideit@home.org.au>
+Sylvain Baubeau <sbaubeau@redhat.com>
+Sébastien HOUZÉ <cto@verylastroom.com>
+T K Sourabh <sourabhtk37@gmail.com>
+TAGOMORI Satoshi <tagomoris@gmail.com>
+taiji-tech <csuhqg@foxmail.com>
+Taylor Jones <monitorjbl@gmail.com>
+Tejaswini Duggaraju <naduggar@microsoft.com>
+Thatcher Peskens <thatcher@docker.com>
+Thomas Gazagnaire <thomas@gazagnaire.org>
+Thomas Krzero <thomas.kovatchitch@gmail.com>
+Thomas Leonard <thomas.leonard@docker.com>
+Thomas Léveil <thomasleveil@gmail.com>
+Thomas Riccardi <thomas@deepomatic.com>
+Thomas Swift <tgs242@gmail.com>
+Tianon Gravi <admwiggin@gmail.com>
+Tianyi Wang <capkurmagati@gmail.com>
+Tibor Vass <teabee89@gmail.com>
+Tim Dettrick <t.dettrick@uq.edu.au>
+Tim Hockin <thockin@google.com>
+Tim Smith <timbot@google.com>
+Tim Waugh <twaugh@redhat.com>
+Tim Wraight <tim.wraight@tangentlabs.co.uk>
+timfeirg <kkcocogogo@gmail.com>
+Timothy Hobbs <timothyhobbs@seznam.cz>
+Tobias Bradtke <webwurst@gmail.com>
+Tobias Gesellchen <tobias@gesellix.de>
+Todd Whiteman <todd.whiteman@joyent.com>
+Tom Denham <tom@tomdee.co.uk>
+Tom Fotherby <tom+github@peopleperhour.com>
+Tom Klingenberg <tklingenberg@lastflood.net>
+Tom Milligan <code@tommilligan.net>
+Tom X. Tobin <tomxtobin@tomxtobin.com>
+Tomas Tomecek <ttomecek@redhat.com>
+Tomasz Kopczynski <tomek@kopczynski.net.pl>
+Tomáš Hrčka <thrcka@redhat.com>
+Tony Abboud <tdabboud@hotmail.com>
+Tõnis Tiigi <tonistiigi@gmail.com>
+Trapier Marshall <trapier.marshall@docker.com>
+Travis Cline <travis.cline@gmail.com>
+Tristan Carel <tristan@cogniteev.com>
+Tycho Andersen <tycho@docker.com>
+Tycho Andersen <tycho@tycho.ws>
+uhayate <uhayate.gong@daocloud.io>
+Ulysses Souza <ulysses.souza@docker.com>
+Umesh Yadav <umesh4257@gmail.com>
+Valentin Lorentz <progval+git@progval.net>
+Veres Lajos <vlajos@gmail.com>
+Victor Vieux <victor.vieux@docker.com>
+Victoria Bialas <victoria.bialas@docker.com>
+Viktor Stanchev <me@viktorstanchev.com>
+Vimal Raghubir <vraghubir0418@gmail.com>
+Vincent Batts <vbatts@redhat.com>
+Vincent Bernat <Vincent.Bernat@exoscale.ch>
+Vincent Demeester <vincent.demeester@docker.com>
+Vincent Woo <me@vincentwoo.com>
+Vishnu Kannan <vishnuk@google.com>
+Vivek Goyal <vgoyal@redhat.com>
+Wang Jie <wangjie5@chinaskycloud.com>
+Wang Lei <wanglei@tenxcloud.com>
+Wang Long <long.wanglong@huawei.com>
+Wang Ping <present.wp@icloud.com>
+Wang Xing <hzwangxing@corp.netease.com>
+Wang Yuexiao <wang.yuexiao@zte.com.cn>
+Wataru Ishida <ishida.wataru@lab.ntt.co.jp>
+Wayne Song <wsong@docker.com>
+Wen Cheng Ma <wenchma@cn.ibm.com>
+Wenzhi Liang <wenzhi.liang@gmail.com>
+Wes Morgan <cap10morgan@gmail.com>
+Wewang Xiaorenfine <wang.xiaoren@zte.com.cn>
+William Henry <whenry@redhat.com>
+Xianglin Gao <xlgao@zju.edu.cn>
+Xiaodong Zhang <a4012017@sina.com>
+Xiaoxi He <xxhe@alauda.io>
+Xinbo Weng <xihuanbo_0521@zju.edu.cn>
+Xuecong Liao <satorulogic@gmail.com>
+Yan Feng <yanfeng2@huawei.com>
+Yanqiang Miao <miao.yanqiang@zte.com.cn>
+Yassine Tijani <yasstij11@gmail.com>
+Yi EungJun <eungjun.yi@navercorp.com>
+Ying Li <ying.li@docker.com>
+Yong Tang <yong.tang.github@outlook.com>
+Yosef Fertel <yfertel@gmail.com>
+Yu Peng <yu.peng36@zte.com.cn>
+Yuan Sun <sunyuan3@huawei.com>
+Yue Zhang <zy675793960@yeah.net>
+Yunxiang Huang <hyxqshk@vip.qq.com>
+Zachary Romero <zacromero3@gmail.com>
+Zander Mackie <zmackie@gmail.com>
+zebrilee <zebrilee@gmail.com>
+Zhang Kun <zkazure@gmail.com>
+Zhang Wei <zhangwei555@huawei.com>
+Zhang Wentao <zhangwentao234@huawei.com>
+ZhangHang <stevezhang2014@gmail.com>
+zhenghenghuo <zhenghenghuo@zju.edu.cn>
+Zhou Hao <zhouhao@cn.fujitsu.com>
+Zhoulin Xie <zhoulin.xie@daocloud.io>
+Zhu Guihua <zhugh.fnst@cn.fujitsu.com>
+Álex González <agonzalezro@gmail.com>
+Álvaro Lázaro <alvaro.lazaro.g@gmail.com>
+Átila Camurça Alves <camurca.home@gmail.com>
+徐俊杰 <paco.xu@daocloud.io>

--- a/vendor/github.com/docker/cli/LICENSE
+++ b/vendor/github.com/docker/cli/LICENSE
@@ -1,0 +1,191 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        https://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2013-2017 Docker, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/docker/cli/NOTICE
+++ b/vendor/github.com/docker/cli/NOTICE
@@ -1,0 +1,19 @@
+Docker
+Copyright 2012-2017 Docker, Inc.
+
+This product includes software developed at Docker, Inc. (https://www.docker.com).
+
+This product contains software (https://github.com/creack/pty) developed
+by Keith Rarick, licensed under the MIT License.
+
+The following is courtesy of our legal counsel:
+
+
+Use and transfer of Docker may be subject to certain restrictions by the
+United States and other governments.
+It is your responsibility to ensure that your use and/or transfer does not
+violate applicable laws.
+
+For more information, please see https://www.bis.doc.gov
+
+See also https://www.apache.org/dev/crypto.html and/or seek legal counsel.

--- a/vendor/github.com/docker/cli/cli/config/config.go
+++ b/vendor/github.com/docker/cli/cli/config/config.go
@@ -1,0 +1,140 @@
+package config
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/docker/cli/cli/config/configfile"
+	"github.com/docker/cli/cli/config/credentials"
+	"github.com/docker/cli/cli/config/types"
+	"github.com/docker/docker/pkg/homedir"
+	"github.com/pkg/errors"
+)
+
+const (
+	// ConfigFileName is the name of config file
+	ConfigFileName = "config.json"
+	configFileDir  = ".docker"
+	oldConfigfile  = ".dockercfg"
+	contextsDir    = "contexts"
+)
+
+var (
+	configDir = os.Getenv("DOCKER_CONFIG")
+)
+
+func init() {
+	if configDir == "" {
+		configDir = filepath.Join(homedir.Get(), configFileDir)
+	}
+}
+
+// Dir returns the directory the configuration file is stored in
+func Dir() string {
+	return configDir
+}
+
+// ContextStoreDir returns the directory the docker contexts are stored in
+func ContextStoreDir() string {
+	return filepath.Join(Dir(), contextsDir)
+}
+
+// SetDir sets the directory the configuration file is stored in
+func SetDir(dir string) {
+	configDir = filepath.Clean(dir)
+}
+
+// Path returns the path to a file relative to the config dir
+func Path(p ...string) (string, error) {
+	path := filepath.Join(append([]string{Dir()}, p...)...)
+	if !strings.HasPrefix(path, Dir()+string(filepath.Separator)) {
+		return "", errors.Errorf("path %q is outside of root config directory %q", path, Dir())
+	}
+	return path, nil
+}
+
+// LegacyLoadFromReader is a convenience function that creates a ConfigFile object from
+// a non-nested reader
+func LegacyLoadFromReader(configData io.Reader) (*configfile.ConfigFile, error) {
+	configFile := configfile.ConfigFile{
+		AuthConfigs: make(map[string]types.AuthConfig),
+	}
+	err := configFile.LegacyLoadFromReader(configData)
+	return &configFile, err
+}
+
+// LoadFromReader is a convenience function that creates a ConfigFile object from
+// a reader
+func LoadFromReader(configData io.Reader) (*configfile.ConfigFile, error) {
+	configFile := configfile.ConfigFile{
+		AuthConfigs: make(map[string]types.AuthConfig),
+	}
+	err := configFile.LoadFromReader(configData)
+	return &configFile, err
+}
+
+// Load reads the configuration files in the given directory, and sets up
+// the auth config information and returns values.
+// FIXME: use the internal golang config parser
+func Load(configDir string) (*configfile.ConfigFile, error) {
+	if configDir == "" {
+		configDir = Dir()
+	}
+
+	filename := filepath.Join(configDir, ConfigFileName)
+	configFile := configfile.New(filename)
+
+	// Try happy path first - latest config file
+	if _, err := os.Stat(filename); err == nil {
+		file, err := os.Open(filename)
+		if err != nil {
+			return configFile, errors.Wrap(err, filename)
+		}
+		defer file.Close()
+		err = configFile.LoadFromReader(file)
+		if err != nil {
+			err = errors.Wrap(err, filename)
+		}
+		return configFile, err
+	} else if !os.IsNotExist(err) {
+		// if file is there but we can't stat it for any reason other
+		// than it doesn't exist then stop
+		return configFile, errors.Wrap(err, filename)
+	}
+
+	// Can't find latest config file so check for the old one
+	homedir, err := os.UserHomeDir()
+	if err != nil {
+		return configFile, errors.Wrap(err, oldConfigfile)
+	}
+	confFile := filepath.Join(homedir, oldConfigfile)
+	if _, err := os.Stat(confFile); err != nil {
+		return configFile, nil // missing file is not an error
+	}
+	file, err := os.Open(confFile)
+	if err != nil {
+		return configFile, errors.Wrap(err, filename)
+	}
+	defer file.Close()
+	err = configFile.LegacyLoadFromReader(file)
+	if err != nil {
+		return configFile, errors.Wrap(err, filename)
+	}
+	return configFile, nil
+}
+
+// LoadDefaultConfigFile attempts to load the default config file and returns
+// an initialized ConfigFile struct if none is found.
+func LoadDefaultConfigFile(stderr io.Writer) *configfile.ConfigFile {
+	configFile, err := Load(Dir())
+	if err != nil {
+		fmt.Fprintf(stderr, "WARNING: Error loading config file: %v\n", err)
+	}
+	if !configFile.ContainsAuth() {
+		configFile.CredentialsStore = credentials.DetectDefaultStore(configFile.CredentialsStore)
+	}
+	return configFile
+}

--- a/vendor/github.com/docker/cli/cli/config/configfile/file.go
+++ b/vendor/github.com/docker/cli/cli/config/configfile/file.go
@@ -1,0 +1,390 @@
+package configfile
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/docker/cli/cli/config/credentials"
+	"github.com/docker/cli/cli/config/types"
+	"github.com/pkg/errors"
+)
+
+const (
+	// This constant is only used for really old config files when the
+	// URL wasn't saved as part of the config file and it was just
+	// assumed to be this value.
+	defaultIndexServer = "https://index.docker.io/v1/"
+)
+
+// ConfigFile ~/.docker/config.json file info
+type ConfigFile struct {
+	AuthConfigs          map[string]types.AuthConfig  `json:"auths"`
+	HTTPHeaders          map[string]string            `json:"HttpHeaders,omitempty"`
+	PsFormat             string                       `json:"psFormat,omitempty"`
+	ImagesFormat         string                       `json:"imagesFormat,omitempty"`
+	NetworksFormat       string                       `json:"networksFormat,omitempty"`
+	PluginsFormat        string                       `json:"pluginsFormat,omitempty"`
+	VolumesFormat        string                       `json:"volumesFormat,omitempty"`
+	StatsFormat          string                       `json:"statsFormat,omitempty"`
+	DetachKeys           string                       `json:"detachKeys,omitempty"`
+	CredentialsStore     string                       `json:"credsStore,omitempty"`
+	CredentialHelpers    map[string]string            `json:"credHelpers,omitempty"`
+	Filename             string                       `json:"-"` // Note: for internal use only
+	ServiceInspectFormat string                       `json:"serviceInspectFormat,omitempty"`
+	ServicesFormat       string                       `json:"servicesFormat,omitempty"`
+	TasksFormat          string                       `json:"tasksFormat,omitempty"`
+	SecretFormat         string                       `json:"secretFormat,omitempty"`
+	ConfigFormat         string                       `json:"configFormat,omitempty"`
+	NodesFormat          string                       `json:"nodesFormat,omitempty"`
+	PruneFilters         []string                     `json:"pruneFilters,omitempty"`
+	Proxies              map[string]ProxyConfig       `json:"proxies,omitempty"`
+	Experimental         string                       `json:"experimental,omitempty"`
+	StackOrchestrator    string                       `json:"stackOrchestrator,omitempty"`
+	Kubernetes           *KubernetesConfig            `json:"kubernetes,omitempty"`
+	CurrentContext       string                       `json:"currentContext,omitempty"`
+	CLIPluginsExtraDirs  []string                     `json:"cliPluginsExtraDirs,omitempty"`
+	Plugins              map[string]map[string]string `json:"plugins,omitempty"`
+	Aliases              map[string]string            `json:"aliases,omitempty"`
+}
+
+// ProxyConfig contains proxy configuration settings
+type ProxyConfig struct {
+	HTTPProxy  string `json:"httpProxy,omitempty"`
+	HTTPSProxy string `json:"httpsProxy,omitempty"`
+	NoProxy    string `json:"noProxy,omitempty"`
+	FTPProxy   string `json:"ftpProxy,omitempty"`
+}
+
+// KubernetesConfig contains Kubernetes orchestrator settings
+type KubernetesConfig struct {
+	AllNamespaces string `json:"allNamespaces,omitempty"`
+}
+
+// New initializes an empty configuration file for the given filename 'fn'
+func New(fn string) *ConfigFile {
+	return &ConfigFile{
+		AuthConfigs: make(map[string]types.AuthConfig),
+		HTTPHeaders: make(map[string]string),
+		Filename:    fn,
+		Plugins:     make(map[string]map[string]string),
+		Aliases:     make(map[string]string),
+	}
+}
+
+// LegacyLoadFromReader reads the non-nested configuration data given and sets up the
+// auth config information with given directory and populates the receiver object
+func (configFile *ConfigFile) LegacyLoadFromReader(configData io.Reader) error {
+	b, err := ioutil.ReadAll(configData)
+	if err != nil {
+		return err
+	}
+
+	if err := json.Unmarshal(b, &configFile.AuthConfigs); err != nil {
+		arr := strings.Split(string(b), "\n")
+		if len(arr) < 2 {
+			return errors.Errorf("The Auth config file is empty")
+		}
+		authConfig := types.AuthConfig{}
+		origAuth := strings.Split(arr[0], " = ")
+		if len(origAuth) != 2 {
+			return errors.Errorf("Invalid Auth config file")
+		}
+		authConfig.Username, authConfig.Password, err = decodeAuth(origAuth[1])
+		if err != nil {
+			return err
+		}
+		authConfig.ServerAddress = defaultIndexServer
+		configFile.AuthConfigs[defaultIndexServer] = authConfig
+	} else {
+		for k, authConfig := range configFile.AuthConfigs {
+			authConfig.Username, authConfig.Password, err = decodeAuth(authConfig.Auth)
+			if err != nil {
+				return err
+			}
+			authConfig.Auth = ""
+			authConfig.ServerAddress = k
+			configFile.AuthConfigs[k] = authConfig
+		}
+	}
+	return nil
+}
+
+// LoadFromReader reads the configuration data given and sets up the auth config
+// information with given directory and populates the receiver object
+func (configFile *ConfigFile) LoadFromReader(configData io.Reader) error {
+	if err := json.NewDecoder(configData).Decode(&configFile); err != nil {
+		return err
+	}
+	var err error
+	for addr, ac := range configFile.AuthConfigs {
+		if ac.Auth != "" {
+			ac.Username, ac.Password, err = decodeAuth(ac.Auth)
+			if err != nil {
+				return err
+			}
+		}
+		ac.Auth = ""
+		ac.ServerAddress = addr
+		configFile.AuthConfigs[addr] = ac
+	}
+	return checkKubernetesConfiguration(configFile.Kubernetes)
+}
+
+// ContainsAuth returns whether there is authentication configured
+// in this file or not.
+func (configFile *ConfigFile) ContainsAuth() bool {
+	return configFile.CredentialsStore != "" ||
+		len(configFile.CredentialHelpers) > 0 ||
+		len(configFile.AuthConfigs) > 0
+}
+
+// GetAuthConfigs returns the mapping of repo to auth configuration
+func (configFile *ConfigFile) GetAuthConfigs() map[string]types.AuthConfig {
+	return configFile.AuthConfigs
+}
+
+// SaveToWriter encodes and writes out all the authorization information to
+// the given writer
+func (configFile *ConfigFile) SaveToWriter(writer io.Writer) error {
+	// Encode sensitive data into a new/temp struct
+	tmpAuthConfigs := make(map[string]types.AuthConfig, len(configFile.AuthConfigs))
+	for k, authConfig := range configFile.AuthConfigs {
+		authCopy := authConfig
+		// encode and save the authstring, while blanking out the original fields
+		authCopy.Auth = encodeAuth(&authCopy)
+		authCopy.Username = ""
+		authCopy.Password = ""
+		authCopy.ServerAddress = ""
+		tmpAuthConfigs[k] = authCopy
+	}
+
+	saveAuthConfigs := configFile.AuthConfigs
+	configFile.AuthConfigs = tmpAuthConfigs
+	defer func() { configFile.AuthConfigs = saveAuthConfigs }()
+
+	data, err := json.MarshalIndent(configFile, "", "\t")
+	if err != nil {
+		return err
+	}
+	_, err = writer.Write(data)
+	return err
+}
+
+// Save encodes and writes out all the authorization information
+func (configFile *ConfigFile) Save() error {
+	if configFile.Filename == "" {
+		return errors.Errorf("Can't save config with empty filename")
+	}
+
+	dir := filepath.Dir(configFile.Filename)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return err
+	}
+	temp, err := ioutil.TempFile(dir, filepath.Base(configFile.Filename))
+	if err != nil {
+		return err
+	}
+	err = configFile.SaveToWriter(temp)
+	temp.Close()
+	if err != nil {
+		os.Remove(temp.Name())
+		return err
+	}
+	// Try copying the current config file (if any) ownership and permissions
+	copyFilePermissions(configFile.Filename, temp.Name())
+
+	return os.Rename(temp.Name(), configFile.Filename)
+}
+
+// ParseProxyConfig computes proxy configuration by retrieving the config for the provided host and
+// then checking this against any environment variables provided to the container
+func (configFile *ConfigFile) ParseProxyConfig(host string, runOpts map[string]*string) map[string]*string {
+	var cfgKey string
+
+	if _, ok := configFile.Proxies[host]; !ok {
+		cfgKey = "default"
+	} else {
+		cfgKey = host
+	}
+
+	config := configFile.Proxies[cfgKey]
+	permitted := map[string]*string{
+		"HTTP_PROXY":  &config.HTTPProxy,
+		"HTTPS_PROXY": &config.HTTPSProxy,
+		"NO_PROXY":    &config.NoProxy,
+		"FTP_PROXY":   &config.FTPProxy,
+	}
+	m := runOpts
+	if m == nil {
+		m = make(map[string]*string)
+	}
+	for k := range permitted {
+		if *permitted[k] == "" {
+			continue
+		}
+		if _, ok := m[k]; !ok {
+			m[k] = permitted[k]
+		}
+		if _, ok := m[strings.ToLower(k)]; !ok {
+			m[strings.ToLower(k)] = permitted[k]
+		}
+	}
+	return m
+}
+
+// encodeAuth creates a base64 encoded string to containing authorization information
+func encodeAuth(authConfig *types.AuthConfig) string {
+	if authConfig.Username == "" && authConfig.Password == "" {
+		return ""
+	}
+
+	authStr := authConfig.Username + ":" + authConfig.Password
+	msg := []byte(authStr)
+	encoded := make([]byte, base64.StdEncoding.EncodedLen(len(msg)))
+	base64.StdEncoding.Encode(encoded, msg)
+	return string(encoded)
+}
+
+// decodeAuth decodes a base64 encoded string and returns username and password
+func decodeAuth(authStr string) (string, string, error) {
+	if authStr == "" {
+		return "", "", nil
+	}
+
+	decLen := base64.StdEncoding.DecodedLen(len(authStr))
+	decoded := make([]byte, decLen)
+	authByte := []byte(authStr)
+	n, err := base64.StdEncoding.Decode(decoded, authByte)
+	if err != nil {
+		return "", "", err
+	}
+	if n > decLen {
+		return "", "", errors.Errorf("Something went wrong decoding auth config")
+	}
+	arr := strings.SplitN(string(decoded), ":", 2)
+	if len(arr) != 2 {
+		return "", "", errors.Errorf("Invalid auth configuration file")
+	}
+	password := strings.Trim(arr[1], "\x00")
+	return arr[0], password, nil
+}
+
+// GetCredentialsStore returns a new credentials store from the settings in the
+// configuration file
+func (configFile *ConfigFile) GetCredentialsStore(registryHostname string) credentials.Store {
+	if helper := getConfiguredCredentialStore(configFile, registryHostname); helper != "" {
+		return newNativeStore(configFile, helper)
+	}
+	return credentials.NewFileStore(configFile)
+}
+
+// var for unit testing.
+var newNativeStore = func(configFile *ConfigFile, helperSuffix string) credentials.Store {
+	return credentials.NewNativeStore(configFile, helperSuffix)
+}
+
+// GetAuthConfig for a repository from the credential store
+func (configFile *ConfigFile) GetAuthConfig(registryHostname string) (types.AuthConfig, error) {
+	return configFile.GetCredentialsStore(registryHostname).Get(registryHostname)
+}
+
+// getConfiguredCredentialStore returns the credential helper configured for the
+// given registry, the default credsStore, or the empty string if neither are
+// configured.
+func getConfiguredCredentialStore(c *ConfigFile, registryHostname string) string {
+	if c.CredentialHelpers != nil && registryHostname != "" {
+		if helper, exists := c.CredentialHelpers[registryHostname]; exists {
+			return helper
+		}
+	}
+	return c.CredentialsStore
+}
+
+// GetAllCredentials returns all of the credentials stored in all of the
+// configured credential stores.
+func (configFile *ConfigFile) GetAllCredentials() (map[string]types.AuthConfig, error) {
+	auths := make(map[string]types.AuthConfig)
+	addAll := func(from map[string]types.AuthConfig) {
+		for reg, ac := range from {
+			auths[reg] = ac
+		}
+	}
+
+	defaultStore := configFile.GetCredentialsStore("")
+	newAuths, err := defaultStore.GetAll()
+	if err != nil {
+		return nil, err
+	}
+	addAll(newAuths)
+
+	// Auth configs from a registry-specific helper should override those from the default store.
+	for registryHostname := range configFile.CredentialHelpers {
+		newAuth, err := configFile.GetAuthConfig(registryHostname)
+		if err != nil {
+			return nil, err
+		}
+		auths[registryHostname] = newAuth
+	}
+	return auths, nil
+}
+
+// GetFilename returns the file name that this config file is based on.
+func (configFile *ConfigFile) GetFilename() string {
+	return configFile.Filename
+}
+
+// PluginConfig retrieves the requested option for the given plugin.
+func (configFile *ConfigFile) PluginConfig(pluginname, option string) (string, bool) {
+	if configFile.Plugins == nil {
+		return "", false
+	}
+	pluginConfig, ok := configFile.Plugins[pluginname]
+	if !ok {
+		return "", false
+	}
+	value, ok := pluginConfig[option]
+	return value, ok
+}
+
+// SetPluginConfig sets the option to the given value for the given
+// plugin. Passing a value of "" will remove the option. If removing
+// the final config item for a given plugin then also cleans up the
+// overall plugin entry.
+func (configFile *ConfigFile) SetPluginConfig(pluginname, option, value string) {
+	if configFile.Plugins == nil {
+		configFile.Plugins = make(map[string]map[string]string)
+	}
+	pluginConfig, ok := configFile.Plugins[pluginname]
+	if !ok {
+		pluginConfig = make(map[string]string)
+		configFile.Plugins[pluginname] = pluginConfig
+	}
+	if value != "" {
+		pluginConfig[option] = value
+	} else {
+		delete(pluginConfig, option)
+	}
+	if len(pluginConfig) == 0 {
+		delete(configFile.Plugins, pluginname)
+	}
+}
+
+func checkKubernetesConfiguration(kubeConfig *KubernetesConfig) error {
+	if kubeConfig == nil {
+		return nil
+	}
+	switch kubeConfig.AllNamespaces {
+	case "":
+	case "enabled":
+	case "disabled":
+	default:
+		return fmt.Errorf("invalid 'kubernetes.allNamespaces' value, should be 'enabled' or 'disabled': %s", kubeConfig.AllNamespaces)
+	}
+	return nil
+}

--- a/vendor/github.com/docker/cli/cli/config/configfile/file_unix.go
+++ b/vendor/github.com/docker/cli/cli/config/configfile/file_unix.go
@@ -1,0 +1,35 @@
+// +build !windows
+
+package configfile
+
+import (
+	"os"
+	"syscall"
+)
+
+// copyFilePermissions copies file ownership and permissions from "src" to "dst",
+// ignoring any error during the process.
+func copyFilePermissions(src, dst string) {
+	var (
+		mode     os.FileMode = 0600
+		uid, gid int
+	)
+
+	fi, err := os.Stat(src)
+	if err != nil {
+		return
+	}
+	if fi.Mode().IsRegular() {
+		mode = fi.Mode()
+	}
+	if err := os.Chmod(dst, mode); err != nil {
+		return
+	}
+
+	uid = int(fi.Sys().(*syscall.Stat_t).Uid)
+	gid = int(fi.Sys().(*syscall.Stat_t).Gid)
+
+	if uid > 0 && gid > 0 {
+		_ = os.Chown(dst, uid, gid)
+	}
+}

--- a/vendor/github.com/docker/cli/cli/config/configfile/file_windows.go
+++ b/vendor/github.com/docker/cli/cli/config/configfile/file_windows.go
@@ -1,0 +1,5 @@
+package configfile
+
+func copyFilePermissions(src, dst string) {
+	// TODO implement for Windows
+}

--- a/vendor/github.com/docker/cli/cli/config/credentials/credentials.go
+++ b/vendor/github.com/docker/cli/cli/config/credentials/credentials.go
@@ -1,0 +1,17 @@
+package credentials
+
+import (
+	"github.com/docker/cli/cli/config/types"
+)
+
+// Store is the interface that any credentials store must implement.
+type Store interface {
+	// Erase removes credentials from the store for a given server.
+	Erase(serverAddress string) error
+	// Get retrieves credentials from the store for a given server.
+	Get(serverAddress string) (types.AuthConfig, error)
+	// GetAll retrieves all the credentials from the store.
+	GetAll() (map[string]types.AuthConfig, error)
+	// Store saves credentials in the store.
+	Store(authConfig types.AuthConfig) error
+}

--- a/vendor/github.com/docker/cli/cli/config/credentials/default_store.go
+++ b/vendor/github.com/docker/cli/cli/config/credentials/default_store.go
@@ -1,0 +1,21 @@
+package credentials
+
+import (
+	"os/exec"
+)
+
+// DetectDefaultStore return the default credentials store for the platform if
+// the store executable is available.
+func DetectDefaultStore(store string) string {
+	platformDefault := defaultCredentialsStore()
+
+	// user defined or no default for platform
+	if store != "" || platformDefault == "" {
+		return store
+	}
+
+	if _, err := exec.LookPath(remoteCredentialsPrefix + platformDefault); err == nil {
+		return platformDefault
+	}
+	return ""
+}

--- a/vendor/github.com/docker/cli/cli/config/credentials/default_store_darwin.go
+++ b/vendor/github.com/docker/cli/cli/config/credentials/default_store_darwin.go
@@ -1,0 +1,5 @@
+package credentials
+
+func defaultCredentialsStore() string {
+	return "osxkeychain"
+}

--- a/vendor/github.com/docker/cli/cli/config/credentials/default_store_linux.go
+++ b/vendor/github.com/docker/cli/cli/config/credentials/default_store_linux.go
@@ -1,0 +1,13 @@
+package credentials
+
+import (
+	"os/exec"
+)
+
+func defaultCredentialsStore() string {
+	if _, err := exec.LookPath("pass"); err == nil {
+		return "pass"
+	}
+
+	return "secretservice"
+}

--- a/vendor/github.com/docker/cli/cli/config/credentials/default_store_unsupported.go
+++ b/vendor/github.com/docker/cli/cli/config/credentials/default_store_unsupported.go
@@ -1,0 +1,7 @@
+// +build !windows,!darwin,!linux
+
+package credentials
+
+func defaultCredentialsStore() string {
+	return ""
+}

--- a/vendor/github.com/docker/cli/cli/config/credentials/default_store_windows.go
+++ b/vendor/github.com/docker/cli/cli/config/credentials/default_store_windows.go
@@ -1,0 +1,5 @@
+package credentials
+
+func defaultCredentialsStore() string {
+	return "wincred"
+}

--- a/vendor/github.com/docker/cli/cli/config/credentials/file_store.go
+++ b/vendor/github.com/docker/cli/cli/config/credentials/file_store.go
@@ -1,0 +1,81 @@
+package credentials
+
+import (
+	"strings"
+
+	"github.com/docker/cli/cli/config/types"
+)
+
+type store interface {
+	Save() error
+	GetAuthConfigs() map[string]types.AuthConfig
+	GetFilename() string
+}
+
+// fileStore implements a credentials store using
+// the docker configuration file to keep the credentials in plain text.
+type fileStore struct {
+	file store
+}
+
+// NewFileStore creates a new file credentials store.
+func NewFileStore(file store) Store {
+	return &fileStore{file: file}
+}
+
+// Erase removes the given credentials from the file store.
+func (c *fileStore) Erase(serverAddress string) error {
+	delete(c.file.GetAuthConfigs(), serverAddress)
+	return c.file.Save()
+}
+
+// Get retrieves credentials for a specific server from the file store.
+func (c *fileStore) Get(serverAddress string) (types.AuthConfig, error) {
+	authConfig, ok := c.file.GetAuthConfigs()[serverAddress]
+	if !ok {
+		// Maybe they have a legacy config file, we will iterate the keys converting
+		// them to the new format and testing
+		for r, ac := range c.file.GetAuthConfigs() {
+			if serverAddress == ConvertToHostname(r) {
+				return ac, nil
+			}
+		}
+
+		authConfig = types.AuthConfig{}
+	}
+	return authConfig, nil
+}
+
+func (c *fileStore) GetAll() (map[string]types.AuthConfig, error) {
+	return c.file.GetAuthConfigs(), nil
+}
+
+// Store saves the given credentials in the file store.
+func (c *fileStore) Store(authConfig types.AuthConfig) error {
+	c.file.GetAuthConfigs()[authConfig.ServerAddress] = authConfig
+	return c.file.Save()
+}
+
+func (c *fileStore) GetFilename() string {
+	return c.file.GetFilename()
+}
+
+func (c *fileStore) IsFileStore() bool {
+	return true
+}
+
+// ConvertToHostname converts a registry url which has http|https prepended
+// to just an hostname.
+// Copied from github.com/docker/docker/registry.ConvertToHostname to reduce dependencies.
+func ConvertToHostname(url string) string {
+	stripped := url
+	if strings.HasPrefix(url, "http://") {
+		stripped = strings.TrimPrefix(url, "http://")
+	} else if strings.HasPrefix(url, "https://") {
+		stripped = strings.TrimPrefix(url, "https://")
+	}
+
+	nameParts := strings.SplitN(stripped, "/", 2)
+
+	return nameParts[0]
+}

--- a/vendor/github.com/docker/cli/cli/config/credentials/native_store.go
+++ b/vendor/github.com/docker/cli/cli/config/credentials/native_store.go
@@ -1,0 +1,143 @@
+package credentials
+
+import (
+	"github.com/docker/cli/cli/config/types"
+	"github.com/docker/docker-credential-helpers/client"
+	"github.com/docker/docker-credential-helpers/credentials"
+)
+
+const (
+	remoteCredentialsPrefix = "docker-credential-"
+	tokenUsername           = "<token>"
+)
+
+// nativeStore implements a credentials store
+// using native keychain to keep credentials secure.
+// It piggybacks into a file store to keep users' emails.
+type nativeStore struct {
+	programFunc client.ProgramFunc
+	fileStore   Store
+}
+
+// NewNativeStore creates a new native store that
+// uses a remote helper program to manage credentials.
+func NewNativeStore(file store, helperSuffix string) Store {
+	name := remoteCredentialsPrefix + helperSuffix
+	return &nativeStore{
+		programFunc: client.NewShellProgramFunc(name),
+		fileStore:   NewFileStore(file),
+	}
+}
+
+// Erase removes the given credentials from the native store.
+func (c *nativeStore) Erase(serverAddress string) error {
+	if err := client.Erase(c.programFunc, serverAddress); err != nil {
+		return err
+	}
+
+	// Fallback to plain text store to remove email
+	return c.fileStore.Erase(serverAddress)
+}
+
+// Get retrieves credentials for a specific server from the native store.
+func (c *nativeStore) Get(serverAddress string) (types.AuthConfig, error) {
+	// load user email if it exist or an empty auth config.
+	auth, _ := c.fileStore.Get(serverAddress)
+
+	creds, err := c.getCredentialsFromStore(serverAddress)
+	if err != nil {
+		return auth, err
+	}
+	auth.Username = creds.Username
+	auth.IdentityToken = creds.IdentityToken
+	auth.Password = creds.Password
+
+	return auth, nil
+}
+
+// GetAll retrieves all the credentials from the native store.
+func (c *nativeStore) GetAll() (map[string]types.AuthConfig, error) {
+	auths, err := c.listCredentialsInStore()
+	if err != nil {
+		return nil, err
+	}
+
+	// Emails are only stored in the file store.
+	// This call can be safely eliminated when emails are removed.
+	fileConfigs, _ := c.fileStore.GetAll()
+
+	authConfigs := make(map[string]types.AuthConfig)
+	for registry := range auths {
+		creds, err := c.getCredentialsFromStore(registry)
+		if err != nil {
+			return nil, err
+		}
+		ac := fileConfigs[registry] // might contain Email
+		ac.Username = creds.Username
+		ac.Password = creds.Password
+		ac.IdentityToken = creds.IdentityToken
+		authConfigs[registry] = ac
+	}
+
+	return authConfigs, nil
+}
+
+// Store saves the given credentials in the file store.
+func (c *nativeStore) Store(authConfig types.AuthConfig) error {
+	if err := c.storeCredentialsInStore(authConfig); err != nil {
+		return err
+	}
+	authConfig.Username = ""
+	authConfig.Password = ""
+	authConfig.IdentityToken = ""
+
+	// Fallback to old credential in plain text to save only the email
+	return c.fileStore.Store(authConfig)
+}
+
+// storeCredentialsInStore executes the command to store the credentials in the native store.
+func (c *nativeStore) storeCredentialsInStore(config types.AuthConfig) error {
+	creds := &credentials.Credentials{
+		ServerURL: config.ServerAddress,
+		Username:  config.Username,
+		Secret:    config.Password,
+	}
+
+	if config.IdentityToken != "" {
+		creds.Username = tokenUsername
+		creds.Secret = config.IdentityToken
+	}
+
+	return client.Store(c.programFunc, creds)
+}
+
+// getCredentialsFromStore executes the command to get the credentials from the native store.
+func (c *nativeStore) getCredentialsFromStore(serverAddress string) (types.AuthConfig, error) {
+	var ret types.AuthConfig
+
+	creds, err := client.Get(c.programFunc, serverAddress)
+	if err != nil {
+		if credentials.IsErrCredentialsNotFound(err) {
+			// do not return an error if the credentials are not
+			// in the keychain. Let docker ask for new credentials.
+			return ret, nil
+		}
+		return ret, err
+	}
+
+	if creds.Username == tokenUsername {
+		ret.IdentityToken = creds.Secret
+	} else {
+		ret.Password = creds.Secret
+		ret.Username = creds.Username
+	}
+
+	ret.ServerAddress = serverAddress
+	return ret, nil
+}
+
+// listCredentialsInStore returns a listing of stored credentials as a map of
+// URL -> username.
+func (c *nativeStore) listCredentialsInStore() (map[string]string, error) {
+	return client.List(c.programFunc)
+}

--- a/vendor/github.com/docker/cli/cli/config/types/authconfig.go
+++ b/vendor/github.com/docker/cli/cli/config/types/authconfig.go
@@ -1,0 +1,22 @@
+package types
+
+// AuthConfig contains authorization information for connecting to a Registry
+type AuthConfig struct {
+	Username string `json:"username,omitempty"`
+	Password string `json:"password,omitempty"`
+	Auth     string `json:"auth,omitempty"`
+
+	// Email is an optional value associated with the username.
+	// This field is deprecated and will be removed in a later
+	// version of docker.
+	Email string `json:"email,omitempty"`
+
+	ServerAddress string `json:"serveraddress,omitempty"`
+
+	// IdentityToken is used to authenticate the user and get
+	// an access token for the registry.
+	IdentityToken string `json:"identitytoken,omitempty"`
+
+	// RegistryToken is a bearer token to be sent to a registry
+	RegistryToken string `json:"registrytoken,omitempty"`
+}

--- a/vendor/github.com/docker/docker-credential-helpers/LICENSE
+++ b/vendor/github.com/docker/docker-credential-helpers/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2016 David Calavera
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/docker/docker-credential-helpers/client/client.go
+++ b/vendor/github.com/docker/docker-credential-helpers/client/client.go
@@ -1,0 +1,121 @@
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/docker/docker-credential-helpers/credentials"
+)
+
+// isValidCredsMessage checks if 'msg' contains invalid credentials error message.
+// It returns whether the logs are free of invalid credentials errors and the error if it isn't.
+// error values can be errCredentialsMissingServerURL or errCredentialsMissingUsername.
+func isValidCredsMessage(msg string) error {
+	if credentials.IsCredentialsMissingServerURLMessage(msg) {
+		return credentials.NewErrCredentialsMissingServerURL()
+	}
+
+	if credentials.IsCredentialsMissingUsernameMessage(msg) {
+		return credentials.NewErrCredentialsMissingUsername()
+	}
+
+	return nil
+}
+
+// Store uses an external program to save credentials.
+func Store(program ProgramFunc, creds *credentials.Credentials) error {
+	cmd := program("store")
+
+	buffer := new(bytes.Buffer)
+	if err := json.NewEncoder(buffer).Encode(creds); err != nil {
+		return err
+	}
+	cmd.Input(buffer)
+
+	out, err := cmd.Output()
+	if err != nil {
+		t := strings.TrimSpace(string(out))
+
+		if isValidErr := isValidCredsMessage(t); isValidErr != nil {
+			err = isValidErr
+		}
+
+		return fmt.Errorf("error storing credentials - err: %v, out: `%s`", err, t)
+	}
+
+	return nil
+}
+
+// Get executes an external program to get the credentials from a native store.
+func Get(program ProgramFunc, serverURL string) (*credentials.Credentials, error) {
+	cmd := program("get")
+	cmd.Input(strings.NewReader(serverURL))
+
+	out, err := cmd.Output()
+	if err != nil {
+		t := strings.TrimSpace(string(out))
+
+		if credentials.IsErrCredentialsNotFoundMessage(t) {
+			return nil, credentials.NewErrCredentialsNotFound()
+		}
+
+		if isValidErr := isValidCredsMessage(t); isValidErr != nil {
+			err = isValidErr
+		}
+
+		return nil, fmt.Errorf("error getting credentials - err: %v, out: `%s`", err, t)
+	}
+
+	resp := &credentials.Credentials{
+		ServerURL: serverURL,
+	}
+
+	if err := json.NewDecoder(bytes.NewReader(out)).Decode(resp); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// Erase executes a program to remove the server credentials from the native store.
+func Erase(program ProgramFunc, serverURL string) error {
+	cmd := program("erase")
+	cmd.Input(strings.NewReader(serverURL))
+	out, err := cmd.Output()
+	if err != nil {
+		t := strings.TrimSpace(string(out))
+
+		if isValidErr := isValidCredsMessage(t); isValidErr != nil {
+			err = isValidErr
+		}
+
+		return fmt.Errorf("error erasing credentials - err: %v, out: `%s`", err, t)
+	}
+
+	return nil
+}
+
+// List executes a program to list server credentials in the native store.
+func List(program ProgramFunc) (map[string]string, error) {
+	cmd := program("list")
+	cmd.Input(strings.NewReader("unused"))
+	out, err := cmd.Output()
+	if err != nil {
+		t := strings.TrimSpace(string(out))
+
+		if isValidErr := isValidCredsMessage(t); isValidErr != nil {
+			err = isValidErr
+		}
+
+		return nil, fmt.Errorf("error listing credentials - err: %v, out: `%s`", err, t)
+	}
+
+	var resp map[string]string
+	if err = json.NewDecoder(bytes.NewReader(out)).Decode(&resp); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}

--- a/vendor/github.com/docker/docker-credential-helpers/client/command.go
+++ b/vendor/github.com/docker/docker-credential-helpers/client/command.go
@@ -1,0 +1,56 @@
+package client
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+)
+
+// Program is an interface to execute external programs.
+type Program interface {
+	Output() ([]byte, error)
+	Input(in io.Reader)
+}
+
+// ProgramFunc is a type of function that initializes programs based on arguments.
+type ProgramFunc func(args ...string) Program
+
+// NewShellProgramFunc creates programs that are executed in a Shell.
+func NewShellProgramFunc(name string) ProgramFunc {
+	return NewShellProgramFuncWithEnv(name, nil)
+}
+
+// NewShellProgramFuncWithEnv creates programs that are executed in a Shell with environment variables
+func NewShellProgramFuncWithEnv(name string, env *map[string]string) ProgramFunc {
+	return func(args ...string) Program {
+		return &Shell{cmd: createProgramCmdRedirectErr(name, args, env)}
+	}
+}
+
+func createProgramCmdRedirectErr(commandName string, args []string, env *map[string]string) *exec.Cmd {
+	programCmd := exec.Command(commandName, args...)
+	programCmd.Env = os.Environ()
+	if env != nil {
+		for k, v := range *env {
+			programCmd.Env = append(programCmd.Env, fmt.Sprintf("%s=%s", k, v))
+		}
+	}
+	programCmd.Stderr = os.Stderr
+	return programCmd
+}
+
+// Shell invokes shell commands to talk with a remote credentials helper.
+type Shell struct {
+	cmd *exec.Cmd
+}
+
+// Output returns responses from the remote credentials helper.
+func (s *Shell) Output() ([]byte, error) {
+	return s.cmd.Output()
+}
+
+// Input sets the input to send to a remote credentials helper.
+func (s *Shell) Input(in io.Reader) {
+	s.cmd.Stdin = in
+}

--- a/vendor/github.com/docker/docker-credential-helpers/credentials/credentials.go
+++ b/vendor/github.com/docker/docker-credential-helpers/credentials/credentials.go
@@ -1,0 +1,186 @@
+package credentials
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+// Credentials holds the information shared between docker and the credentials store.
+type Credentials struct {
+	ServerURL string
+	Username  string
+	Secret    string
+}
+
+// isValid checks the integrity of Credentials object such that no credentials lack
+// a server URL or a username.
+// It returns whether the credentials are valid and the error if it isn't.
+// error values can be errCredentialsMissingServerURL or errCredentialsMissingUsername
+func (c *Credentials) isValid() (bool, error) {
+	if len(c.ServerURL) == 0 {
+		return false, NewErrCredentialsMissingServerURL()
+	}
+
+	if len(c.Username) == 0 {
+		return false, NewErrCredentialsMissingUsername()
+	}
+
+	return true, nil
+}
+
+// CredsLabel holds the way Docker credentials should be labeled as such in credentials stores that allow labelling.
+// That label allows to filter out non-Docker credentials too at lookup/search in macOS keychain,
+// Windows credentials manager and Linux libsecret. Default value is "Docker Credentials"
+var CredsLabel = "Docker Credentials"
+
+// SetCredsLabel is a simple setter for CredsLabel
+func SetCredsLabel(label string) {
+	CredsLabel = label
+}
+
+// Serve initializes the credentials helper and parses the action argument.
+// This function is designed to be called from a command line interface.
+// It uses os.Args[1] as the key for the action.
+// It uses os.Stdin as input and os.Stdout as output.
+// This function terminates the program with os.Exit(1) if there is an error.
+func Serve(helper Helper) {
+	var err error
+	if len(os.Args) != 2 {
+		err = fmt.Errorf("Usage: %s <store|get|erase|list|version>", os.Args[0])
+	}
+
+	if err == nil {
+		err = HandleCommand(helper, os.Args[1], os.Stdin, os.Stdout)
+	}
+
+	if err != nil {
+		fmt.Fprintf(os.Stdout, "%v\n", err)
+		os.Exit(1)
+	}
+}
+
+// HandleCommand uses a helper and a key to run a credential action.
+func HandleCommand(helper Helper, key string, in io.Reader, out io.Writer) error {
+	switch key {
+	case "store":
+		return Store(helper, in)
+	case "get":
+		return Get(helper, in, out)
+	case "erase":
+		return Erase(helper, in)
+	case "list":
+		return List(helper, out)
+	case "version":
+		return PrintVersion(out)
+	}
+	return fmt.Errorf("Unknown credential action `%s`", key)
+}
+
+// Store uses a helper and an input reader to save credentials.
+// The reader must contain the JSON serialization of a Credentials struct.
+func Store(helper Helper, reader io.Reader) error {
+	scanner := bufio.NewScanner(reader)
+
+	buffer := new(bytes.Buffer)
+	for scanner.Scan() {
+		buffer.Write(scanner.Bytes())
+	}
+
+	if err := scanner.Err(); err != nil && err != io.EOF {
+		return err
+	}
+
+	var creds Credentials
+	if err := json.NewDecoder(buffer).Decode(&creds); err != nil {
+		return err
+	}
+
+	if ok, err := creds.isValid(); !ok {
+		return err
+	}
+
+	return helper.Add(&creds)
+}
+
+// Get retrieves the credentials for a given server url.
+// The reader must contain the server URL to search.
+// The writer is used to write the JSON serialization of the credentials.
+func Get(helper Helper, reader io.Reader, writer io.Writer) error {
+	scanner := bufio.NewScanner(reader)
+
+	buffer := new(bytes.Buffer)
+	for scanner.Scan() {
+		buffer.Write(scanner.Bytes())
+	}
+
+	if err := scanner.Err(); err != nil && err != io.EOF {
+		return err
+	}
+
+	serverURL := strings.TrimSpace(buffer.String())
+	if len(serverURL) == 0 {
+		return NewErrCredentialsMissingServerURL()
+	}
+
+	username, secret, err := helper.Get(serverURL)
+	if err != nil {
+		return err
+	}
+
+	resp := Credentials{
+		ServerURL: serverURL,
+		Username:  username,
+		Secret:    secret,
+	}
+
+	buffer.Reset()
+	if err := json.NewEncoder(buffer).Encode(resp); err != nil {
+		return err
+	}
+
+	fmt.Fprint(writer, buffer.String())
+	return nil
+}
+
+// Erase removes credentials from the store.
+// The reader must contain the server URL to remove.
+func Erase(helper Helper, reader io.Reader) error {
+	scanner := bufio.NewScanner(reader)
+
+	buffer := new(bytes.Buffer)
+	for scanner.Scan() {
+		buffer.Write(scanner.Bytes())
+	}
+
+	if err := scanner.Err(); err != nil && err != io.EOF {
+		return err
+	}
+
+	serverURL := strings.TrimSpace(buffer.String())
+	if len(serverURL) == 0 {
+		return NewErrCredentialsMissingServerURL()
+	}
+
+	return helper.Delete(serverURL)
+}
+
+//List returns all the serverURLs of keys in
+//the OS store as a list of strings
+func List(helper Helper, writer io.Writer) error {
+	accts, err := helper.List()
+	if err != nil {
+		return err
+	}
+	return json.NewEncoder(writer).Encode(accts)
+}
+
+//PrintVersion outputs the current version.
+func PrintVersion(writer io.Writer) error {
+	fmt.Fprintln(writer, Version)
+	return nil
+}

--- a/vendor/github.com/docker/docker-credential-helpers/credentials/error.go
+++ b/vendor/github.com/docker/docker-credential-helpers/credentials/error.go
@@ -1,0 +1,102 @@
+package credentials
+
+const (
+	// ErrCredentialsNotFound standardizes the not found error, so every helper returns
+	// the same message and docker can handle it properly.
+	errCredentialsNotFoundMessage = "credentials not found in native keychain"
+
+	// ErrCredentialsMissingServerURL and ErrCredentialsMissingUsername standardize
+	// invalid credentials or credentials management operations
+	errCredentialsMissingServerURLMessage = "no credentials server URL"
+	errCredentialsMissingUsernameMessage  = "no credentials username"
+)
+
+// errCredentialsNotFound represents an error
+// raised when credentials are not in the store.
+type errCredentialsNotFound struct{}
+
+// Error returns the standard error message
+// for when the credentials are not in the store.
+func (errCredentialsNotFound) Error() string {
+	return errCredentialsNotFoundMessage
+}
+
+// NewErrCredentialsNotFound creates a new error
+// for when the credentials are not in the store.
+func NewErrCredentialsNotFound() error {
+	return errCredentialsNotFound{}
+}
+
+// IsErrCredentialsNotFound returns true if the error
+// was caused by not having a set of credentials in a store.
+func IsErrCredentialsNotFound(err error) bool {
+	_, ok := err.(errCredentialsNotFound)
+	return ok
+}
+
+// IsErrCredentialsNotFoundMessage returns true if the error
+// was caused by not having a set of credentials in a store.
+//
+// This function helps to check messages returned by an
+// external program via its standard output.
+func IsErrCredentialsNotFoundMessage(err string) bool {
+	return err == errCredentialsNotFoundMessage
+}
+
+// errCredentialsMissingServerURL represents an error raised
+// when the credentials object has no server URL or when no
+// server URL is provided to a credentials operation requiring
+// one.
+type errCredentialsMissingServerURL struct{}
+
+func (errCredentialsMissingServerURL) Error() string {
+	return errCredentialsMissingServerURLMessage
+}
+
+// errCredentialsMissingUsername represents an error raised
+// when the credentials object has no username or when no
+// username is provided to a credentials operation requiring
+// one.
+type errCredentialsMissingUsername struct{}
+
+func (errCredentialsMissingUsername) Error() string {
+	return errCredentialsMissingUsernameMessage
+}
+
+// NewErrCredentialsMissingServerURL creates a new error for
+// errCredentialsMissingServerURL.
+func NewErrCredentialsMissingServerURL() error {
+	return errCredentialsMissingServerURL{}
+}
+
+// NewErrCredentialsMissingUsername creates a new error for
+// errCredentialsMissingUsername.
+func NewErrCredentialsMissingUsername() error {
+	return errCredentialsMissingUsername{}
+}
+
+// IsCredentialsMissingServerURL returns true if the error
+// was an errCredentialsMissingServerURL.
+func IsCredentialsMissingServerURL(err error) bool {
+	_, ok := err.(errCredentialsMissingServerURL)
+	return ok
+}
+
+// IsCredentialsMissingServerURLMessage checks for an
+// errCredentialsMissingServerURL in the error message.
+func IsCredentialsMissingServerURLMessage(err string) bool {
+	return err == errCredentialsMissingServerURLMessage
+}
+
+// IsCredentialsMissingUsername returns true if the error
+// was an errCredentialsMissingUsername.
+func IsCredentialsMissingUsername(err error) bool {
+	_, ok := err.(errCredentialsMissingUsername)
+	return ok
+}
+
+// IsCredentialsMissingUsernameMessage checks for an
+// errCredentialsMissingUsername in the error message.
+func IsCredentialsMissingUsernameMessage(err string) bool {
+	return err == errCredentialsMissingUsernameMessage
+}

--- a/vendor/github.com/docker/docker-credential-helpers/credentials/helper.go
+++ b/vendor/github.com/docker/docker-credential-helpers/credentials/helper.go
@@ -1,0 +1,14 @@
+package credentials
+
+// Helper is the interface a credentials store helper must implement.
+type Helper interface {
+	// Add appends credentials to the store.
+	Add(*Credentials) error
+	// Delete removes credentials from the store.
+	Delete(serverURL string) error
+	// Get retrieves credentials from the store.
+	// It returns username and secret as strings.
+	Get(serverURL string) (string, string, error)
+	// List returns the stored serverURLs and their associated usernames.
+	List() (map[string]string, error)
+}

--- a/vendor/github.com/docker/docker-credential-helpers/credentials/version.go
+++ b/vendor/github.com/docker/docker-credential-helpers/credentials/version.go
@@ -1,0 +1,4 @@
+package credentials
+
+// Version holds a string describing the current version
+const Version = "0.6.3"

--- a/vendor/github.com/docker/docker/pkg/homedir/homedir_linux.go
+++ b/vendor/github.com/docker/docker/pkg/homedir/homedir_linux.go
@@ -1,0 +1,93 @@
+package homedir // import "github.com/docker/docker/pkg/homedir"
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// GetRuntimeDir returns XDG_RUNTIME_DIR.
+// XDG_RUNTIME_DIR is typically configured via pam_systemd.
+// GetRuntimeDir returns non-nil error if XDG_RUNTIME_DIR is not set.
+//
+// See also https://standards.freedesktop.org/basedir-spec/latest/ar01s03.html
+func GetRuntimeDir() (string, error) {
+	if xdgRuntimeDir := os.Getenv("XDG_RUNTIME_DIR"); xdgRuntimeDir != "" {
+		return xdgRuntimeDir, nil
+	}
+	return "", errors.New("could not get XDG_RUNTIME_DIR")
+}
+
+// StickRuntimeDirContents sets the sticky bit on files that are under
+// XDG_RUNTIME_DIR, so that the files won't be periodically removed by the system.
+//
+// StickyRuntimeDir returns slice of sticked files.
+// StickyRuntimeDir returns nil error if XDG_RUNTIME_DIR is not set.
+//
+// See also https://standards.freedesktop.org/basedir-spec/latest/ar01s03.html
+func StickRuntimeDirContents(files []string) ([]string, error) {
+	runtimeDir, err := GetRuntimeDir()
+	if err != nil {
+		// ignore error if runtimeDir is empty
+		return nil, nil
+	}
+	runtimeDir, err = filepath.Abs(runtimeDir)
+	if err != nil {
+		return nil, err
+	}
+	var sticked []string
+	for _, f := range files {
+		f, err = filepath.Abs(f)
+		if err != nil {
+			return sticked, err
+		}
+		if strings.HasPrefix(f, runtimeDir+"/") {
+			if err = stick(f); err != nil {
+				return sticked, err
+			}
+			sticked = append(sticked, f)
+		}
+	}
+	return sticked, nil
+}
+
+func stick(f string) error {
+	st, err := os.Stat(f)
+	if err != nil {
+		return err
+	}
+	m := st.Mode()
+	m |= os.ModeSticky
+	return os.Chmod(f, m)
+}
+
+// GetDataHome returns XDG_DATA_HOME.
+// GetDataHome returns $HOME/.local/share and nil error if XDG_DATA_HOME is not set.
+//
+// See also https://standards.freedesktop.org/basedir-spec/latest/ar01s03.html
+func GetDataHome() (string, error) {
+	if xdgDataHome := os.Getenv("XDG_DATA_HOME"); xdgDataHome != "" {
+		return xdgDataHome, nil
+	}
+	home := os.Getenv("HOME")
+	if home == "" {
+		return "", errors.New("could not get either XDG_DATA_HOME or HOME")
+	}
+	return filepath.Join(home, ".local", "share"), nil
+}
+
+// GetConfigHome returns XDG_CONFIG_HOME.
+// GetConfigHome returns $HOME/.config and nil error if XDG_CONFIG_HOME is not set.
+//
+// See also https://standards.freedesktop.org/basedir-spec/latest/ar01s03.html
+func GetConfigHome() (string, error) {
+	if xdgConfigHome := os.Getenv("XDG_CONFIG_HOME"); xdgConfigHome != "" {
+		return xdgConfigHome, nil
+	}
+	home := os.Getenv("HOME")
+	if home == "" {
+		return "", errors.New("could not get either XDG_CONFIG_HOME or HOME")
+	}
+	return filepath.Join(home, ".config"), nil
+}

--- a/vendor/github.com/docker/docker/pkg/homedir/homedir_others.go
+++ b/vendor/github.com/docker/docker/pkg/homedir/homedir_others.go
@@ -1,0 +1,27 @@
+// +build !linux
+
+package homedir // import "github.com/docker/docker/pkg/homedir"
+
+import (
+	"errors"
+)
+
+// GetRuntimeDir is unsupported on non-linux system.
+func GetRuntimeDir() (string, error) {
+	return "", errors.New("homedir.GetRuntimeDir() is not supported on this system")
+}
+
+// StickRuntimeDirContents is unsupported on non-linux system.
+func StickRuntimeDirContents(files []string) ([]string, error) {
+	return nil, errors.New("homedir.StickRuntimeDirContents() is not supported on this system")
+}
+
+// GetDataHome is unsupported on non-linux system.
+func GetDataHome() (string, error) {
+	return "", errors.New("homedir.GetDataHome() is not supported on this system")
+}
+
+// GetConfigHome is unsupported on non-linux system.
+func GetConfigHome() (string, error) {
+	return "", errors.New("homedir.GetConfigHome() is not supported on this system")
+}

--- a/vendor/github.com/docker/docker/pkg/homedir/homedir_unix.go
+++ b/vendor/github.com/docker/docker/pkg/homedir/homedir_unix.go
@@ -1,0 +1,38 @@
+// +build !windows
+
+package homedir // import "github.com/docker/docker/pkg/homedir"
+
+import (
+	"os"
+	"os/user"
+)
+
+// Key returns the env var name for the user's home dir based on
+// the platform being run on
+func Key() string {
+	return "HOME"
+}
+
+// Get returns the home directory of the current user with the help of
+// environment variables depending on the target operating system.
+// Returned path should be used with "path/filepath" to form new paths.
+//
+// If linking statically with cgo enabled against glibc, ensure the
+// osusergo build tag is used.
+//
+// If needing to do nss lookups, do not disable cgo or set osusergo.
+func Get() string {
+	home := os.Getenv(Key())
+	if home == "" {
+		if u, err := user.Current(); err == nil {
+			return u.HomeDir
+		}
+	}
+	return home
+}
+
+// GetShortcutString returns the string that is shortcut to user's home directory
+// in the native shell of the platform running on.
+func GetShortcutString() string {
+	return "~"
+}

--- a/vendor/github.com/docker/docker/pkg/homedir/homedir_windows.go
+++ b/vendor/github.com/docker/docker/pkg/homedir/homedir_windows.go
@@ -1,0 +1,24 @@
+package homedir // import "github.com/docker/docker/pkg/homedir"
+
+import (
+	"os"
+)
+
+// Key returns the env var name for the user's home dir based on
+// the platform being run on
+func Key() string {
+	return "USERPROFILE"
+}
+
+// Get returns the home directory of the current user with the help of
+// environment variables depending on the target operating system.
+// Returned path should be used with "path/filepath" to form new paths.
+func Get() string {
+	return os.Getenv(Key())
+}
+
+// GetShortcutString returns the string that is shortcut to user's home directory
+// in the native shell of the platform running on.
+func GetShortcutString() string {
+	return "%USERPROFILE%" // be careful while using in format functions
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -153,6 +153,12 @@ github.com/coreos/go-iptables/iptables
 github.com/cpuguy83/go-md2man/v2/md2man
 # github.com/davecgh/go-spew v1.1.1
 github.com/davecgh/go-spew/spew
+# github.com/docker/cli v0.0.0-20200130152716-5d0cf8839492
+## explicit
+github.com/docker/cli/cli/config
+github.com/docker/cli/cli/config/configfile
+github.com/docker/cli/cli/config/credentials
+github.com/docker/cli/cli/config/types
 # github.com/docker/distribution v2.7.1+incompatible => github.com/docker/distribution v0.0.0-20190711223531-1fb7fffdb266
 github.com/docker/distribution/digestset
 github.com/docker/distribution/reference
@@ -177,6 +183,10 @@ github.com/docker/docker/api/types/versions
 github.com/docker/docker/api/types/volume
 github.com/docker/docker/client
 github.com/docker/docker/errdefs
+github.com/docker/docker/pkg/homedir
+# github.com/docker/docker-credential-helpers v0.6.3
+github.com/docker/docker-credential-helpers/client
+github.com/docker/docker-credential-helpers/credentials
 # github.com/docker/go-connections v0.4.0
 ## explicit
 github.com/docker/go-connections/nat


### PR DESCRIPTION
This adds a package `pkg/runtime/auth` with helpers to read the docker cli
config and load the credentials for the host name of a given image. This
is based on nerdctl's `dockerconfigresolver`, refer: https://github.com/containerd/nerdctl/blob/v0.8.1/pkg/imgutil/dockerconfigresolver/dockerconfigresolver.go#L102 .

When using containerd as the runtime, the credentials from docker cli
config is loaded into a containerd remote resolver and passed to the
containerd remote option used for pulling.

When using docker as the runtime, the credentials from docker cli config
is loaded into the docker image pull options in the required format. Based
on https://docs.docker.com/engine/api/sdk/examples/#pull-an-image-with-authentication .

When not logged in:

```console
$ sudo ./bin/ignite image import darkowlzz/alpine:3.13
INFO[0000] containerd image "darkowlzz/alpine:3.13" not found locally, pulling...
FATA[0002] failed to resolve reference "docker.io/darkowlzz/alpine:3.13": pull access denied, repository does not exist or may require authorization: server message: insufficient_scope: authorization failed
```

After logging in:

```console
$ sudo ./bin/ignite image import darkowlzz/alpine:3.13
INFO[0000] containerd image "darkowlzz/alpine:3.13" not found locally, pulling...
INFO[0003] Starting image import...
INFO[0003] Imported OCI image "darkowlzz/alpine:3.13" (5.7 MB) to base image with UID "f01694878f9ed2f0"
INFO[0003] Created image with ID "f01694878f9ed2f0" and name "darkowlzz/alpine:3.13"
```

With docker as runtime:

```console
$ sudo ./bin/ignite image import darkowlzz/alpine:3.13 --runtime docker
INFO[0000] docker image "darkowlzz/alpine:3.13" not found locally, pulling...
INFO[0002] Starting image import...
INFO[0003] Imported OCI image "darkowlzz/alpine:3.13" (5.4 MB) to base image with UID "3d630e9936b42849"
INFO[0003] Created image with ID "3d630e9936b42849" and name "darkowlzz/alpine:3.13"
```

TODO:
- Maybe add flag to the `image` subcommand to pass the path to docker cli config.
- Maybe allow setting the docker cli config path in the ignite configuration file.
- [x] Update docs.
- Set up automated tests.

Fixes #794 
