### PR TITLE
Aligning spawn timeouts between different functions

### DIFF
--- a/cmd/ignite/run/exec.go
+++ b/cmd/ignite/run/exec.go
@@ -1,6 +1,8 @@
 package run
 
 import (
+	"time"
+
 	api "github.com/weaveworks/ignite/pkg/apis/ignite"
 	"github.com/weaveworks/ignite/pkg/constants"
 )
@@ -31,7 +33,7 @@ func (ef *ExecFlags) NewExecOptions(vmMatch string, command ...string) (eo *Exec
 
 // Exec executes command in a VM based on the provided ExecOptions.
 func Exec(eo *ExecOptions) error {
-	if err := waitForSSH(eo.vm, constants.SSH_DEFAULT_TIMEOUT_SECONDS, int(eo.Timeout)); err != nil {
+	if err := waitForSSH(eo.vm, constants.SSH_DEFAULT_TIMEOUT_SECONDS, time.Duration(eo.Timeout)*time.Second); err != nil {
 		return err
 	}
 	return runSSH(eo.vm, eo.IdentityFile, eo.command, eo.Tty, eo.Timeout)

--- a/cmd/ignite/run/start.go
+++ b/cmd/ignite/run/start.go
@@ -84,7 +84,7 @@ func Start(so *StartOptions, fs *flag.FlagSet) error {
 
 	// When --ssh is enabled, wait until SSH service started on port 22 at most N seconds
 	if ssh := so.vm.Spec.SSH; ssh != nil && ssh.Generate && len(so.vm.Status.Network.IPAddresses) > 0 {
-		if err := waitForSSH(so.vm, constants.SSH_DEFAULT_TIMEOUT_SECONDS, 5); err != nil {
+		if err := waitForSSH(so.vm, constants.SSH_DEFAULT_TIMEOUT_SECONDS, constants.IGNITE_SPAWN_TIMEOUT); err != nil {
 			return err
 		}
 	}
@@ -125,7 +125,7 @@ func dialSuccess(vm *ignite.VM, seconds int) error {
 	return nil
 }
 
-func waitForSSH(vm *ignite.VM, dialSeconds, sshTimeout int) error {
+func waitForSSH(vm *ignite.VM, dialSeconds int, sshTimeout time.Duration) error {
 	if err := dialSuccess(vm, dialSeconds); err != nil {
 		return err
 	}
@@ -144,7 +144,7 @@ func waitForSSH(vm *ignite.VM, dialSeconds, sshTimeout int) error {
 
 	config := &ssh.ClientConfig{
 		HostKeyCallback: certCheck.CheckHostKey,
-		Timeout:         time.Duration(sshTimeout) * time.Second,
+		Timeout:         sshTimeout,
 	}
 
 	addr := vm.Status.Network.IPAddresses[0].String() + ":22"

--- a/pkg/constants/vm.go
+++ b/pkg/constants/vm.go
@@ -1,5 +1,7 @@
 package constants
 
+import "time"
+
 const (
 	// Path to directory containing a subdirectory for each VM
 	VM_DIR = DATA_DIR + "/vm"
@@ -44,4 +46,7 @@ const (
 
 	// IGNITE_SANDBOX_ENV_VAR is the annotation prefix to store a list of env variables
 	IGNITE_SANDBOX_ENV_VAR = "ignite.weave.works/sanbox-env/"
+
+	// IGNITE_SPAWN_TIMEOUT determins how long to wait for spawn to start up
+	IGNITE_SPAWN_TIMEOUT = 2 * time.Minute
 )

--- a/pkg/constants/vm.go
+++ b/pkg/constants/vm.go
@@ -47,6 +47,6 @@ const (
 	// IGNITE_SANDBOX_ENV_VAR is the annotation prefix to store a list of env variables
 	IGNITE_SANDBOX_ENV_VAR = "ignite.weave.works/sanbox-env/"
 
-	// IGNITE_SPAWN_TIMEOUT determins how long to wait for spawn to start up
+	// IGNITE_SPAWN_TIMEOUT determines how long to wait for spawn to start up
 	IGNITE_SPAWN_TIMEOUT = 2 * time.Minute
 )

--- a/pkg/container/network.go
+++ b/pkg/container/network.go
@@ -63,9 +63,8 @@ func SetupContainerNetworking(vm *api.VM) (firecracker.NetworkInterfaces, []DHCP
 	}
 
 	interval := 1 * time.Second
-	timeout := 2 * time.Minute
 
-	err := wait.PollImmediate(interval, timeout, func() (bool, error) {
+	err := wait.PollImmediate(interval, constants.IGNITE_SPAWN_TIMEOUT, func() (bool, error) {
 
 		// This func returns true if it's done, and optionally an error
 		retry, err := collectInterfaces(vmIntfs)

--- a/pkg/operations/start.go
+++ b/pkg/operations/start.go
@@ -197,11 +197,10 @@ func verifyPulled(image meta.OCIImageRef) error {
 // TODO: This check for the Prometheus socket file is temporary
 // until we get a proper ignite <-> ignite-spawn communication channel
 func waitForSpawn(vm *api.VM, vmChans *VMChannels) {
-	const timeout = 10 * time.Second
 	const checkInterval = 100 * time.Millisecond
 
 	timer := time.Now()
-	for time.Since(timer) < timeout {
+	for time.Since(timer) < constants.IGNITE_SPAWN_TIMEOUT {
 		time.Sleep(checkInterval)
 
 		if util.FileExists(path.Join(vm.ObjectPath(), constants.PROMETHEUS_SOCKET)) {


### PR DESCRIPTION
This PR aligns three timers waiting for spawn startup:
* Spawn's internal timer waiting for interface to be plugged in
* `waitForSpawn`'s timer to mark VM as `running`
* `wautForSSH`'s timer in `run/start.go`