### PR TITLE
e2e: Set containerd socket address in RMI command

### DIFF
--- a/e2e/util/image.go
+++ b/e2e/util/image.go
@@ -4,6 +4,7 @@ import (
 	"os/exec"
 
 	"github.com/weaveworks/ignite/pkg/runtime"
+	"github.com/weaveworks/ignite/pkg/runtime/containerd"
 )
 
 // RmiDocker removes an image from docker content store.
@@ -16,8 +17,10 @@ func RmiDocker(img string) {
 
 // RmiContainerd removes an image from containerd content store.
 func RmiContainerd(img string) {
+	socketAddr, _ := containerd.StatContainerdSocket()
 	_, _ = exec.Command(
-		"ctr", "-n", "firecracker",
+		"ctr", "-a", socketAddr,
+		"-n", "firecracker",
 		"image", "rm", img,
 	).CombinedOutput()
 }

--- a/pkg/runtime/containerd/client.go
+++ b/pkg/runtime/containerd/client.go
@@ -82,8 +82,8 @@ type ctdClient struct {
 
 var _ runtime.Interface = &ctdClient{}
 
-// statContainerdSocket returns the first existing file in the containerdSocketLocations list
-func statContainerdSocket() (string, error) {
+// StatContainerdSocket returns the first existing file in the containerdSocketLocations list
+func StatContainerdSocket() (string, error) {
 	for _, socket := range containerdSocketLocations {
 		if _, err := os.Stat(socket); err == nil {
 			return socket, nil
@@ -125,7 +125,7 @@ func getNewestAvailableContainerdRuntime() (string, error) {
 
 // GetContainerdClient builds a client for talking to containerd
 func GetContainerdClient() (*ctdClient, error) {
-	ctdSocket, err := statContainerdSocket()
+	ctdSocket, err := StatContainerdSocket()
 	if err != nil {
 		return nil, err
 	}
@@ -857,7 +857,7 @@ func (cc *ctdClient) RawClient() interface{} {
 type containerdSocketChecker struct{}
 
 func (ctdsc containerdSocketChecker) Check() error {
-	_, err := statContainerdSocket()
+	_, err := StatContainerdSocket()
 	return err
 }
 func (ctdsc containerdSocketChecker) Name() string {


### PR DESCRIPTION
In machines where continerd socket isn't in
/run/containerd/containerd.sock, the default path, the tests fail
to cleanup the downloaded images in registry auth tests, resulting in
unexpected test failures due to old images.

Export StatContainerdSocket() from pkg/runtime/containerd/ and use it in
the e2e test to determine the containerd socket.

The test failures are unrelated and are fixed by https://github.com/weaveworks/ignite/pull/923 .