### PR TITLE
Cast to uint64 for Darwin platform

### DIFF
--- a/pkg/runtime/containerd/client.go
+++ b/pkg/runtime/containerd/client.go
@@ -630,6 +630,7 @@ func withDevices(devices []*runtime.Bind) oci.SpecOpts {
 				return err
 			}
 
+			// Cast up to uint64 from stat strut on other OS's
 			major := int64(unix.Major(uint64(stat.Rdev)))
 			minor := int64(unix.Minor(uint64(stat.Rdev)))
 

--- a/pkg/runtime/containerd/client.go
+++ b/pkg/runtime/containerd/client.go
@@ -630,8 +630,8 @@ func withDevices(devices []*runtime.Bind) oci.SpecOpts {
 				return err
 			}
 
-			major := int64(unix.Major(stat.Rdev))
-			minor := int64(unix.Minor(stat.Rdev))
+			major := int64(unix.Major(uint64(stat.Rdev)))
+			minor := int64(unix.Minor(uint64(stat.Rdev)))
 
 			s.Linux.Resources.Devices = append(s.Linux.Resources.Devices, specs.LinuxDeviceCgroup{
 				Type:   devType,


### PR DESCRIPTION
I was futzing around with https://github.com/srl-labs/containerlab/ - just trying to build and run the unit tests on OS X to add a feature, and I got dragged down into some dependencies.

`stat.Rdev` is a `int32` on Darwin, so I just casted it to a uint64 to make the compiler happy

https://cs.opensource.google/go/x/sys/+/master:unix/ztypes_darwin_arm64.go;l=73

I'm not proficient with Go, so I don't know if this is wise or not, but I figured I'd submit it back