### PR TITLE
images/opensuse: Install package shadow

### DIFF
--- a/images/opensuse/Dockerfile
+++ b/images/opensuse/Dockerfile
@@ -11,6 +11,7 @@ RUN zypper -n install \
         systemd-sysvinit \
         udev \
         sudo \
+        shadow \
         wget && \
     zypper clean --all
 


### PR DESCRIPTION
Install package `shadow` for utilities to manage user and group accounts.
This installs `chpasswd` binary that's not present in tumbleweed by
default anymore and causes OS image build failure.

Fixes #859 