### PR TITLE
circleci: Update to ubuntu 20.04 machine image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     machine:
-      image: ubuntu-1604:201903-01
+      image: ubuntu-2004:202201-02
     environment:
       # Flag that this is a CI build to the Makefile
       IS_CI_BUILD: 1
@@ -18,7 +18,7 @@ jobs:
     # TODO: Push to a dev registry
   test:
     machine:
-      image: ubuntu-1604:201903-01
+      image: ubuntu-2004:202201-02
     steps:
     # Checkout the repo
     - checkout


### PR DESCRIPTION
Circleci is deprecating ubuntu 16.04 on May 31, 2022.
Refer https://circleci.com/blog/ubuntu-14-16-image-deprecation