### PR TITLE
Update go versions in github workflows

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -30,7 +30,7 @@ jobs:
           ref: ${{ github.event.inputs.ref }}
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.14.2'
+          go-version: '1.16.3'
       - name: Build binaries for ${{ env.GOARCH }}
         run: make ignite ignite-spawn ignited bin/${{ env.GOARCH }}/Dockerfile GO_MAKE_TARGET=local GOARCH=${{ env.GOARCH }}
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/update-go-deps.yml
+++ b/.github/workflows/update-go-deps.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.14.2'
+          go-version: '1.16.3'
       - name: Update dependencies
         run: |
           export PATH=$PATH:$(go env GOPATH)/bin


### PR DESCRIPTION
This may resolve the CI failures like in https://github.com/weaveworks/ignite/pull/824 . May be related to the version of go and go mod.