### PR TITLE
SIGSEGV with metadata from older version of ignite

### DIFF
--- a/cmd/ignite/run/ps.go
+++ b/cmd/ignite/run/ps.go
@@ -195,6 +195,9 @@ func fetchLatestStatus(vms []*api.VM) (outdatedVMs map[string]bool, errList []er
 				}
 			}
 			vmRuntime = dockerClient
+		default:
+			// Skip VMs with unknown runtime
+			continue
 		}
 
 		// Inspect the VM container using the runtime client.


### PR DESCRIPTION
Signed-off-by: Juozas <juozasgaigalas@gmail.com>

Running `ignite ps` on a system with firecracker VMs created by ignite 0.7 causes a segfault because the `/var/lib/firecracker/vm` metadata does not have the expected `vm.Status.Runtime.Name` field. Instead ignore VMs missing this field.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0x1083c5b]

goroutine 1 [running]:
github.com/weaveworks/ignite/cmd/ignite/run.fetchLatestStatus(0xc00007d860, 0x2, 0x2, 0x1, 0x2, 0xc00007d860, 0x1)
	/go/src/github.com/weaveworks/ignite/cmd/ignite/run/ps.go:201 +0x11b
github.com/weaveworks/ignite/cmd/ignite/run.Ps(0xc00003af40, 0x0, 0x0)
	/go/src/github.com/weaveworks/ignite/cmd/ignite/run/ps.go:81 +0x2bc
github.com/weaveworks/ignite/cmd/ignite/cmd/vmcmd.NewCmdPs.func1.1(0xc0001964e0, 0x131db72, 0x2)
	/go/src/github.com/weaveworks/ignite/cmd/ignite/cmd/vmcmd/ps.go:60 +0x5f
github.com/weaveworks/ignite/cmd/ignite/cmd/vmcmd.NewCmdPs.func1(0xc000453340, 0x1c436e0, 0x0, 0x0)
	/go/src/github.com/weaveworks/ignite/cmd/ignite/cmd/vmcmd/ps.go:61 +0x7a
github.com/spf13/cobra.(*Command).execute(0xc000453340, 0x1c436e0, 0x0, 0x0, 0xc000453340, 0x1c436e0)
	/go/src/github.com/weaveworks/ignite/vendor/github.com/spf13/cobra/command.go:846 +0x2c2
github.com/spf13/cobra.(*Command).ExecuteC(0xc00051b8c0, 0xc000182000, 0x14892e0, 0xc00000e010)
	/go/src/github.com/weaveworks/ignite/vendor/github.com/spf13/cobra/command.go:950 +0x375
github.com/spf13/cobra.(*Command).Execute(...)
	/go/src/github.com/weaveworks/ignite/vendor/github.com/spf13/cobra/command.go:887
main.Run(0x112f160, 0xc000040178)
	/go/src/github.com/weaveworks/ignite/cmd/ignite/ignite.go:24 +0xab
main.main()
	/go/src/github.com/weaveworks/ignite/cmd/ignite/ignite.go:13 +0x25
```