### PR TITLE
ignited: allow running help, completion, version subcommands without root permission

### DIFF
--- a/cmd/ignite/cmd/root.go
+++ b/cmd/ignite/cmd/root.go
@@ -39,8 +39,6 @@ func NewIgniteCommand(in io.Reader, out, err io.Writer) *cobra.Command {
 			// Set the desired logging level, now that the flags are parsed
 			logs.Logger.SetLevel(logLevel)
 
-			// TODO Some commands do not need to check root
-			// Currently it seems to be only ignite version that does not require root
 			if isNonRootCommand(cmd.Name(), cmd.Parent().Name()) {
 				return
 			}
@@ -52,6 +50,9 @@ func NewIgniteCommand(in io.Reader, out, err io.Writer) *cobra.Command {
 
 			// Create the directories needed for running
 			util.GenericCheckErr(util.CreateDirectories())
+
+			// Preload necessary providers
+			util.GenericCheckErr(providers.Populate(ignite.Preload))
 
 			if err := config.ApplyConfiguration(configPath); err != nil {
 				log.Fatal(err)

--- a/cmd/ignite/ignite.go
+++ b/cmd/ignite/ignite.go
@@ -4,9 +4,6 @@ import (
 	"os"
 
 	"github.com/weaveworks/ignite/cmd/ignite/cmd"
-	"github.com/weaveworks/ignite/pkg/providers"
-	"github.com/weaveworks/ignite/pkg/providers/ignite"
-	"github.com/weaveworks/ignite/pkg/util"
 )
 
 func main() {
@@ -17,9 +14,6 @@ func main() {
 
 // Run runs the main cobra command of this application
 func Run() error {
-	// Preload necessary providers
-	util.GenericCheckErr(providers.Populate(ignite.Preload))
-
 	c := cmd.NewIgniteCommand(os.Stdin, os.Stdout, os.Stderr)
 	return c.Execute()
 }

--- a/cmd/ignited/cmd/root.go
+++ b/cmd/ignited/cmd/root.go
@@ -35,6 +35,10 @@ func NewIgnitedCommand(in io.Reader, out, err io.Writer) *cobra.Command {
 			// Set the desired logging level, now that the flags are parsed
 			logs.Logger.SetLevel(logLevel)
 
+			if isNonRootCommand(cmd.Name(), cmd.Parent().Name()) {
+				return
+			}
+
 			// Ignited needs to run as root for now, see
 			// https://github.com/weaveworks/ignite/issues/46
 			// TODO: Remove this when ready
@@ -70,6 +74,19 @@ func NewIgnitedCommand(in io.Reader, out, err io.Writer) *cobra.Command {
 	root.AddCommand(NewCmdDaemon(os.Stdout))
 	root.AddCommand(versioncmd.NewCmdVersion(os.Stdout))
 	return root
+}
+
+func isNonRootCommand(cmd string, parentCmd string) bool {
+	if parentCmd != "ignited" {
+		return false
+	}
+
+	switch cmd {
+	case "version", "help", "completion":
+		return true
+	}
+
+	return false
 }
 
 func addGlobalFlags(fs *pflag.FlagSet) {

--- a/cmd/ignited/cmd/root.go
+++ b/cmd/ignited/cmd/root.go
@@ -15,7 +15,8 @@ import (
 	logflag "github.com/weaveworks/ignite/pkg/logs/flag"
 	networkflag "github.com/weaveworks/ignite/pkg/network/flag"
 	"github.com/weaveworks/ignite/pkg/providers"
-	"github.com/weaveworks/ignite/pkg/providers/ignite"
+	"github.com/weaveworks/ignite/pkg/providers/ignited"
+	"github.com/weaveworks/ignite/pkg/util"
 	runtimeflag "github.com/weaveworks/ignite/pkg/runtime/flag"
 	versioncmd "github.com/weaveworks/ignite/pkg/version/cmd"
 )
@@ -34,12 +35,23 @@ func NewIgnitedCommand(in io.Reader, out, err io.Writer) *cobra.Command {
 			// Set the desired logging level, now that the flags are parsed
 			logs.Logger.SetLevel(logLevel)
 
+			// Ignited needs to run as root for now, see
+			// https://github.com/weaveworks/ignite/issues/46
+			// TODO: Remove this when ready
+			util.GenericCheckErr(util.TestRoot())
+
+			// Create the directories needed for running
+			util.GenericCheckErr(util.CreateDirectories())
+
+			// Preload necessary providers
+			util.GenericCheckErr(providers.Populate(ignited.Preload))
+
 			if err := config.ApplyConfiguration(configPath); err != nil {
 				log.Fatal(err)
 			}
 
 			// Populate the providers after flags have been parsed
-			if err := providers.Populate(ignite.Providers); err != nil {
+			if err := providers.Populate(ignited.Providers); err != nil {
 				log.Fatal(err)
 			}
 		},

--- a/cmd/ignited/ignited.go
+++ b/cmd/ignited/ignited.go
@@ -9,9 +9,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/weaveworks/ignite/cmd/ignited/cmd"
 	"github.com/weaveworks/ignite/pkg/constants"
-	"github.com/weaveworks/ignite/pkg/providers"
-	"github.com/weaveworks/ignite/pkg/providers/ignited"
-	"github.com/weaveworks/ignite/pkg/util"
 )
 
 func main() {
@@ -44,17 +41,6 @@ func cleanup() {
 
 // Run runs the main cobra command of this application
 func Run() error {
-	// Ignite needs to run as root for now, see
-	// https://github.com/weaveworks/ignite/issues/46
-	// TODO: Remove this when ready
-	util.GenericCheckErr(util.TestRoot())
-
-	// Create the directories needed for running
-	util.GenericCheckErr(util.CreateDirectories())
-
-	// Preload necessary providers
-	util.GenericCheckErr(providers.Populate(ignited.Preload))
-
 	c := cmd.NewIgnitedCommand(os.Stdin, os.Stdout, os.Stderr)
 	return c.Execute()
 }


### PR DESCRIPTION
This is pretty much a copy and paste of https://github.com/weaveworks/ignite/pull/676 but for `ignited` command.

I also did some minor extra things:
- Move all `GenericCheckErr` calls from to PersistentPreRun stage of cobra. A couple of them are already there to begin with (this specially helps `ignited` command as Preload checks for `MANIFEST_DIR` and fails).
- Remove TODO statement on `isNonRootCommand()` function (we already handle each subcommands).
- Fix typo??? in populating `ignited` provider (it was `ignite`).