### PR TITLE
fix wget: "error getting response" problem

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,11 @@ FROM BASEIMAGE AS build
 COPY qemu-QEMUARCH-static /usr/bin/
 
 # device-mapper is needed for snapshot functionalities
+# openssl and wget needes to be updated.
 RUN apk add --no-cache \
-    device-mapper
+    device-mapper \
+    openssl \
+    wget
 
 # Download the Firecracker binary from Github
 ARG FIRECRACKER_VERSION


### PR DESCRIPTION
While BASEIMAGE is alpine and the default wget
doesn't work with HTTPS. We need update both
openssl and wget.

Signed-off-by: haibiao.xiao <xiaohaibiao331@outlook.com>